### PR TITLE
Implement m/merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,31 @@ Transformers are composable:
 ;           :lonlat [61.4858322 23.7854658]}}
 ```
 
+## Merging Schemas
+
+Schemas can be deep-merged with `m/merge`:
+
+```clj
+(m/merge
+  Address
+  [:map
+   [:description string?]
+   [:address
+    [:map
+     [:country string?]]]])
+;[:map
+; [:id string?]
+; [:tags [:set keyword?]]
+; [:address 
+;  [:map 
+;   [:street string?] 
+;   [:city string?] 
+;   [:zip int?] 
+;   [:lonlat [:tuple double? double?]] 
+;   [:country string?]]]
+; [:description string?]]
+```
+
 ## Schema Transformation
 
 Schemas can be transformed using the [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern):

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -149,15 +149,13 @@
 (defn- -optional-entry? [[_ ?p]]
   (boolean (and (map? ?p) (true? (:optional ?p)))))
 
-(defn- -optional-entry [[k ?p s :as entry] ?]
+(defn- -optional-entry [[k ?p s :as entry] optional]
   (if (map? ?p)
     (cond
-      ? (update entry 1 assoc :optional true)
+      optional (update entry 1 assoc :optional true)
       (= [:optional] (keys ?p)) [k s]
       :else (update entry 1 dissoc :optional))
-    (cond
-      ? [k {:optional true} ?p]
-      :else [k ?p])))
+    (if optional [k {:optional true} ?p] [k ?p])))
 
 (defn- -expand-key [[k ?p ?v] opts f]
   (let [[p v] (if (map? ?p) [?p ?v] [nil ?p])
@@ -640,6 +638,12 @@
      value)))
 
 (defn merge
+  "Deep-merges two schemas into one with the following rules:
+
+  * if either schemas is `nil`, the other one is used, regardless of value
+  * with two :map schemas, both keys and values are merged
+  * with any other schemas, 2-arity `:malli.core/merge` function is used, defaulting
+    to constantly schema2"
   ([?schema1 ?schema2]
    (merge ?schema1 ?schema2 nil))
   ([?schema1 ?schema2 opts]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -624,12 +624,14 @@
    ((explainer ?schema opts) value [] [])))
 
 (defn transformer
+  "Creates a value transformer given a transformer and a schema."
   ([?schema t]
    (transformer ?schema nil t))
   ([?schema opts t]
    (or (-transformer (schema ?schema opts) t) identity)))
 
 (defn transform
+  "Transforms a value with a given transformer agains a schema."
   ([?schema value t]
    (transform ?schema value nil t))
   ([?schema value opts t]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -542,7 +542,7 @@
       {}
       [:map [:x pos-int?]]
 
-      ;; TODO: should retain the :optional key!
+      ;; TODO: should retain the :optional key?
       [:map [:x {:optional false} int?]]
       [:map [:x {:optional true} pos-int?]]
       {}


### PR DESCRIPTION
... one of the original reasons for `malli` was to be able deep-merge map-schemas easily. Not perfect (doesn't understand how to merge things like `:and` & `:or`), but a start. Code is kinda bloaty.

Will fix: #45 

```clj
(m/merge
  [:map 
   [:parameters
    [:map
     [:query-params 
      [:map [:x int?]]]]]]
  [:map 
   [:parameters
    [:map
     [:query-params 
      [:map [:y int?]]]
     [:body-params
      [:map [:z int?]]]]]])
;[:map 
; [:parameters
;  [:map
;   [:query-params 
;    [:map [:x string?] [:y int?]]]
;   [:body-params
;    [:map [:z int?]]]]]]
```