### PR TITLE
correctly validate false map values

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -174,8 +174,7 @@
                                (fn [[key {:keys [optional]} value]]
                                  (let [valid? (-validator value)
                                        default (boolean optional)]
-                                   (fn [m] (let [v (key m ::missing-key)]
-                                             (if (not= v ::missing-key) (valid? v) default)))))
+                                   (fn [m] (if-let [map-entry (find m key)] (valid? (val map-entry)) default))))
                                entries)
                   validate (fn [m]
                              (boolean

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -174,7 +174,8 @@
                                (fn [[key {:keys [optional]} value]]
                                  (let [valid? (-validator value)
                                        default (boolean optional)]
-                                   (fn [m] (if-let [v (key m)] (valid? v) default))))
+                                   (fn [m] (let [v (key m ::missing-key)]
+                                             (if (not= v ::missing-key) (valid? v) default)))))
                                entries)
                   validate (fn [m]
                              (boolean

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -235,7 +235,11 @@
               [:y {:optional true} 'int?]
               [:z {:optional false} 'string?]]
              (m/form schema1)
-             (m/form schema2)))))
+             (m/form schema2))))
+
+    (is (true? (m/validate [:map [:b boolean?]] {:b true})))
+    (is (true? (m/validate [:map [:b boolean?]] {:b false})))
+    (is (true? (m/validate [:map [:n nil?]] {:n nil}))))
 
   (testing "map-of schema"
 


### PR DESCRIPTION
The current code does not correctly validate map values when they evaluate to a false (`false` or `nil`) value.
