### PR TITLE
Transformer to strip extra map keys

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -166,8 +166,7 @@
     (-name [_] :map)
     (-into-schema [_ properties childs opts]
       (let [{:keys [entries forms keys]} (-parse-keys childs opts)
-            form (create-form :map properties forms)
-            properties' (assoc properties ::map-keys keys)]
+            form (create-form :map properties forms)]
         ^{:type ::schema}
         (reify Schema
           (-validator [_]
@@ -228,7 +227,7 @@
                     x)))))
           (-accept [this visitor opts]
             (visitor this (->> entries (map last) (mapv #(-accept % visitor opts))) opts))
-          (-properties [_] properties')
+          (-properties [_] properties)
           (-form [_] form))))))
 
 (defn- -map-of-schema []

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -105,6 +105,11 @@
 
 (defn any->any [x] x)
 
+(defn strip-extra-keys [keys x]
+  (if (and keys (map? x))
+    (select-keys x keys)
+    x))
+
 ;;
 ;; transformers
 ;;
@@ -157,5 +162,9 @@
 
 (defn json-transformer [schema]
   (get +json-decoders+ (m/name schema)))
+
+(defn strip-extra-keys-transformer [schema]
+  (when-some [keys (-> schema m/properties ::m/map-keys)]
+    (partial strip-extra-keys keys)))
 
 (defn collection-transformer [schema])

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -164,7 +164,11 @@
   (get +json-decoders+ (m/name schema)))
 
 (defn strip-extra-keys-transformer [schema]
-  (when-some [keys (-> schema m/properties ::m/map-keys)]
-    (partial strip-extra-keys keys)))
+  (case (m/name schema)
+    :map
+    (let [{:keys [keys]} (m/-parse-keys (m/childs schema) nil)]
+      (fn [x]
+        (strip-extra-keys keys x)))
+    nil))
 
 (defn collection-transformer [schema])

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -226,6 +226,7 @@
 
       (is (= {:x true, :y 1} (m/transform schema1 {:x "true", :y "1"} transform/string-transformer)))
       (is (= {:x "true", :y "1"} (m/transform schema1 {:x "true", :y "1"} transform/json-transformer)))
+      (is (= {:x true, :y 1} (m/transform schema1 {:x true, :y 1, :a 1} transform/strip-extra-keys-transformer)))
 
       (is (true? (m/validate (over-the-wire schema1) valid)))
 


### PR DESCRIPTION
#56 

```clojure
(m/transform [:map [:x string?] [:y int?]] {:x "x" :y 1 :z 2} strip-extra-keys-transformer)
=> {:x "x" :y 1}
```