### PR TITLE
Humanized Errors, part3

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -219,12 +219,13 @@
                   explainers (mapv
                                (fn [[i [key {:keys [optional] :as key-properties} schema]]]
                                  (let [key-distance (if (seq key-properties) 2 1)
-                                       explainer (-explainer schema (into path [(+ i distance) key-distance]))]
+                                       explainer (-explainer schema (into path [(+ i distance) key-distance]))
+                                       key-path (into path [(+ i distance) 0])]
                                    (fn [x in acc]
                                      (if-let [v (key x)]
                                        (explainer v (conj in key) acc)
                                        (if-not optional
-                                         (conj acc (-> (error path in this nil ::missing-key) (assoc ::key key))))))))
+                                         (conj acc (error key-path (conj in key) this nil ::missing-key)))))))
                                (map-indexed vector entries))]
               (fn [x in acc]
                 (if-not (map? x)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -369,8 +369,11 @@
                 (cond
                   (not (fpred x)) (conj acc (error path in this x ::invalid-type))
                   (not (validate-limits x)) (conj acc (error path in this x ::limits))
-                  :else (loop [acc acc, i 0, [x & xs] x]
-                          (cond-> (explainer x (conj in i) acc) xs (recur (inc i) xs)))))))
+                  :else (let [size (count x)]
+                          (loop [acc acc, i 0, [x & xs] x]
+                            (if (< i size)
+                              (cond-> (or (explainer x (conj in i) acc) acc) xs (recur (inc i) xs))
+                              acc)))))))
           (-transformer [_ transformer]
             (if-let [t (-transformer schema transformer)]
               (if fempty

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -76,7 +76,7 @@
    (reduce
      (fn [acc error]
        (if (= ::m/missing-key (:type error))
-         (assoc-in acc (conj (:in error) (::m/key error))
+         (assoc-in acc (:in error)
                    (assoc error :message (-maybe-localized (:error/message (::m/missing-key errors)) locale)))
          (assoc-in acc (:in error) (assoc error :message (error-message error opts)))))
      (empty (:value explanation))

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -5,7 +5,50 @@
 (def default-errors
   {::unknown {:error/message {:en "unknown error"}}
    ::m/missing-key {:error/message {:en "missing required key"}}
-   'int? {:error/message {:en "should be an int"}}})
+   'any? {:error/message {:en "should be any"}}
+   'some? {:error/message {:en "shoud be some"}}
+   'number? {:error/message {:en "should be number"}}
+   'integer? {:error/message {:en "should be integer"}}
+   'int? {:error/message {:en "should be int"}}
+   'pos-int? {:error/message {:en "should be positive int"}}
+   'neg-int? {:error/message {:en "should be negative int"}}
+   'nat-int? {:error/message {:en "should be non-negative int"}}
+   'float? {:error/message {:en "should be float"}}
+   'double? {:error/message {:en "should be double"}}
+   'boolean? {:error/message {:en "should be boolean"}}
+   'string? {:error/message {:en "should be string"}}
+   'ident? {:error/message {:en "should be ident"}}
+   'simple-ident? {:error/message {:en "should be simple ident"}}
+   'qualified-ident? {:error/message {:en "should be qualified ident"}}
+   'keyword? {:error/message {:en "should be keyword"}}
+   'simple-keyword? {:error/message {:en "should be simple keyword"}}
+   'qualified-keyword? {:error/message {:en "should be qualified keyword"}}
+   'symbol? {:error/message {:en "should be symbol"}}
+   'simple-symbol? {:error/message {:en "should be simple symbol"}}
+   'qualified-symbol? {:error/message {:en "should be qualified symbol"}}
+   'uuid? {:error/message {:en "should be uuid"}}
+   'uri? {:error/message {:en "should be uri"}}
+   #?@(:clj ['decimal? {:error/message {:en "should be decimal"}}])
+   'inst? {:error/message {:en "should be inst"}}
+   'seqable? {:error/message {:en "should be seqable"}}
+   'indexed? {:error/message {:en "should be indexed"}}
+   'map? {:error/message {:en "should be map"}}
+   'vector? {:error/message {:en "should be vector"}}
+   'list? {:error/message {:en "should be list"}}
+   'seq? {:error/message {:en "should be seq"}}
+   'char? {:error/message {:en "should be char"}}
+   'set? {:error/message {:en "should be set"}}
+   'nil? {:error/message {:en "should be nil"}}
+   'false? {:error/message {:en "should be false"}}
+   'true? {:error/message {:en "should be true"}}
+   'zero? {:error/message {:en "should be zero"}}
+   #?@(:clj ['rational? {:error/message {:en "should be rational"}}])
+   'coll? {:error/message {:en "should be coll"}}
+   'empty? {:error/message {:en "should be empty"}}
+   'associative? {:error/message {:en "should be associative"}}
+   'sequential? {:error/message {:en "should be sequential"}}
+   #?@(:clj ['ratio? {:error/message {:en "should be ratio"}}])
+   #?@(:clj ['bytes? {:error/message {:en "should be bytes"}}])})
 
 (defn- -maybe-localized [x locale]
   (if (map? x) (get x locale (get x :en)) x))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -256,7 +256,7 @@
       (is (results= {:schema schema1
                      :value {:y "invalid" :z "kikka"}
                      :errors
-                     [{:path [], :in [], :schema schema1, :type ::m/missing-key, ::m/key :x}
+                     [{:path [1 0], :in [:x], :schema schema1, :type ::m/missing-key}
                       {:path [2 2], :in [:y], :schema int?, :value "invalid"}]}
                     (m/explain schema1 {:y "invalid" :z "kikka"})))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -68,6 +68,9 @@
       (is (results= {:schema schema
                      :value "1"
                      :errors [{:path [], :in [], :schema schema, :value "1"}]}
+                    {:schema schema
+                     :value "1"
+                     :errors [(m/error [] [] schema "1")]}
                     (m/explain schema "1")))
 
       (is (= 1 (m/transform schema "1" transform/string-transformer)))
@@ -102,7 +105,19 @@
 
       (is (= [:and ['int?] [:or ['pos-int?] ['neg-int?]]] (m/accept schema visitor)))
 
-      (is (= [:and 'int? [:or 'pos-int? 'neg-int?]] (m/form schema)))))
+      (is (= [:and 'int? [:or 'pos-int? 'neg-int?]] (m/form schema))))
+
+    (testing "explain with branches"
+      (let [schema [:and pos-int? neg-int?]]
+        (is (results= {:schema schema,
+                       :value -1,
+                       :errors [{:path [1], :in [], :schema pos-int?, :value -1}]}
+                      (m/explain schema -1))))
+      (let [schema [:and pos-int? neg-int?]]
+        (is (results= {:schema schema,
+                       :value 1,
+                       :errors [{:path [2], :in [], :schema neg-int?, :value 1}]}
+                      (m/explain schema 1))))))
 
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -6,7 +6,12 @@
 (defn with-schema-forms [result]
   (some-> result
           (update :schema m/form)
-          (update :errors (partial map #(update % :schema m/form)))))
+          (update :errors (partial map (fn [error]
+                                         (-> error
+                                             (update :schema m/form)
+                                             (update :type (fnil identity nil))
+                                             (update :message (fnil identity nil))
+                                             (m/map->SchemaError)))))))
 
 (defn results= [& results]
   (apply = (map with-schema-forms results)))
@@ -479,26 +484,26 @@
                                        :value [1 2]
                                        :errors [{:path [2], :in [1], :schema string?, :value 2}]}]])
                           "map+enum" (let [schema [:map [:x [:enum "x"]]
-                                                        [:y [:enum "y"]]]]
+                                                   [:y [:enum "y"]]]]
 
-                                         [[schema {:x "x" :y "y"}
-                                           nil]
+                                       [[schema {:x "x" :y "y"}
+                                         nil]
 
-                                          [schema {:x "non-x" :y "y"}
-                                           {:schema schema
-                                            :value {:x "non-x" :y "y"}
-                                            :errors [{:path [1 1], :in [:x], :schema [:enum "x"] , :value "non-x"}]}]
+                                        [schema {:x "non-x" :y "y"}
+                                         {:schema schema
+                                          :value {:x "non-x" :y "y"}
+                                          :errors [{:path [1 1], :in [:x], :schema [:enum "x"], :value "non-x"}]}]
 
-                                          [schema {:x "x" :y "non-y"}
-                                           {:schema schema
-                                            :value {:x "x" :y "non-y"}
-                                            :errors [{:path [2 1], :in [:y], :schema [:enum "y"] , :value "non-y"}]}]
+                                        [schema {:x "x" :y "non-y"}
+                                         {:schema schema
+                                          :value {:x "x" :y "non-y"}
+                                          :errors [{:path [2 1], :in [:y], :schema [:enum "y"], :value "non-y"}]}]
 
-                                          [schema {:x "non-x" :y "non-y"}
-                                           {:schema schema
-                                            :value {:x "non-x" :y "non-y"}
-                                            :errors [{:path [1 1], :in [:x], :schema [:enum "x"] , :value "non-x"}
-                                                     {:path [2 1], :in [:y], :schema [:enum "y"] , :value "non-y"}]}]])}]
+                                        [schema {:x "non-x" :y "non-y"}
+                                         {:schema schema
+                                          :value {:x "non-x" :y "non-y"}
+                                          :errors [{:path [1 1], :in [:x], :schema [:enum "x"], :value "non-x"}
+                                                   {:path [2 1], :in [:y], :schema [:enum "y"], :value "non-y"}]}]])}]
 
         (doseq [[name data] expectations
                 [schema value expected] data]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -327,6 +327,7 @@
     (testing "validation"
       (let [expectations {"vector" [[true [:vector int?] [1 2 3]]
                                     [false [:vector int?] [1 "2" 3]]
+                                    [false [:vector int?] [1 2 "3"]]
                                     [false [:vector int?] [nil]]
                                     [false [:vector int?] "invalid"]
 
@@ -344,6 +345,7 @@
 
                           "list" [[true [:list int?] '(1 2 3)]
                                   [false [:list int?] '(1 "2" 3)]
+                                  [false [:list int?] '(1 2 "3")]
                                   [false [:vector int?] '(nil)]
                                   [false [:list int?] "invalid"]
 
@@ -361,6 +363,7 @@
 
                           "set" [[true [:set int?] #{1 2 3}]
                                  [false [:set int?] #{1 "2" 3}]
+                                 [false [:set int?] #{1 2 "3"}]
                                  [false [:set int?] #{nil}]
                                  [false [:set int?] "invalid"]
 

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -25,8 +25,9 @@
               {:errors {'int? {:error/message "fail1", :error/fn (constantly "fail2")}}}]]]
       (is (= message (-> (m/explain schema value) :errors first (me/error-message opts)))))))
 
-(deftest merge-errors-test
-  (let [schema [:map
+;; FIXME
+#_(deftest merge-errors-test
+    (let [schema [:map
                 [:a int?]
                 [:b pos-int?]
                 [:c [pos-int? {:error/message "stay positive"}]]
@@ -36,30 +37,30 @@
                   [:f [int? {:error/message {:en "should be zip", :fi "pitäisi olla numero"}}]]]]]
         error? (partial me/->SchemaError "invalid")]
 
-    (testing "with default locale"
-      (is (= {:a (error? "should be an int")
+      (testing "with default locale"
+        (is (= {:a (error? "should be an int")
               :b (error? "unknown error")
               :c (error? "stay positive"),
               :d {:f (error? "should be zip"),
                   :e (me/->SchemaError nil "missing required key")}}
-             (-> (m/explain
+               (-> (m/explain
                    schema
                    {:a "invalid"
                     :b "invalid"
                     :c "invalid"
                     :d {:f "invalid"}})
-                 (me/merge-errors)))))
+                   (me/check)))))
 
-    (testing "localization is applied, if available"
-      (is (= {:a (error? "should be an int")
+      (testing "localization is applied, if available"
+        (is (= {:a (error? "should be an int")
               :b (error? "unknown error")
               :c (error? "stay positive"),
               :d {:f (error? "pitäisi olla numero"),
                   :e (me/->SchemaError nil "missing required key")}}
-             (-> (m/explain
+               (-> (m/explain
                    schema
                    {:a "invalid"
                     :b "invalid"
                     :c "invalid"
                     :d {:f "invalid"}})
-                 (me/merge-errors {:locale :fi})))))))
+                   (me/check {:locale :fi})))))))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -1,13 +1,12 @@
 (ns malli.error-test
   (:require [clojure.test :refer [deftest testing is are]]
             [malli.error :as me]
-            [malli.core :as m]
-            [clojure.walk :as walk]))
+            [malli.core :as m]))
 
 (deftest error-message-test
   (let [msg "should be an int"
-        fn1 (fn [_ value _] (str "should be an int, was " value))
-        fn2 '(fn [_ value _] (str "should be an int, was " value))]
+        fn1 (fn [{:keys [value]} _] (str "should be an int, was " value))
+        fn2 '(fn [{:keys [value]} _] (str "should be an int, was " value))]
     (doseq [[schema value message opts]
             [;; via schema
              [[int? {:error/message msg}] "kikka" "should be an int"]

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -1,7 +1,8 @@
 (ns malli.error-test
   (:require [clojure.test :refer [deftest testing is are]]
             [malli.error :as me]
-            [malli.core :as m]))
+            [malli.core :as m]
+            [clojure.walk :as walk]))
 
 (deftest error-message-test
   (let [msg "should be an int"
@@ -25,42 +26,47 @@
               {:errors {'int? {:error/message "fail1", :error/fn (constantly "fail2")}}}]]]
       (is (= message (-> (m/explain schema value) :errors first (me/error-message opts)))))))
 
-;; FIXME
-#_(deftest merge-errors-test
-    (let [schema [:map
+(deftest merge-errors-test
+  (let [schema [:map
                 [:a int?]
                 [:b pos-int?]
-                [:c [pos-int? {:error/message "stay positive"}]]
+                [:c [pos-int? {:error/message "STAY POSITIVE"
+                               :error/fn {:fi '(constantly "POSITIIVINEN")}}]]
                 [:d
                  [:map
                   [:e any?]
-                  [:f [int? {:error/message {:en "should be zip", :fi "pitäisi olla numero"}}]]]]]
-        error? (partial me/->SchemaError "invalid")]
+                  [:f [int? {:error/message {:en "SHOULD BE ZIP", :fi "PITÄISI OLLA NUMERO"}}]]]]]
+        value {:a "invalid"
+               :b "invalid"
+               :c "invalid"
+               :d {:f "invalid"}}
+        with-just-messages (fn [x]
+                            (walk/prewalk
+                              (fn [x]
+                                (if (m/error? x)
+                                  (:message x)
+                                  x)) x))]
 
-      (testing "with default locale"
-        (is (= {:a (error? "should be an int")
-              :b (error? "unknown error")
-              :c (error? "stay positive"),
-              :d {:f (error? "should be zip"),
-                  :e (me/->SchemaError nil "missing required key")}}
-               (-> (m/explain
-                   schema
-                   {:a "invalid"
-                    :b "invalid"
-                    :c "invalid"
-                    :d {:f "invalid"}})
-                   (me/check)))))
+    (testing "with default locale"
+      (is (= {:a "should be int"
+              :b "should be positive int"
+              :c "STAY POSITIVE",
+              :d {:e "missing required key"
+                  :f "SHOULD BE ZIP"}}
+             (-> (m/explain schema value)
+                 (me/check)
+                 (with-just-messages)))))
 
-      (testing "localization is applied, if available"
-        (is (= {:a (error? "should be an int")
-              :b (error? "unknown error")
-              :c (error? "stay positive"),
-              :d {:f (error? "pitäisi olla numero"),
-                  :e (me/->SchemaError nil "missing required key")}}
-               (-> (m/explain
-                   schema
-                   {:a "invalid"
-                    :b "invalid"
-                    :c "invalid"
-                    :d {:f "invalid"}})
-                   (me/check {:locale :fi})))))))
+    (testing "localization is applied, if available"
+      (is (= {:a "NUMERO"
+              :b "should be positive int"
+              :c "POSITIIVINEN",
+              :d {:e "PUUTTUVA AVAIN"
+                  :f "PITÄISI OLLA NUMERO"}}
+             (-> (m/explain schema value)
+                 (me/check
+                   {:locale :fi
+                    :errors (-> me/default-errors
+                                (assoc-in ['int? :error/message :fi] "NUMERO")
+                                (assoc-in [::m/missing-key :error/message :fi] "PUUTTUVA AVAIN"))})
+                 (with-just-messages)))))))


### PR DESCRIPTION
* `:errors` are first class Records in `m/explain` results
* default errors for all core predicates in `:en`
* fix collection explainer (to handle `nil`s)
* `merge-errors` is now `humanize` and feels like Prismatic `check`