### PR TITLE
User-defined errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,52 @@ Detailed errors with `m/explain`:
 ;          {:path [3 1 4 1 2], :in [:address :lonlat 1], :schema double?, :value nil})}
 ```
 
+## Custom Error Messages
+
+Schema properties `:error/message` and `:error/fn` can be used for human-readable errors:
+
+```clj
+(-> [int? {:error/message "should be an int"}]
+    (m/explain "kikka")
+    :errors
+    (first)
+    (m/error-message))
+; "should be an int"
+
+(-> [int? {:error/fn '(fn [schema value opts] (str "should be a int, was " (type value)))}]
+    (m/explain "kikka")
+    :errors
+    (first)
+    (m/error-message))
+; "should be a int, was class java.lang.String"
+```
+
+Error property values can be wrapped into localication maps (default-locale `:en`):
+
+```clj
+(-> [int? {:error/message {:en "should be an int"
+                           :fi "pitäisi olla numero"}}]
+    (m/explain "kikka")
+    :errors
+    (first)
+    (m/error-message {:locale :fi}))
+; "pitäisi olla numero"
+```
+
+Schema-based defaults can be used:
+
+```clj
+(-> int?
+    (m/explain "kikka")
+    :errors
+    (first)
+    (m/error-message
+      {:locale :fi
+       :errors {'int? {:error/message {:en "should be an int"
+                                       :fi "pitäisi olla numero"}}}}))
+; "pitäisi olla numero"
+```
+
 ## Value Transformation
 
 Schema-driven value transformations with `m/transform`:

--- a/deps.edn
+++ b/deps.edn
@@ -27,8 +27,8 @@
                              "-Dclojure.compiler.direct-linking=true"]}}
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         borkdude/sci {:git/url "https://github.com/borkdude/sci"
-                      :sha "e5cc4e422e2712fe25876ee601f782c2b0d02e7d"}
+                      :sha "1463f84738120275bc58351232ecd1acdaf0fcb1"}
         borkdude/edamame {:git/url "https://github.com/borkdude/edamame"
-                          :sha "739bce6ad55f1ea563ee1ddceb8d0a7f41d0f85b"}
+                          :sha "b577e565b136d3dd51945fe874049d4297946f57"}
         org.clojure/test.check {:mvn/version "0.9.0"}
         com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}


### PR DESCRIPTION
## Custom Error Messages

Schema properties `:error/message` and `:error/fn` can be used for human-readable errors:

```clj
(-> [int? {:error/message "should be an int"}]
    (m/explain "kikka")
    :errors
    (first)
    (m/error-message))
; "should be an int"

(-> [int? {:error/fn '(fn [schema value opts] (str "should be a int, was " (type value)))}]
    (m/explain "kikka")
    :errors
    (first)
    (m/error-message))
; "should be a int, was class java.lang.String"
```

Error property values can be wrapped into localication maps (default-locale `:en`):

```clj
(-> [int? {:error/message {:en "should be an int"
                           :fi "pitäisi olla numero"}}]
    (m/explain "kikka")
    :errors
    (first)
    (m/error-message {:locale :fi}))
; "pitäisi olla numero"
```

Schema-based defaults can be used:

```clj
(-> int?
    (m/explain "kikka")
    :errors
    (first)
    (m/error-message
      {:locale :fi
       :errors {'int? {:error/message {:en "should be an int"
                                       :fi "pitäisi olla numero"}}}}))
; "pitäisi olla numero"
```