### PR TITLE
malli.edn and gen/elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Scehmas can be used to generate values:
   {:seed 42, :size 10})
 ; => "CaR@MavCk70OHiX.yZ"
 
-;; gen/elements
+;; gen/elements (note, are not validated)
 (mg/generate
   [:and {:gen/elements ["kikka" "kukka" "kakka"]} string?]
   {:seed 10})

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,7 +1,6 @@
 (ns malli.core
   (:refer-clojure :exclude [-name eval name merge])
-  (:require [sci.core :as sci]
-            [edamame.core :as edamame])
+  (:require [sci.core :as sci])
   #?(:clj (:import (java.util.regex Pattern))))
 
 ;;
@@ -708,18 +707,6 @@
                              {:keys #{}, :form []}
                              (mapcat #(-> % (childs opts) (-parse-keys opts) :forms) schemas))))
                    (schema opts)))))))
-
-(defn serialize
-  ([?schema]
-   (serialize ?schema nil))
-  ([?schema opts]
-   (pr-str (form ?schema opts))))
-
-(defn deserialize
-  ([form]
-   (deserialize form nil))
-  ([form opts]
-   (schema (edamame/parse-string form {:dispatch {\# {\" #(re-pattern %)}}}) opts)))
 
 (defn map-key [_]
   ^{:type ::schema}

--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -1,0 +1,16 @@
+(ns malli.edn
+  (:refer-clojure :exclude [read-string])
+  (:require [malli.core :as m]
+            [edamame.core :as edamame]))
+
+(defn write-string
+  ([?schema]
+   (write-string ?schema nil))
+  ([?schema opts]
+   (pr-str (m/form ?schema opts))))
+
+(defn read-string
+  ([form]
+   (read-string form nil))
+  ([form opts]
+   (m/schema (edamame/parse-string form {:dispatch {\# {\" #(re-pattern %)}}}) opts)))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -79,9 +79,11 @@
 
 (defn- -create [schema opts]
   (let [gen (-generator schema opts)
-        fmap (:gen/fmap (m/properties schema))]
+        {:gen/keys [fmap elements]} (m/properties schema)
+        elements (if elements (gen/elements elements))]
     (cond
-      fmap (gen/fmap (m/eval fmap) (or gen (gen/return nil)))
+      fmap (gen/fmap (m/eval fmap) (or elements gen (gen/return nil)))
+      elements elements
       gen gen
       :else (m/fail! ::no-generator {:schema schema, :opts opts}))))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1,6 +1,7 @@
 (ns malli.core-test
   (:require [clojure.test :refer [deftest testing is are]]
             [malli.core :as m]
+            [malli.edn :as me]
             [malli.transform :as transform]))
 
 (defn with-schema-forms [result]
@@ -17,7 +18,7 @@
   (apply = (map with-schema-forms results)))
 
 (defn over-the-wire [?schema]
-  (-> ?schema (m/serialize) (m/deserialize)))
+  (-> ?schema (me/write-string) (me/read-string)))
 
 (deftest keyword->string
   (is (= "abba" (m/keyword->string :abba)))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -40,4 +40,9 @@
         (dotimes [_ 100]
           (m/validate schema (mg/generate generator)))))
     (testing "with generator"
-      (is (re-matches #"kikka_\d+" (mg/generate [:and {:gen/fmap '(partial str "kikka_")} pos-int?]))))))
+      (is (re-matches #"kikka_\d+" (mg/generate [:and {:gen/fmap '(partial str "kikka_")} pos-int?])))))
+  (testing "gen/elements"
+    (dotimes [_ 1000]
+      (#{1 2} (mg/generate [:and {:gen/elements [1 2]} int?])))
+    (dotimes [_ 1000]
+      (#{"1" "2"} (mg/generate [:and {:gen/elements [1 2], :gen/fmap 'str} int?])))))


### PR DESCRIPTION
Move edn-related code to separate ns for smaller size & faster loading of the core. Also, add `:gen/elements` to spesify examples by hand.