### PR TITLE
Welcome :re schemas!

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,10 @@ Scehmas can be used to generate values:
 (mg/generate pos-int? {:seed 10, :size 100})
 ;; => 55740
 
+;; regexs work too
+(mg/generate [:re #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$"] {:seed 42, :size 10})
+; => "CaR@MavCk70OHiX.yZ"
+
 ;; portable gen/fmap
 (mg/generate
   [:and {:gen/fmap '(partial str "kikka_")}
@@ -448,7 +452,7 @@ Comparator functions as keywords: `:>`, `:>=`, `:<`, `:<=`, `:=` and `:not=`.
 
 #### `malli.core/base-registry`
 
-Contains `:and`, `:or`, `:map`, `:map-of`, `:vector`, `:list`, `:set`, `:tuple`, `:enum`, `:fn` and `:maybe`.
+Contains `:and`, `:or`, `:map`, `:map-of`, `:vector`, `:list`, `:set`, `:tuple`, `:enum`, `:maybe`, `:re` and `:fn`.
 
 ### Custom registry
 

--- a/deps.edn
+++ b/deps.edn
@@ -27,8 +27,8 @@
                              "-Dclojure.compiler.direct-linking=true"]}}
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         borkdude/sci {:git/url "https://github.com/borkdude/sci"
-                      :sha "73d0de59debe7a8acc4cb13e64f3cfe34baf0294"}
+                      :sha "939cfde3143c84e2134caaff1b5640510e6096f6"}
         borkdude/edamame {:git/url "https://github.com/borkdude/edamame"
-                          :sha "ce13fd14275548bebf3eb5c9f2d003e9c96ccdb0"}
+                          :sha "945cb3ee22fc5d20445a2b007df318b0efa63205"}
         org.clojure/test.check {:mvn/version "0.9.0"}
         com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -30,4 +30,5 @@
                       :sha "73d0de59debe7a8acc4cb13e64f3cfe34baf0294"}
         borkdude/edamame {:git/url "https://github.com/borkdude/edamame"
                           :sha "ce13fd14275548bebf3eb5c9f2d003e9c96ccdb0"}
