### PR TITLE
Errors, part2

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,14 @@ Schema properties `:error/message` and `:error/fn` can be used for human-readabl
     (m/explain "kikka")
     :errors
     (first)
-    (m/error-message))
+    (me/error-message))
 ; "should be an int"
 
 (-> [int? {:error/fn '(fn [schema value opts] (str "should be a int, was " (type value)))}]
     (m/explain "kikka")
     :errors
     (first)
-    (m/error-message))
+    (me/error-message))
 ; "should be a int, was class java.lang.String"
 ```
 
@@ -177,7 +177,7 @@ Error property values can be wrapped into localication maps (default-locale `:en
     (m/explain "kikka")
     :errors
     (first)
-    (m/error-message {:locale :fi}))
+    (me/error-message {:locale :fi}))
 ; "pitäisi olla numero"
 ```
 
@@ -188,7 +188,7 @@ Schema-based defaults can be used:
     (m/explain "kikka")
     :errors
     (first)
-    (m/error-message
+    (me/error-message
       {:locale :fi
        :errors {'int? {:error/message {:en "should be an int"
                                        :fi "pitäisi olla numero"}}}}))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -664,18 +664,6 @@
   ([?schema value opts]
    ((explainer ?schema opts) value [] [])))
 
-(defn error-message
-  ([error]
-   (error-message error nil))
-  ([{:keys [value schema]} {:keys [errors locale] :or {errors {}} :as opts}]
-   (let [maybe-localized (fn [x] (if (map? x) (get x (or locale :en)) x))
-         schema-properties (properties schema)
-         default-properties (errors (name schema))]
-     (or (if-let [fn (maybe-localized (:error/fn schema-properties))] ((eval fn) schema value opts))
-         (maybe-localized (:error/message schema-properties))
-         (if-let [fn (maybe-localized (:error/fn default-properties))] ((eval fn) schema value opts))
-         (maybe-localized (:error/message default-properties))))))
-
 (defn transformer
   "Creates a value transformer given a transformer and a schema."
   ([?schema t]

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -1,6 +1,7 @@
 (ns malli.error
   (:require [malli.core :as m]))
 
+;; TODO: complete this
 (def default-errors
   {::unknown {:error/message {:en "unknown error"}}
    ::m/missing-key {:error/message {:en "missing required key"}}

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -12,7 +12,7 @@
   (if (map? x) (get x locale (get x :en)) x))
 
 (defn -message [{:keys [value schema]} x locale opts]
-  (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((eval fn) schema value opts))
+  (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn) schema value opts))
       (-maybe-localized (:error/message x) locale)))
 
 ;;
@@ -33,9 +33,9 @@
   ([explanation {:keys [errors locale] :or {errors default-errors} :as opts}]
    (reduce
      (fn [acc error]
-       (if (identical? ::m/missing-key (:type error))
-         (update-in acc (conj (:in error) (::m/key error))
-                    (fn [x] (->SchemaError x (-maybe-localized (:error/message (::m/missing-key errors)) locale))))
+       (if (= ::m/missing-key (:type error))
+         (update-in acc (conj (:in error) (::m/key error)) ->SchemaError
+                    (-maybe-localized (:error/message (::m/missing-key errors)) locale))
          (update-in acc (:in error) (fn [x] (->SchemaError x (error-message error opts))))))
      (:value explanation)
      (:errors explanation))))

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -1,0 +1,41 @@
+(ns malli.error
+  (:require [malli.core :as m]))
+
+(def default-errors
+  {::unknown {:error/message {:en "unknown error"}}
+   ::m/missing-key {:error/message {:en "missing required key"}}
+   'int? {:error/message {:en "should be an int"}}})
+
+(defrecord SchemaError [value message])
+
+(defn -maybe-localized [x locale]
+  (if (map? x) (get x locale (get x :en)) x))
+
+(defn -message [{:keys [value schema]} x locale opts]
+  (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((eval fn) schema value opts))
+      (-maybe-localized (:error/message x) locale)))
+
+;;
+;; public api
+;;
+
+(defn error-message
+  ([error]
+   (error-message error nil))
+  ([{:keys [schema] :as error} {:keys [errors locale] :or {errors default-errors} :as opts}]
+   (or (-message error (m/properties schema) locale opts)
+       (-message error (errors (m/name schema)) locale opts)
+       (-maybe-localized (-> errors ::unknown :error/message) locale))))
+
+(defn merge-errors
+  ([explanation]
+   (merge-errors explanation nil))
+  ([explanation {:keys [errors locale] :or {errors default-errors} :as opts}]
+   (reduce
+     (fn [acc error]
+       (if (identical? ::m/missing-key (:type error))
+         (update-in acc (conj (:in error) (::m/key error))
+                    (fn [x] (->SchemaError x (-maybe-localized (:error/message (::m/missing-key errors)) locale))))
+         (update-in acc (:in error) (fn [x] (->SchemaError x (error-message error opts))))))
+     (:value explanation)
+     (:errors explanation))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -526,29 +526,6 @@
     (is (= [2 1] (?path (m/explain [:map {:name int?} [:x int?]] {:x "1"}))))
     (is (= [2 2] (?path (m/explain [:map {:name int?} [:x {:optional false} int?]] {:x "1"}))))))
 
-(deftest error-message-test
-  (let [msg "should be an int"
-        fn1 (fn [_ value _] (str "should be an int, was " value))
-        fn2 '(fn [_ value _] (str "should be an int, was " value))]
-    (doseq [[schema value message opts]
-            [;; via schema
-             [[int? {:error/message msg}] "kikka" "should be an int"]
-             [[int? {:error/fn fn1}] "kikka" "should be an int, was kikka"]
-             [[int? {:error/fn fn2}] "kikka" "should be an int, was kikka"]
-             [[int? {:error/message msg, :error/fn fn2}] "kikka" "should be an int, was kikka"]
-             ;; via defaults
-             [[int?] "kikka" "should be an int" {:errors {'int? {:error/message msg}}}]
-             [[int?] "kikka" "should be an int, was kikka" {:errors {'int? {:error/fn fn1}}}]
-             [[int?] "kikka" "should be an int, was kikka" {:errors {'int? {:error/fn fn2}}}]
-             [[int?] "kikka" "should be an int, was kikka" {:errors {'int? {:error/message msg, :error/fn fn2}}}]
-             ;; both
-             [[int?
-               {:error/message msg, :error/fn fn2}]
-              "kikka" "should be an int, was kikka"
-              {:errors {'int? {:error/message "fail1", :error/fn (constantly "fail2")}}}]]]
-      (is (= message (-> (m/explain schema value) :errors first (m/error-message opts)))))))
-
-
 (deftest properties-test
   (testing "properties can be set and retrieved"
     (let [properties {:title "kikka"}]

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -1,0 +1,66 @@
+(ns malli.error-test
+  (:require [clojure.test :refer [deftest testing is are]]
+            [malli.error :as me]
+            [malli.core :as m]))
+
+(deftest error-message-test
+  (let [msg "should be an int"
+        fn1 (fn [_ value _] (str "should be an int, was " value))
+        fn2 '(fn [_ value _] (str "should be an int, was " value))]
+    (doseq [[schema value message opts]
+            [;; via schema
+             [[int? {:error/message msg}] "kikka" "should be an int"]
+             [[int? {:error/fn fn1}] "kikka" "should be an int, was kikka"]
+             [[int? {:error/fn fn2}] "kikka" "should be an int, was kikka"]
+             [[int? {:error/message msg, :error/fn fn2}] "kikka" "should be an int, was kikka"]
+             ;; via defaults
+             [[int?] "kikka" "should be an int" {:errors {'int? {:error/message msg}}}]
+             [[int?] "kikka" "should be an int, was kikka" {:errors {'int? {:error/fn fn1}}}]
+             [[int?] "kikka" "should be an int, was kikka" {:errors {'int? {:error/fn fn2}}}]
+             [[int?] "kikka" "should be an int, was kikka" {:errors {'int? {:error/message msg, :error/fn fn2}}}]
+             ;; both
+             [[int?
+               {:error/message msg, :error/fn fn2}]
+              "kikka" "should be an int, was kikka"
+              {:errors {'int? {:error/message "fail1", :error/fn (constantly "fail2")}}}]]]
+      (is (= message (-> (m/explain schema value) :errors first (me/error-message opts)))))))
+
+(deftest merge-errors-test
+  (let [schema [:map
+                [:a int?]
+                [:b pos-int?]
+                [:c [pos-int? {:error/message "stay positive"}]]
+                [:d
+                 [:map
+                  [:e any?]
+                  [:f [int? {:error/message {:en "should be zip"
+                                             :fi "pitäisi olla numero"}}]]]]]
+        error? (partial me/->SchemaError "invalid")]
+
+    (testing "with default locale"
+      (is (= {:a (error? "should be an int")
+              :b (error? "unknown error")
+              :c (error? "stay positive"),
+              :d {:f (error? "should be zip"),
+                  :e (me/->SchemaError nil "missing required key")}}
+             (-> (m/explain
+                   schema
+                   {:a "invalid"
+                    :b "invalid"
+                    :c "invalid"
+                    :d {:f "invalid"}})
+                 (me/merge-errors)))))
+
+    (testing "localization is applied, if available"
+      (is (= {:a (error? "should be an int")
+              :b (error? "unknown error")
+              :c (error? "stay positive"),
+              :d {:f (error? "pitäisi olla numero"),
+                  :e (me/->SchemaError nil "missing required key")}}
+             (-> (m/explain
+                   schema
+                   {:a "invalid"
+                    :b "invalid"
+                    :c "invalid"
+                    :d {:f "invalid"}})
+                 (me/merge-errors {:locale :fi})))))))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -33,8 +33,7 @@
                 [:d
                  [:map
                   [:e any?]
-                  [:f [int? {:error/message {:en "should be zip"
-                                             :fi "pitäisi olla numero"}}]]]]]
+                  [:f [int? {:error/message {:en "should be zip", :fi "pitäisi olla numero"}}]]]]]
         error? (partial me/->SchemaError "invalid")]
 
     (testing "with default locale"


### PR DESCRIPTION
new ns `malli.error` to host the thigs. Initial vomitation of global error message catalog.