### PR TITLE
Fix returning acc in enum explainer

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -469,7 +469,8 @@
                 (conj acc {:path path
                            :in in
                            :schema this
-                           :value x}))))
+                           :value x})
+                acc)))
           ;; TODO: should we try to derive the type from values? e.g. [:enum 1 2] ~> int?
           (-transformer [_ _])
           (-accept [this visitor opts] (visitor this (vec childs) opts))
@@ -590,11 +591,11 @@
    (schema ?schema nil))
   ([?schema {:keys [registry] :as opts :or {registry default-registry}}]
    (let [-get #(or (get registry %) (some-> registry (get (type %)) (-into-schema nil [%] opts)))]
-   (cond
-     (schema? ?schema) ?schema
-     (satisfies? IntoSchema ?schema) (-into-schema ?schema nil nil opts)
+     (cond
+       (schema? ?schema) ?schema
+       (satisfies? IntoSchema ?schema) (-into-schema ?schema nil nil opts)
        (vector? ?schema) (apply -into-schema (concat [(-get (first ?schema))]
-                                                   (-properties-and-childs (rest ?schema)) [opts]))
+                                                     (-properties-and-childs (rest ?schema)) [opts]))
        :else (or (some-> ?schema -get schema) (fail! ::invalid-schema {:schema ?schema}))))))
 
 (defn form

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -469,7 +469,28 @@
                                      [schema [1 2]
                                       {:schema schema
                                        :value [1 2]
-                                       :errors [{:path [2], :in [1], :schema string?, :value 2}]}]])}]
+                                       :errors [{:path [2], :in [1], :schema string?, :value 2}]}]])
+                          "map+enum" (let [schema [:map [:x [:enum "x"]]
+                                                        [:y [:enum "y"]]]]
+
+                                         [[schema {:x "x" :y "y"}
+                                           nil]
+
+                                          [schema {:x "non-x" :y "y"}
+                                           {:schema schema
+                                            :value {:x "non-x" :y "y"}
+                                            :errors [{:path [1 1], :in [:x], :schema [:enum "x"] , :value "non-x"}]}]
+
+                                          [schema {:x "x" :y "non-y"}
+                                           {:schema schema
+                                            :value {:x "x" :y "non-y"}
+                                            :errors [{:path [2 1], :in [:y], :schema [:enum "y"] , :value "non-y"}]}]
+
+                                          [schema {:x "non-x" :y "non-y"}
+                                           {:schema schema
+                                            :value {:x "non-x" :y "non-y"}
+                                            :errors [{:path [1 1], :in [:x], :schema [:enum "x"] , :value "non-x"}
+                                                     {:path [2 1], :in [:y], :schema [:enum "y"] , :value "non-y"}]}]])}]
 
         (doseq [[name data] expectations
                 [schema value expected] data]


### PR DESCRIPTION
`enum` spec might cause collection explainers can't produce errors report properly. To reproduce the problem:
```
(do (require '[malli.core :as m])
    (m/explain [:map [:x [:fn '(constantly false)]] ; `explain` should complain about this.
                     [:a [:enum "A" "B"]]]
               {:a "A" :x "123"}))  ; but here returns `nil` instead
```