### PR TITLE
key-transformer should transformed all keys

### DIFF
--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -129,3 +129,10 @@
            (m/transform [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
                         {:x 18 :y "john" :a "doe"}
                         strip-extra-key-transformer)))))
+
+(deftest key-transformer
+  (let [key-transformer (transform/key-transformer #(-> % name (str "_key") keyword))]
+    (is (= {:x_key 18 :y_key "john" :a_key "doe"}
+           (m/transform [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
+                        {:x 18 :y "john" :a "doe"}
+                        key-transformer)))))


### PR DESCRIPTION
#91 
So let `mt/key-transformer` to transform all keys in the map. 

If we want to transform only keys in the schema, compose `mt/strip-extra-keys-transformer` and `mt/key-transformer`. Ok with that @ikitommi?