-        org.clojure/test.check {:mvn/version "0.9.0"}}}
+        org.clojure/test.check {:mvn/version "0.9.0"}
+        com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -45,9 +45,10 @@
   (let [[k-gen v-gen] (map #(generator % opts) (m/childs schema opts))]
     (gen/fmap (partial into {}) (gen/vector-distinct (gen/tuple k-gen v-gen)))))
 
-(defn -re-gen [schema opts]
-  (let [[re] (m/childs schema opts)]
-    (gen2/string-from-regex (re-pattern (str/replace re #"^\^?(.*?)(\$?)$" "$1")))))
+#?(:clj
+   (defn -re-gen [schema opts]
+     (let [[re] (m/childs schema opts)]
+       (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1"))))))
 
 ;;
 ;; generators
@@ -74,7 +75,7 @@
 (defmethod -generator :enum [schema _] (gen/elements (m/childs schema)))
 (defmethod -generator :maybe [schema opts] (gen/one-of [(gen/return nil) (-> schema m/childs first (generator opts))]))
 (defmethod -generator :tuple [schema opts] (apply gen/tuple (->> schema m/childs (mapv #(generator % opts)))))
-(defmethod -generator :re [schema opts] (-re-gen schema opts))
+#?(:clj (defmethod -generator :re [schema opts] (-re-gen schema opts)))
 
 (defn- -create [schema opts]
   (let [gen (-generator schema opts)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -1,9 +1,11 @@
 (ns malli.generator
   (:require [clojure.test.check.generators :as gen]
+            [com.gfredericks.test.chuck.generators :as gen2]
             [clojure.test.check.random :as random]
             [clojure.test.check.rose-tree :as rose]
             [clojure.spec.gen.alpha :as ga]
-            [malli.core :as m]))
+            [malli.core :as m]
+            [clojure.string :as str]))
 
 (declare generator)
 
@@ -43,6 +45,10 @@
   (let [[k-gen v-gen] (map #(generator % opts) (m/childs schema opts))]
     (gen/fmap (partial into {}) (gen/vector-distinct (gen/tuple k-gen v-gen)))))
 
+(defn -re-gen [schema opts]
+  (let [[re] (m/childs schema opts)]
+    (gen2/string-from-regex (re-pattern (str/replace re #"^\^?(.*?)(\$?)$" "$1")))))
+
 ;;
 ;; generators
 ;;
@@ -68,6 +74,7 @@
 (defmethod -generator :enum [schema _] (gen/elements (m/childs schema)))
 (defmethod -generator :maybe [schema opts] (gen/one-of [(gen/return nil) (-> schema m/childs first (generator opts))]))
 (defmethod -generator :tuple [schema opts] (apply gen/tuple (->> schema m/childs (mapv #(generator % opts)))))
+(defmethod -generator :re [schema opts] (-re-gen schema opts))
 
 (defn- -create [schema opts]
   (let [gen (-generator schema opts)

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -80,6 +80,7 @@
 (defmethod accept :enum [_ _ children _] {:enum children})
 (defmethod accept :maybe [_ _ children _] {:oneOf (conj children {:type "null"})})
 (defmethod accept :tuple [_ _ children _] {:type "array", :items children, :additionalItems false})
+(defmethod accept :re [_ schema _ opts] {:type "string", :pattern (first (m/childs schema opts))})
 (defmethod accept :fn [_ _ _ _] {})
 
 (defn- -json-schema-visitor [schema childs opts]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -152,6 +152,25 @@
 
       (is (= [:maybe 'int?] (m/form schema)))))
 
+  (testing "re schemas"
+    (let [form [:re {:description "a regex"} "^[a-z]+\\.[a-z]+$"]
+          schema (m/schema form)]
+
+      (is (true? (m/validate schema "a.b")))
+      (is (false? (m/validate schema "abba")))
+      (is (false? (m/validate schema ".b")))
+      (is (false? (m/validate schema false)))
+
+      (is (nil? (m/explain schema "a.b")))
+      (is (results= {:schema schema, :value "abba", :errors [{:path [], :in [], :schema schema, :value "abba"}]}
+                    (m/explain schema "abba")))
+
+      (is (true? (m/validate (over-the-wire schema) "a.b")))
+
+      (is (= [:re] (m/accept schema visitor)))
+
+      (is (= form (m/form schema)))))
+
   (testing "fn schemas"
     (doseq [fn ['(fn [x] (and (int? x) (< 10 x 18)))
                 "(fn [x] (and (int? x) (< 10 x 18)))"]]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -153,23 +153,24 @@
       (is (= [:maybe 'int?] (m/form schema)))))
 
   (testing "re schemas"
-    (let [form [:re {:description "a regex"} "^[a-z]+\\.[a-z]+$"]
-          schema (m/schema form)]
+    (doseq [form [[:re "^[a-z]+\\.[a-z]+$"]
+                  [:re #"^[a-z]+\.[a-z]+$"]]]
+      (let [schema (m/schema form)]
 
-      (is (true? (m/validate schema "a.b")))
-      (is (false? (m/validate schema "abba")))
-      (is (false? (m/validate schema ".b")))
-      (is (false? (m/validate schema false)))
+        (is (true? (m/validate schema "a.b")))
+        (is (false? (m/validate schema "abba")))
+        (is (false? (m/validate schema ".b")))
+        (is (false? (m/validate schema false)))
 
-      (is (nil? (m/explain schema "a.b")))
-      (is (results= {:schema schema, :value "abba", :errors [{:path [], :in [], :schema schema, :value "abba"}]}
-                    (m/explain schema "abba")))
+        (is (nil? (m/explain schema "a.b")))
+        (is (results= {:schema schema, :value "abba", :errors [{:path [], :in [], :schema schema, :value "abba"}]}
+                      (m/explain schema "abba")))
 
-      (is (true? (m/validate (over-the-wire schema) "a.b")))
+        (is (true? (m/validate (over-the-wire schema) "a.b")))
 
-      (is (= [:re] (m/accept schema visitor)))
+        (is (= [:re] (m/accept schema visitor)))
 
-      (is (= form (m/form schema)))))
+        (is (= form (m/form schema))))))
 
   (testing "fn schemas"
     (doseq [fn ['(fn [x] (and (int? x) (< 10 x 18)))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -5,7 +5,9 @@
             [malli.core :as m]))
 
 (deftest generator-test
-  (doseq [[?schema] json-schema-test/expectations]
+  (doseq [[?schema] json-schema-test/expectations
+          ;; cljs doesn't have a regex generator :(
+          #?@(:cljs [:when (not= (m/name ?schema) :re)])]
     (testing (m/form ?schema)
       (testing "generate"
         (is (= (mg/generate ?schema {:seed 123})

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -36,7 +36,8 @@
    [[:maybe string?] {:oneOf [{:type "string"} {:type "null"}]}]
    [[:tuple string? string?] {:type "array"
                               :items [{:type "string"} {:type "string"}]
-                              :additionalItems false}]])
+                              :additionalItems false}]
+   [[:re "^[a-z]+\\.[a-z]+$"] {:type "string", :pattern "^[a-z]+\\.[a-z]+$"}]])
 
 (deftest json-schema-test
   (doseq [[schema json-schema] expectations]

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -42,7 +42,8 @@
    [[:tuple string? string?] {:type "array"
                               :items {}
                               :x-items [{:type "string"}
-                                        {:type "string"}]}]])
+                                        {:type "string"}]}]
+   [[:re "^[a-z]+\\.[a-z]+$"] {:type "string", :pattern "^[a-z]+\\.[a-z]+$"}]])
 
 (deftest swagger-test
   (doseq [[schema swagger-schema] expectations]


### PR DESCRIPTION
```clj
(def Email 
  [:re #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$"])

(m/validate Email "tommi@kikka.com")
; => true

(-> Email (m/serialize) (m/deserialize) (m/validate "tommi@kikka.com"))
; => true

(mg/generate Email {:seed 42, :size 10})
; => "CaR@MavCk70OHiX.yZ"
```

Question: Should the `Pattern` implement `IntoSchema` so it could be used without the`:re` schema tag? Would be always on...
