### PR TITLE
Regex schemas work unwrapped

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -27,8 +27,8 @@
                              "-Dclojure.compiler.direct-linking=true"]}}
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         borkdude/sci {:git/url "https://github.com/borkdude/sci"
-                      :sha "939cfde3143c84e2134caaff1b5640510e6096f6"}
+                      :sha "e73331e74322b6c6a823ed487a724caec3f28a9e"}
         borkdude/edamame {:git/url "https://github.com/borkdude/edamame"
-                          :sha "945cb3ee22fc5d20445a2b007df318b0efa63205"}
+                          :sha "739bce6ad55f1ea563ee1ddceb8d0a7f41d0f85b"}
         org.clojure/test.check {:mvn/version "0.9.0"}
         com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -768,15 +768,3 @@
 
 (def default-registry
   (clojure.core/merge predicate-registry comparator-registry base-registry))
-
-(validate #"\d+\.\d+" "1.2")
-
-(defn visitor [schema childs _]
-  (into [(name schema)] (seq childs)))
-
-(accept #"\d+\.\d+" visitor)
-(accept [:re #"\d+\.\d+"] visitor)
-(accept [:re "\\d+\\.\\d+"] visitor)
-
-(form [:re #"\d+\.\d+"])
-(form [:re "\\d+\\.\\d+"])

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -153,24 +153,26 @@
       (is (= [:maybe 'int?] (m/form schema)))))
 
   (testing "re schemas"
-    (doseq [form [[:re "^[a-z]+\\.[a-z]+$"]
-                  [:re #"^[a-z]+\.[a-z]+$"]]]
-      (let [schema (m/schema form)]
+    (let [re #"^[a-z]+\.[a-z]+$"]
+      (doseq [[form visited] [[[:re "^[a-z]+\\.[a-z]+$"] [:re]]
+                              [[:re #"^[a-z]+\.[a-z]+$"] [:re]]
+                              [re [re]]]]
+        (let [schema (m/schema form)]
 
-        (is (true? (m/validate schema "a.b")))
-        (is (false? (m/validate schema "abba")))
-        (is (false? (m/validate schema ".b")))
-        (is (false? (m/validate schema false)))
+          (is (true? (m/validate schema "a.b")))
+          (is (false? (m/validate schema "abba")))
+          (is (false? (m/validate schema ".b")))
+          (is (false? (m/validate schema false)))
 
-        (is (nil? (m/explain schema "a.b")))
-        (is (results= {:schema schema, :value "abba", :errors [{:path [], :in [], :schema schema, :value "abba"}]}
-                      (m/explain schema "abba")))
+          (is (nil? (m/explain schema "a.b")))
+          (is (results= {:schema schema, :value "abba", :errors [{:path [], :in [], :schema schema, :value "abba"}]}
+                        (m/explain schema "abba")))
 
-        (is (true? (m/validate (over-the-wire schema) "a.b")))
+          (is (true? (m/validate (over-the-wire schema) "a.b")))
 
-        (is (= [:re] (m/accept schema visitor)))
+          (is (= visited (m/accept schema visitor)))
 
-        (is (= form (m/form schema))))))
+          (is (= form (m/form schema)))))))
 
   (testing "fn schemas"
     (doseq [fn ['(fn [x] (and (int? x) (< 10 x 18)))


### PR DESCRIPTION
Making Regexs implement the `IntoSchema` so we can use them without `:re` tag. Is this a good idea? One can't turn off this support, it would be always on.

```clj
(def Email #"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,63}$")

(m/validate Email "tommi@kikka.com")
; => true

(-> Email (m/serialize) (m/deserialize) (m/validate "tommi@kikka.com"))
; => true

(mg/generate Email {:seed 42, :size 10})
; => "CaR@MavCk70OHiX.yZ"
```