### PR TITLE
Add macroexpansion style expander

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,3 @@
 {:paths ["src" "resources"]
+ :aliases {:test {:extra-paths ["test"]}}
  :deps {org.clojure/clojure {:mvn/version "1.9.0"}}}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,0 +1,66 @@
+(ns malli.core
+  "Plain data schemas.")
+
+(defprotocol SchemaFunctor
+  ""
+  (-map-children [self f]))
+
+(extend-protocol SchemaFunctor
+  clojure.lang.APersistentVector
+  (-map-children [self f]
+    (if (seq self)
+      (into [(first self)] (map f) (rest self))
+      self))
+
+  clojure.lang.Keyword
+  (-map-children [self _] self))
+
+(defn map-children [f schema] (-map-children schema f))
+
+;;;;
+
+(defn- expand-node-once [registry schema]
+  (cond
+    (vector? schema) (if-let [expander (and (seq schema) (get registry (first schema)))]
+                       (apply expander (rest schema))
+                       schema)
+    (keyword? schema) (get registry schema schema)
+    :else schema))
+
+(defn expand-node [registry schema]
+  (let [schema* (expand-node-once registry schema)]
+    (if (identical? schema* schema)
+      schema*
+      (expand-node registry schema*))))
+
+(defn expand
+  "Recursively expand `schema` and its children using the abbreviations and expanders in `registry`."
+  [registry schema]
+  (map-children (partial expand registry)
+                (expand-node registry schema)))
+
+;;;;
+
+(deftype IntSchema []
+  SchemaFunctor
+  (-map-children [self _] self))
+
+(def Int
+  "Schema for integers."
+  (->IntSchema))
+
+(declare ->SetSchema)
+
+(deftype SetSchema [elem-schema]
+  SchemaFunctor
+  (-map-children [_ f] (->SetSchema (f elem-schema))))
+
+(def Set
+  "Schema constructor for sets."
+  ->SetSchema)
+
+;;;;
+
+(def default-registry
+  {::int Int
+   ::set Set})

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -41,23 +41,16 @@
 
 ;;;;
 
-(deftype IntSchema []
-  SchemaFunctor
-  (-map-children [self _] self))
-
 (def Int
   "Schema for integers."
-  (->IntSchema))
+  (reify SchemaFunctor
+    (-map-children [self _] self)))
 
-(declare ->SetSchema)
-
-(deftype SetSchema [elem-schema]
-  SchemaFunctor
-  (-map-children [_ f] (->SetSchema (f elem-schema))))
-
-(def Set
+(defn Set
   "Schema constructor for sets."
-  ->SetSchema)
+  [elem-schema]
+  (reify SchemaFunctor
+    (-map-children [_ f] (Set (f elem-schema)))))
 
 ;;;;
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -31,7 +31,7 @@
   (let [schema* (expand-node-once registry schema)]
     (if (identical? schema* schema)
       schema*
-      (expand-node registry schema*))))
+      (recur registry schema*))))
 
 (defn expand
   "Recursively expand `schema` and its children using the abbreviations and expanders in `registry`."

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1,0 +1,8 @@
+(ns malli.core-test
+  (:require [clojure.test :refer :all]
+            [malli.core :as malli]))
+
+(deftest expand-test
+  (is (= (malli/expand {::foo (fn [arg] arg)} [::foo ::bar]) ::bar))
+
+  (is (= (malli/expand malli/default-registry ::malli/int) malli/Int)))


### PR DESCRIPTION
Applies
```
:foo ;=> (get registry :foo)
[:foo :bar] ;=> (apply (get registry :foo) [:bar])
```
exhaustively at each node in a prewalk of the schema.

If things are not found in registry, leaves them unexpanded. Maybe that should be an error instead but it depends on the semantics of the expanded schemas which is left open here.

