### PR TITLE
Generating values based on schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,35 @@ Schema-driven value transformations with `m/transform`:
 ;           :lonlat [61.4858322 23.7854658]}}
 ```
 
+Generating example values for a schema:
+
+```clj
+(require '[malli.generator :as mg])
+
+(mg/generate keyword?)
+; :NB
+
+(mg/generate string? {:seed 3, :size 20})
+; "606FGq87f1Tk"
+
+(mg/generate Address {:seed 123, :size 4})
+;{:id "H7",
+; :tags #{:v?.w.t6!.QJYk-/-?s*4
+;         :_7U
+;         :QdG/Xi8J
+;         :*Q-.p*8*/n-J9u}
+; :address {:street "V9s"
+;           :city ""
+;           :zip 3
+;           :lonlat [-2.75 -0.625]}}
+
+(m/validate Address (mg/generate Address))
+; => true
+
+(mg/sample [:and pos-int? [:> 100] [:< 1000]] {:size 10})
+; (201 299 388 354 115 127 104 128 281 192)
+```
+
 Transforming Schemas using a [visitor](https://en.wikipedia.org/wiki/Visitor_pattern):
 
 ```clj

--- a/README.md
+++ b/README.md
@@ -167,16 +167,29 @@ Schema-driven value transformations with `m/transform`:
 ;           :lonlat [61.4858322 23.7854658]}}
 ```
 
-Generating example values for a schema:
+Generating example data for a schema:
 
 ```clj
 (require '[malli.generator :as mg])
 
+;; random
 (mg/generate keyword?)
-; :NB
+; => :?
 
-(mg/generate string? {:seed 3, :size 20})
-; "606FGq87f1Tk"
+;; using seed
+(mg/generate [:enum "a" "b" "c"] {:seed 42})
+;; => "a"
+
+;; using seed and size
+(mg/generate pos-int? {:seed 10, :size 100})
+;; => 55740
+
+;; portable gen/fmap
+(mg/generate
+  [:and {:gen/fmap '(partial str "kikka_")}
+   string?]
+  {:seed 10, :size 10})
+;; => "kikka_WT3K0yax2"
 
 (mg/generate Address {:seed 123, :size 4})
 ;{:id "H7",
@@ -192,8 +205,9 @@ Generating example values for a schema:
 (m/validate Address (mg/generate Address))
 ; => true
 
-(mg/sample [:and pos-int? [:> 100] [:< 1000]] {:size 10})
-; (201 299 388 354 115 127 104 128 281 192)
+;; sampling
+(mg/sample [:and int? [:> 10] [:< 100]] {:seed 123})
+; => (25 39 51 13 53 43 57 15 26 27)
 ```
 
 Transforming Schemas using a [visitor](https://en.wikipedia.org/wiki/Visitor_pattern):

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -542,6 +542,13 @@
   ([?schema opts]
    (-properties (schema ?schema opts))))
 
+(defn childs
+  ([?schema]
+   (childs ?schema nil))
+  ([?schema opts]
+   (let [schema (schema ?schema opts)]
+     (->> schema (-form) (drop (if (-properties schema) 2 1))))))
+
 (defn name
   ([?schema]
    (name ?schema nil))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -7,10 +7,7 @@
 
 (declare generator)
 
-(defn- -random [seed]
-  (if seed
-    (random/make-random seed)
-    (random/make-random)))
+(defn- -random [seed] (if seed (random/make-random seed) (random/make-random)))
 
 (defn- -double-gen [opts] (gen/double* (merge {:infinite? false, :NaN? false} opts)))
 
@@ -86,9 +83,9 @@
 (defn generate
   ([?gen-or-schema]
    (generate ?gen-or-schema nil))
-  ([?gen-or-schema {:keys [seed] :as opts}]
+  ([?gen-or-schema {:keys [seed size] :or {size 1} :as opts}]
    (let [gen (if (gen/generator? ?gen-or-schema) ?gen-or-schema (generator ?gen-or-schema opts))]
-     (rose/root (gen/call-gen gen (-random seed) 1)))))
+     (rose/root (gen/call-gen gen (-random seed) size)))))
 
 (defn sample
   ([?gen-or-schema]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -1,0 +1,73 @@
+(ns malli.generator
+  (:require [clojure.test.check.generators :as gen]
+            [clojure.test.check.random :as random]
+            [clojure.test.check.rose-tree :as rose]
+            [clojure.spec.gen.alpha :as ga]
+            [malli.core :as m]))
+
+(defn- -random [seed]
+  (if seed
+    (random/make-random seed)
+    (random/make-random)))
+
+(defn generate
+  ([gen]
+   (generate gen nil))
+  ([gen {:keys [seed]}]
+   (rose/root (gen/call-gen gen (-random seed) 1))))
+
+(defn sample
+  ([gen]
+   (sample gen nil))
+  ([gen {:keys [seed size] :or {size 10}}]
+   (->> (gen/make-size-range-seq size)
+        (map #(rose/root (gen/call-gen gen %1 %2))
+             (gen/lazy-random-states (-random seed)))
+        (take size))))
+
+(defmulti -generator (fn [schema opts] (m/name schema opts)) :default ::default)
+
+(defmethod -generator ::default [schema _]
+  (ga/gen-for-pred (m/validator schema)))
+
+(defn generator
+  ([?schema]
+   (generator ?schema nil))
+  ([?schema opts]
+   (-generator (m/schema ?schema opts) opts)))
+
+;;
+;; spike
+;;
+
+(sample
+  (gen/elements [:a :b :c])
+  {:size 10, :seed nil})
+; (:b :c :a :a :a :b :b :b :a :c)
+
+(->> m/predicate-registry
+     (filter (comp fn? key))
+     (map (fn [[f schema]]
+            [(-> schema (m/schema) (m/name))
+             (-> f (generator) (sample {:size 4, :seed 0}))]))
+     (into {}))
+
+
+(sample (generator string?) {:size 10, :seed 0})
+; ("" "e" "wp" "t5" "L" "ho" "K99" "40" "4r3" "y3V8s")
+
+;;
+;; [:and int? neg-int?]
+;;
+
+; 1) this is not optimal (lot's of misses)
+(sample (gen/such-that int? (generator neg-int?)) {:seed 0})
+; (-1 -1 -2 -2 -2 -8 -5 -2 -7 -126)
+
+; 2) this would be better
+(sample (gen/such-that neg-int? (generator int?)) {:seed 0})
+; (-1 -1 -1 -1 -1 -7 -4 -4 -6 -16)
+
+; 3) this would be optiomal. how is the result different to 1???
+(sample (generator neg-int?) {:seed 0})
+; (-1 -2 -2 -2 -1 -4 -2 -2 -8 -110)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -42,6 +42,10 @@
                      (apply gen/tuple))]
     (gen/fmap (fn [[req opt]] (into {} (concat req opt))) (gen/tuple gen-req gen-opt))))
 
+(defn -map-of-gen [schema opts]
+  (let [[k-gen v-gen] (map #(generator % opts) (m/childs schema opts))]
+    (gen/fmap (partial into {}) (gen/vector-distinct (gen/tuple k-gen v-gen)))))
+
 ;;
 ;; generators
 ;;
@@ -60,6 +64,7 @@
 (defmethod -generator :and [schema _] (gen/such-that (m/validator schema) (-> schema m/childs first generator) 100))
 (defmethod -generator :or [schema opts] (gen/one-of (->> schema m/childs (mapv #(generator % opts)))))
 (defmethod -generator :map [schema opts] (-map-gen schema opts))
+(defmethod -generator :map-of [schema opts] (-map-of-gen schema opts))
 (defmethod -generator :vector [schema _] (-coll-gen schema identity))
 (defmethod -generator :list [schema _] (-coll-gen schema (partial apply list)))
 (defmethod -generator :set [schema _] (-coll-distict-gen schema set))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -84,16 +84,18 @@
    (-generator (m/schema ?schema opts) opts)))
 
 (defn generate
-  ([gen]
-   (generate gen nil))
-  ([gen {:keys [seed]}]
-   (rose/root (gen/call-gen gen (-random seed) 1))))
+  ([?gen-or-schema]
+   (generate ?gen-or-schema nil))
+  ([?gen-or-schema {:keys [seed] :as opts}]
+   (let [gen (if (gen/generator? ?gen-or-schema) ?gen-or-schema (generator ?gen-or-schema opts))]
+     (rose/root (gen/call-gen gen (-random seed) 1)))))
 
 (defn sample
-  ([gen]
-   (sample gen nil))
-  ([gen {:keys [seed size] :or {size 10}}]
-   (->> (gen/make-size-range-seq size)
-        (map #(rose/root (gen/call-gen gen %1 %2))
-             (gen/lazy-random-states (-random seed)))
-        (take size))))
+  ([?gen-or-schema]
+   (sample ?gen-or-schema nil))
+  ([?gen-or-schema {:keys [seed size] :or {size 10} :as opts}]
+   (let [gen (if (gen/generator? ?gen-or-schema) ?gen-or-schema (generator ?gen-or-schema opts))]
+     (->> (gen/make-size-range-seq size)
+          (map #(rose/root (gen/call-gen gen %1 %2))
+               (gen/lazy-random-states (-random seed)))
+          (take size)))))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -66,8 +66,7 @@
 (defmethod accept :or [_ _ children _] {:anyOf children})
 
 (defmethod accept :map [_ schema children opts]
-  (let [distance (if (m/properties schema) 2 1)
-        {:keys [required keys]} (m/-parse-keys (drop distance (m/form schema)) opts)]
+  (let [{:keys [required keys]} (m/-parse-keys (m/childs schema opts) opts)]
     (merge
       {:type "object"
        :properties (apply array-map (interleave keys children))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -489,6 +489,12 @@
              (m/properties [:and properties int?])
              (m/properties [int? properties]))))))
 
+(deftest childs-test
+  (testing "childs can be set and retrieved"
+    (is (= ['int? 'pos-int?]
+           (m/childs [:and {:a 1} int? pos-int?])
+           (m/childs [:and int? pos-int?])))))
+
 (deftest round-trip-test
   (testing "schemas can be roundtripped"
     (let [schema (m/schema

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1,0 +1,12 @@
+(ns malli.generator-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [malli.json-schema-test :as json-schema-test]
+            [malli.generator :as mg]
+            [malli.core :as m]))
+
+(deftest generator-test
+  (doseq [[?schema] json-schema-test/expectations
+          :when (not= (m/name ?schema) :map-of) ;; will be removed
+          value (mg/sample (mg/generator ?schema))]
+    (testing (m/form ?schema)
+      (is (m/validate ?schema value)))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -7,7 +7,9 @@
 (deftest generator-test
   (doseq [[?schema] json-schema-test/expectations]
     (testing (m/form ?schema)
-      (is (= (mg/sample (mg/generator ?schema) {:seed 123})
+      (is (= (mg/sample ?schema {:seed 123})
+             (mg/sample ?schema {:seed 123})
+             (mg/sample (mg/generator ?schema) {:seed 123})
              (mg/sample (mg/generator ?schema) {:seed 123})))
-      (doseq [value (mg/sample (mg/generator ?schema))]
+      (doseq [value (mg/sample ?schema)]
         (is (m/validate ?schema value))))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -7,9 +7,16 @@
 (deftest generator-test
   (doseq [[?schema] json-schema-test/expectations]
     (testing (m/form ?schema)
-      (is (= (mg/sample ?schema {:seed 123})
-             (mg/sample ?schema {:seed 123})
-             (mg/sample (mg/generator ?schema) {:seed 123})
-             (mg/sample (mg/generator ?schema) {:seed 123})))
-      (doseq [value (mg/sample ?schema)]
-        (is (m/validate ?schema value))))))
+      (testing "generate"
+        (is (= (mg/generate ?schema {:seed 123})
+               (mg/generate ?schema {:seed 123})))
+        (is (= (mg/generate ?schema {:seed 123, :size 10})
+               (mg/generate ?schema {:seed 123, :size 10})))
+        (is (m/validate ?schema (mg/generate ?schema {:seed 123}))))
+      (testing "sample"
+        (is (= (mg/sample ?schema {:seed 123})
+               (mg/sample ?schema {:seed 123})))
+        (is (= (mg/sample ?schema {:seed 123, :size 10})
+               (mg/sample ?schema {:seed 123, :size 10})))
+        (doseq [value (mg/sample ?schema {:seed 123})]
+          (is (m/validate ?schema value)))))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -19,4 +19,18 @@
         (is (= (mg/sample ?schema {:seed 123, :size 10})
                (mg/sample ?schema {:seed 123, :size 10})))
         (doseq [value (mg/sample ?schema {:seed 123})]
-          (is (m/validate ?schema value)))))))
+          (is (m/validate ?schema value))))))
+  (testing "no generator"
+    (is (thrown-with-msg?
+          #?(:clj Exception, :cljs js/Error)
+          #":malli.generator/no-generator"
+          (mg/generate [:fn '(fn [x] (<= 0 x 10))]))))
+  (testing "generator override"
+    (testing "without generator"
+      (let [schema [:fn {:gen/fmap '(fn [_] (rand-int 10))}
+                    '(fn [x] (<= 0 x 10))]
+            generator (mg/generator schema)]
+        (dotimes [_ 100]
+          (m/validate schema (mg/generate generator)))))
+    (testing "with generator"
+      (is (re-matches #"kikka_\d+" (mg/generate [:and {:gen/fmap '(partial str "kikka_")} pos-int?]))))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -6,7 +6,6 @@
 
 (deftest generator-test
   (doseq [[?schema] json-schema-test/expectations
-          :when (not= (m/name ?schema) :map-of) ;; will be removed
           value (mg/sample (mg/generator ?schema))]
     (testing (m/form ?schema)
       (is (m/validate ?schema value)))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -5,7 +5,9 @@
             [malli.core :as m]))
 
 (deftest generator-test
-  (doseq [[?schema] json-schema-test/expectations
-          value (mg/sample (mg/generator ?schema))]
+  (doseq [[?schema] json-schema-test/expectations]
     (testing (m/form ?schema)
-      (is (m/validate ?schema value)))))
+      (is (= (mg/sample (mg/generator ?schema) {:seed 123})
+             (mg/sample (mg/generator ?schema) {:seed 123})))
+      (doseq [value (mg/sample (mg/generator ?schema))]
+        (is (m/validate ?schema value))))))

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -12,7 +12,8 @@
    [[:< 6] {:type "number", :format "double", :exclusiveMaximum 6}]
    [[:<= 6] {:type "number", :format "double", :maximum 6}]
    ;; base
-   [[:and int? string?] {:allOf [{:type "integer", :format "int64"} {:type "string"}]}]
+   [[:and int? pos-int?] {:allOf [{:type "integer", :format "int64"}
+                                  {:type "integer", :format "int64" :minimum 1}]}]
    [[:or int? string?] {:anyOf [{:type "integer", :format "int64"} {:type "string"}]}]
    [[:map
      [:a string?]


### PR DESCRIPTION
To resolve #13 . Let's not reinvent things, clojure-spec ships with Clojure and it has mostly solved this already. Few extra goals:

- push `seed` and `size` to all public apis and verify it creates same results for both Clojure/Script => consistent sampling
- support portable override of generators via `:gen/fmap` with [sci](https://github.com/borkdude/sci) scripts that can be serialized

Examples:

```clj
(require '[malli.generator :as mg])

;; random
(mg/generate keyword?)
; => :?

;; using seed
(mg/generate [:enum "a" "b" "c"] {:seed 42})
;; => "a"

;; using seed and size
(mg/generate pos-int? {:seed 10, :size 100})
;; => 55740

;; portable gen/fmap
(mg/generate
  [:and {:gen/fmap '(partial str "kikka_")}
   string?]
  {:seed 10, :size 10})
;; => "kikka_WT3K0yax2"

(def Address
  [:map
   [:id string?]
   [:tags [:set keyword?]]
   [:address
    [:map
     [:street string?]
     [:city string?]
     [:zip int?]
     [:lonlat [:tuple double? double?]]]]])

(mg/generate Address {:seed 123, :size 4})
;{:id "H7",
; :tags #{:v?.w.t6!.QJYk-/-?s*4
;         :_7U
;         :QdG/Xi8J
;         :*Q-.p*8*/n-J9u}
; :address {:street "V9s"
;           :city ""
;           :zip 3
;           :lonlat [-2.75 -0.625]}}

(require '[malli.core :as m])

(m/validate Address (mg/generate Address))
; => true

;; sampling
(mg/sample [:and int? [:> 10] [:< 100]] {:seed 123})
; => (25 39 51 13 53 43 57 15 26 27)
```
