### PR TITLE
Separate encode & decode + schema-hinted transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,12 +234,12 @@ Errors can be targetted using `:error/path` property:
 
 ## Value Transformation
 
-Schema-driven value transformations with `m/transform`:
+Schema-driven value transformations with `m/decode` and `m/encode`:
 
 ```clj
 (require '[malli.transform :as mt])
 
-(m/transform
+(m/decode
   Address
   {:id "Lillan",
    :tags ["coffee" "artesan" "garden"],
@@ -259,7 +259,7 @@ Schema-driven value transformations with `m/transform`:
 Transform map keys with `mt/key-transformer`:
 
 ```clj
-(m/transform
+(m/decode
   Address
   {:id "Lillan",
    :tags ["coffee" "artesan" "garden"],
@@ -284,7 +284,7 @@ Transformers are composable:
     mt/strip-extra-keys-transformer
     mt/json-transformer)
 
-(m/transform
+(m/decode
   Address
   {:id "Lillan",
    :EVIL "LYN"
@@ -591,7 +591,7 @@ Coercion:
 
 ;; 140ns
 (let [schema [:map [:id int?] [:name string?]]
-      transform (m/transformer schema transform/string-transformer)]
+      transform (m/decoder schema transform/string-transformer)]
   (cc/quick-bench
     (transform {:id "1", :name "kikka"})))
 ```

--- a/README.md
+++ b/README.md
@@ -333,16 +333,16 @@ Schemas can be deep-merged with `m/merge`:
 Writing and Reading schemas as [EDN](https://github.com/edn-format/edn), no `eval` needed.
 
 ```clj
-(require '[malli.edn :as me])
+(require '[malli.edn :as edn])
 
 (-> [:and
      [:map
       [:x int?]
       [:y int?]]
      [:fn '(fn [{:keys [x y]}] (> x y))]]
-    (me/write-string)
+    (edn/write-string)
     (doto prn) ; => "[:and [:map [:x int?] [:y int?]] [:fn (fn [{:keys [x y]}] (> x y))]]"
-    (me/read-string)
+    (edn/read-string)
     (doto (-> (m/validate {:x 0, :y 1}) prn)) ; => false
     (doto (-> (m/validate {:x 2, :y 1}) prn))) ; => true
 ;[:and 

--- a/deps.edn
+++ b/deps.edn
@@ -28,7 +28,8 @@
                              "-Dclojure.compiler.direct-linking=true"]}}
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
         borkdude/sci {:git/url "https://github.com/borkdude/sci"
-                      :sha "a1f6c2204bbfa0c191dbb99efef99709dc454fbe"}
-        borkdude/edamame {:mvn/version "0.0.6"}
+                      :sha "a66dd0dce8edab65627b86f6388100740e36bd66"}
+        borkdude/edamame {:git/url "https://github.com/borkdude/edamame"
+                          :sha "34755e7a875fae2ab4d64e6be89b6270046a91a3"}
         org.clojure/test.check {:mvn/version "0.10.0"}
         com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}

--- a/perf/malli/perf_test.cljc
+++ b/perf/malli/perf_test.cljc
@@ -158,7 +158,7 @@
       ;; 74µs
       (cc/quick-bench (json->place json)))
 
-    (let [json->place (m/transformer Place transform/json-transformer)]
+    (let [json->place (m/decoder Place transform/json-transformer)]
       (clojure.pprint/pprint (json->place json))
 
       ;; 1µs
@@ -179,7 +179,7 @@
       (string->edn "1")))
 
   ;; 4ns
-  (let [string->edn (m/transformer int? transform/string-transformer)]
+  (let [string->edn (m/decoder int? transform/string-transformer)]
     (assert (= 1
                (string->edn "1")
                (string->edn 1)))
@@ -204,7 +204,7 @@
 
   ;; 140ns
   (let [schema [:map [:id int?] [:name string?]]
-        string->edn (m/transformer schema transform/string-transformer)]
+        string->edn (m/decoder schema transform/string-transformer)]
     (assert (= {:id 1, :name "kikka"}
                (string->edn {:id 1, :name "kikka"})
                (string->edn {:id "1", :name "kikka"})))
@@ -225,7 +225,7 @@
 
   ;; 3.0ns
   (let [schema [:map [:id int?] [:name string?]]
-        string->edn (m/transformer schema transform/json-transformer)]
+        string->edn (m/decoder schema transform/json-transformer)]
     (assert (= {:id 1, :name "kikka"}
                (string->edn {:id 1, :name "kikka"})))
     (cc/quick-bench
@@ -271,7 +271,7 @@
 
     ;; 3ns -> 3ns
     ;; 520ns -> 130ns
-    (let [>> (m/transformer [:map [:x string?] [:y int?]] transformer)]
+    (let [>> (m/decoder [:map [:x string?] [:y int?]] transformer)]
       (cc/quick-bench (>> {:x "1", :y 1})))))
 
 (comment

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -729,6 +729,7 @@
   (reify Schema
     (-name [_] ::map-key)
     (-form [_] ::map-key)
+    (-properties [_])
     (-transformer [this transformer context] (-value-transformer transformer this context))))
 
 ;;

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -506,7 +506,8 @@
                   acc)
                 (catch #?(:clj Exception, :cljs js/Error) e
                   (conj acc (error path in this x (:type (ex-data e))))))))
-          (-transformer [_ _ _])
+          (-transformer [this transformer context]
+            (-value-transformer transformer this context))
           (-accept [this visitor opts] (visitor this [] opts))
           (-properties [_] properties)
           (-form [_] form))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -479,7 +479,8 @@
             (fn explain [x in acc]
               (if-not (validator x) (conj acc (error path in this x)) acc)))
           ;; TODO: should we try to derive the type from values? e.g. [:enum 1 2] ~> int?
-          (-transformer [_ _ _])
+          (-transformer [this transformer context]
+            (-value-transformer transformer this context))
           (-accept [this visitor opts] (visitor this (vec children) opts))
           (-properties [_] properties)
           (-form [_] (create-form :enum properties children)))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -532,7 +532,8 @@
                   acc)
                 (catch #?(:clj Exception, :cljs js/Error) e
                   (conj acc (error path in this x (:type (ex-data e))))))))
-          (-transformer [_ _ _])
+          (-transformer [this transformer context]
+            (-value-transformer transformer this context))
           (-accept [this visitor opts] (visitor this [] opts))
           (-properties [_] properties)
           (-form [_] (create-form :fn properties children)))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -554,7 +554,10 @@
           (-explainer [this path]
             (fn explain [x in acc]
               (if-not (or (nil? x) (validator' x)) (conj acc (error path in this x)) acc)))
-          (-transformer [_ transformer context] (-transformer schema' transformer context))
+          (-transformer [this transformer context]
+            (let [tt (-value-transformer transformer this context)
+                  t (-transformer schema' transformer context)]
+              (if (and tt t) (comp t tt) (or tt t))))
           (-accept [this visitor opts] (visitor this [(-accept schema' visitor opts)] opts))
           (-properties [_] properties)
           (-form [_] form))))))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -11,7 +11,7 @@
 
 (defn transformer [& ?options]
   (let [options (map #(if (satisfies? m/Transformer %) (m/-transformer-options %) %) ?options)
-        transformer-name (-> options last :name)
+        transformer-name (->> options reverse (some :name))
         decoders (->> options (map :decoders) (apply merge))
         encoders (->> options (map :encoders) (apply merge))
         transformers {:encode encoders, :decode decoders}

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -70,8 +70,8 @@
                      :errors [(m/error [] [] schema "1")]}
                     (m/explain schema "1")))
 
-      (is (= 1 (m/transform schema "1" transform/string-transformer)))
-      (is (= "1" (m/transform schema "1" transform/json-transformer)))
+      (is (= 1 (m/decode schema "1" transform/string-transformer)))
+      (is (= "1" (m/decode schema "1" transform/json-transformer)))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
@@ -95,8 +95,8 @@
                               {:path [2 2], :in [], :schema neg-int?, :value 0}]}
                     (m/explain schema 0)))
 
-      (is (= 1 (m/transform schema "1" transform/string-transformer)))
-      (is (= "1" (m/transform schema "1" transform/json-transformer)))
+      (is (= 1 (m/decode schema "1" transform/string-transformer)))
+      (is (= "1" (m/decode schema "1" transform/json-transformer)))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
@@ -127,8 +127,8 @@
       (is (results= {:schema [:> 0], :value 0, :errors [{:path [], :in [], :schema [:> 0], :value 0}]}
                     (m/explain schema 0)))
 
-      (is (= 1 (m/transform schema "1" transform/string-transformer)))
-      (is (= "1" (m/transform schema "1" transform/json-transformer)))
+      (is (= 1 (m/decode schema "1" transform/string-transformer)))
+      (is (= "1" (m/decode schema "1" transform/json-transformer)))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
@@ -148,8 +148,8 @@
                     (m/explain schema 0)))
 
       ;; TODO: infer type from :enum
-      #_(is (= 1 (m/transform schema "1" transform/string-transformer)))
-      #_(is (= "1" (m/transform schema "1" transform/json-transformer)))
+      #_(is (= 1 (m/decode schema "1" transform/string-transformer)))
+      #_(is (= "1" (m/decode schema "1" transform/json-transformer)))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
@@ -168,8 +168,8 @@
       (is (results= {:schema [:maybe int?], :value "abba", :errors [{:path [], :in [], :schema [:maybe int?], :value "abba"}]}
                     (m/explain schema "abba")))
 
-      (is (= 1 (m/transform schema "1" transform/string-transformer)))
-      (is (= "1" (m/transform schema "1" transform/json-transformer)))
+      (is (= 1 (m/decode schema "1" transform/string-transformer)))
+      (is (= "1" (m/decode schema "1" transform/json-transformer)))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
@@ -270,14 +270,14 @@
                      :errors [{:path [], :in [], :schema schema, :value "not-a-map", :type ::m/invalid-type}]}
                     (m/explain schema "not-a-map")))
 
-      (is (= {:x true} (m/transform schema {:x "true"} transform/string-transformer)))
-      (is (= {:x true, :y 1} (m/transform schema {:x "true", :y "1"} transform/string-transformer)))
-      (is (= {:x "true", :y "1"} (m/transform schema {:x "true", :y "1"} transform/json-transformer)))
-      (is (= {:x true, :y 1} (m/transform schema {:x true, :y 1, :a 1} transform/strip-extra-keys-transformer)))
-      (is (= {:x_key true, :y_key 2} (m/transform schema {:x true, :y 2}
-                                                  (transform/key-transformer
-                                                    (fn [key]
-                                                      (-> key name (str "_key") keyword))))))
+      (is (= {:x true} (m/decode schema {:x "true"} transform/string-transformer)))
+      (is (= {:x true, :y 1} (m/decode schema {:x "true", :y "1"} transform/string-transformer)))
+      (is (= {:x "true", :y "1"} (m/decode schema {:x "true", :y "1"} transform/json-transformer)))
+      (is (= {:x true, :y 1} (m/decode schema {:x true, :y 1, :a 1} transform/strip-extra-keys-transformer)))
+      (is (= {:x_key true, :y_key 2} (m/decode schema {:x true, :y 2}
+                                               (transform/key-transformer
+                                                 (fn [key]
+                                                   (-> key name (str "_key") keyword))))))
 
       (is (true? (m/validate (over-the-wire schema) valid)))
 
@@ -337,14 +337,14 @@
                              :value "18"}]}
                   (m/explain [:map-of string? int?] {:age "18"})))
 
-    (is (= {1 1} (m/transform [:map-of int? pos-int?] {"1" "1"} transform/string-transformer)))
+    (is (= {1 1} (m/decode [:map-of int? pos-int?] {"1" "1"} transform/string-transformer)))
 
     (is (true? (m/validate (over-the-wire [:map-of string? int?]) {"age" 18})))
 
     (is (= [:map-of ['int?] ['pos-int?]] (m/accept [:map-of int? pos-int?] visitor)))
 
     (testing "keyword keys are transformed via strings"
-      (is (= {1 1} (m/transform [:map-of int? pos-int?] {:1 "1"} transform/string-transformer)))))
+      (is (= {1 1} (m/decode [:map-of int? pos-int?] {:1 "1"} transform/string-transformer)))))
 
   (testing "sequence schemas"
 

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -1,167 +1,167 @@
 (ns malli.transform-test
   (:require [clojure.test :refer [deftest testing is]]
             [malli.core :as m]
-            [malli.transform :as transform]))
+            [malli.transform :as mt]))
 
 (deftest string->long
-  (is (= 1 (transform/string->long "1")))
-  (is (= 1 (transform/string->long 1)))
-  (is (= "abba" (transform/string->long "abba"))))
+  (is (= 1 (mt/string->long "1")))
+  (is (= 1 (mt/string->long 1)))
+  (is (= "abba" (mt/string->long "abba"))))
 
 (deftest string->double
-  (is (= 1.0 (transform/string->double "1")))
-  (is (= 1.0 (transform/string->double 1.0)))
-  (is (= 1 (transform/string->double 1)))
-  (is (= "abba" (transform/string->double "abba"))))
+  (is (= 1.0 (mt/string->double "1")))
+  (is (= 1.0 (mt/string->double 1.0)))
+  (is (= 1 (mt/string->double 1)))
+  (is (= "abba" (mt/string->double "abba"))))
 
 (deftest string->keyword
-  (is (= :abba (transform/string->keyword "abba")))
-  (is (= :abba (transform/string->keyword :abba))))
+  (is (= :abba (mt/string->keyword "abba")))
+  (is (= :abba (mt/string->keyword :abba))))
 
 (deftest string->boolean
-  (is (= true (transform/string->boolean "true")))
-  (is (= false (transform/string->boolean "false")))
-  (is (= "abba" (transform/string->boolean "abba"))))
+  (is (= true (mt/string->boolean "true")))
+  (is (= false (mt/string->boolean "false")))
+  (is (= "abba" (mt/string->boolean "abba"))))
 
 (deftest string->uuid
-  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (transform/string->uuid "5f60751d-9bf7-4344-97ee-48643c9949ce")))
-  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (transform/string->uuid #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce")))
-  (is (= "abba" (transform/string->uuid "abba"))))
+  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/string->uuid "5f60751d-9bf7-4344-97ee-48643c9949ce")))
+  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/string->uuid #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce")))
+  (is (= "abba" (mt/string->uuid "abba"))))
 
 (deftest string->date
-  (is (= #inst "2018-04-27T18:25:37Z" (transform/string->date "2018-04-27T18:25:37Z")))
-  (is (= #inst "2018-04-27T00:00:00Z" (transform/string->date "2018-04-27")))
-  (is (= #inst "2018-04-27T05:00:00Z" (transform/string->date "2018-04-27T08:00:00+03:00")))
-  (is (= #inst "2018-04-27T18:25:37Z" (transform/string->date "2018-04-27T18:25:37.000Z")))
-  (is (= #inst "2018-04-27T18:25:37Z" (transform/string->date "2018-04-27T18:25:37.000+0000")))
-  (is (= #inst "2014-02-18T18:25:37Z" (transform/string->date #inst "2014-02-18T18:25:37Z")))
-  (is (= #inst "2018-04-27T00:00:00Z" (transform/string->date #inst "2018-04-27")))
-  (is (= #inst "2018-04-27T05:00:00Z" (transform/string->date #inst "2018-04-27T08:00:00+03:00")))
-  (is (= "abba" (transform/string->date "abba"))))
+  (is (= #inst "2018-04-27T18:25:37Z" (mt/string->date "2018-04-27T18:25:37Z")))
+  (is (= #inst "2018-04-27T00:00:00Z" (mt/string->date "2018-04-27")))
+  (is (= #inst "2018-04-27T05:00:00Z" (mt/string->date "2018-04-27T08:00:00+03:00")))
+  (is (= #inst "2018-04-27T18:25:37Z" (mt/string->date "2018-04-27T18:25:37.000Z")))
+  (is (= #inst "2018-04-27T18:25:37Z" (mt/string->date "2018-04-27T18:25:37.000+0000")))
+  (is (= #inst "2014-02-18T18:25:37Z" (mt/string->date #inst "2014-02-18T18:25:37Z")))
+  (is (= #inst "2018-04-27T00:00:00Z" (mt/string->date #inst "2018-04-27")))
+  (is (= #inst "2018-04-27T05:00:00Z" (mt/string->date #inst "2018-04-27T08:00:00+03:00")))
+  (is (= "abba" (mt/string->date "abba"))))
 
 (deftest date->string
-  (is (= "2014-02-18T18:25:37.000Z" (transform/date->string #inst "2014-02-18T18:25:37Z")))
-  (is (= "abba" (transform/date->string "abba"))))
+  (is (= "2014-02-18T18:25:37.000Z" (mt/date->string #inst "2014-02-18T18:25:37Z")))
+  (is (= "abba" (mt/date->string "abba"))))
 
 (deftest string->symbol
-  (is (= 'inc (transform/string->symbol "inc")))
-  (is (= 'inc (transform/string->symbol 'inc))))
+  (is (= 'inc (mt/string->symbol "inc")))
+  (is (= 'inc (mt/string->symbol 'inc))))
 
 (deftest string->nil
-  (is (= nil (transform/string->nil "")))
-  (is (= nil (transform/string->nil nil))))
+  (is (= nil (mt/string->nil "")))
+  (is (= nil (mt/string->nil nil))))
 
 (deftest number->double
-  #?(:clj (is (= 0.5 (transform/number->double 1/2))))
-  (is (= 1.0 (transform/number->double 1)))
-  (is (= "kikka" (transform/number->double "kikka"))))
+  #?(:clj (is (= 0.5 (mt/number->double 1/2))))
+  (is (= 1.0 (mt/number->double 1)))
+  (is (= "kikka" (mt/number->double "kikka"))))
 
 (deftest any->string
-  #?(:clj (is (= "1/2" (transform/any->string 1/2))))
-  (is (= "0.5" (transform/any->string 0.5)))
-  (is (= nil (transform/any->string nil))))
+  #?(:clj (is (= "1/2" (mt/any->string 1/2))))
+  (is (= "0.5" (mt/any->string 0.5)))
+  (is (= nil (mt/any->string nil))))
 
 (deftest any->any
-  #?(:clj (is (= 1/2 (transform/any->any 1/2))))
-  (is (= 0.5 (transform/any->any 0.5)))
-  (is (= nil (transform/any->any nil))))
+  #?(:clj (is (= 1/2 (mt/any->any 1/2))))
+  (is (= 0.5 (mt/any->any 0.5)))
+  (is (= nil (mt/any->any nil))))
 
 (deftest transform-test
   (testing "predicates"
     (testing "decode"
-      (is (= 1 (m/decode int? "1" transform/string-transformer)))
-      (is (= "1" (m/decode int? "1" transform/json-transformer)))
-      (is (= :user/kikka (m/decode keyword? "user/kikka" transform/string-transformer))))
+      (is (= 1 (m/decode int? "1" mt/string-transformer)))
+      (is (= "1" (m/decode int? "1" mt/json-transformer)))
+      (is (= :user/kikka (m/decode keyword? "user/kikka" mt/string-transformer))))
     (testing "encode"
-      (is (= "1" (m/encode int? 1 transform/string-transformer)))
-      (is (= "1" (m/encode int? 1 transform/json-transformer)))
-      (is (= "user/kikka" (m/encode keyword? :user/kikka transform/string-transformer)))))
+      (is (= "1" (m/encode int? 1 mt/string-transformer)))
+      (is (= "1" (m/encode int? 1 mt/json-transformer)))
+      (is (= "user/kikka" (m/encode keyword? :user/kikka mt/string-transformer)))))
   (testing "comparators"
     (testing "decode"
       (doseq [schema (keys m/comparator-registry)]
-        (is (= 1 (m/decode [schema 1] "1" transform/string-transformer)))))
+        (is (= 1 (m/decode [schema 1] "1" mt/string-transformer)))))
     (testing "encode"
       (doseq [schema (keys m/comparator-registry)]
-        (is (= "1" (m/encode [schema 1] 1 transform/string-transformer))))))
+        (is (= "1" (m/encode [schema 1] 1 mt/string-transformer))))))
   (testing "and"
     (testing "decode"
-      (is (= 1 (m/decode [:and int?] "1" transform/string-transformer)))
-      (is (= :1 (m/decode [:and keyword?] "1" transform/string-transformer)))
-      (is (= 1 (m/decode [:and int? keyword?] "1" transform/string-transformer)))
-      (is (= 1 (m/decode [:and int? [:enum 1 2]] "1" transform/string-transformer)))
-      (is (= :1 (m/decode [:and keyword? int?] "1" transform/string-transformer)))
-      (is (= [1] (m/decode [:and [:vector int?]] ["1"] transform/string-transformer))))
+      (is (= 1 (m/decode [:and int?] "1" mt/string-transformer)))
+      (is (= :1 (m/decode [:and keyword?] "1" mt/string-transformer)))
+      (is (= 1 (m/decode [:and int? keyword?] "1" mt/string-transformer)))
+      (is (= 1 (m/decode [:and int? [:enum 1 2]] "1" mt/string-transformer)))
+      (is (= :1 (m/decode [:and keyword? int?] "1" mt/string-transformer)))
+      (is (= [1] (m/decode [:and [:vector int?]] ["1"] mt/string-transformer))))
     (testing "encode"
-      (is (= "1" (m/encode [:and int?] 1 transform/string-transformer)))
-      (is (= "1" (m/encode [:and keyword?] :1 transform/string-transformer)))
-      (is (= "1" (m/encode [:and int? keyword?] 1 transform/string-transformer)))
-      (is (= "1" (m/encode [:and int? [:enum 1 2]] 1 transform/string-transformer)))
-      (is (= "1" (m/encode [:and keyword? int?] :1 transform/string-transformer)))
-      (is (= ["1"] (m/encode [:and [:vector int?]] [1] transform/string-transformer)))))
+      (is (= "1" (m/encode [:and int?] 1 mt/string-transformer)))
+      (is (= "1" (m/encode [:and keyword?] :1 mt/string-transformer)))
+      (is (= "1" (m/encode [:and int? keyword?] 1 mt/string-transformer)))
+      (is (= "1" (m/encode [:and int? [:enum 1 2]] 1 mt/string-transformer)))
+      (is (= "1" (m/encode [:and keyword? int?] :1 mt/string-transformer)))
+      (is (= ["1"] (m/encode [:and [:vector int?]] [1] mt/string-transformer)))))
   (testing "or"
     (testing "decode"
-      (is (= 1 (m/decode [:or int? keyword?] "1" transform/string-transformer)))
-      (is (= 1 (m/decode [:or int? [:enum 1 2]] "1" transform/string-transformer)))
-      (is (= :1 (m/decode [:or keyword? int?] "1" transform/string-transformer))))
+      (is (= 1 (m/decode [:or int? keyword?] "1" mt/string-transformer)))
+      (is (= 1 (m/decode [:or int? [:enum 1 2]] "1" mt/string-transformer)))
+      (is (= :1 (m/decode [:or keyword? int?] "1" mt/string-transformer))))
     (testing "encode"
-      (is (= "1" (m/encode [:or int? keyword?] 1 transform/string-transformer)))
-      (is (= "1" (m/encode [:or int? [:enum 1 2]] 1 transform/string-transformer)))
-      (is (= "1" (m/encode [:or keyword? int?] 1 transform/string-transformer)))))
+      (is (= "1" (m/encode [:or int? keyword?] 1 mt/string-transformer)))
+      (is (= "1" (m/encode [:or int? [:enum 1 2]] 1 mt/string-transformer)))
+      (is (= "1" (m/encode [:or keyword? int?] 1 mt/string-transformer)))))
   ;; TODO: encode
   (testing "collections"
-    (is (= #{1 2 3} (m/decode [:set int?] ["1" 2 "3"] transform/string-transformer)))
-    (is (= #{"1" 2 "3"} (m/decode [:set [:enum 1 2]] ["1" 2 "3"] transform/string-transformer)))
-    (is (= #{"1" 2 "3"} (m/decode [:set int?] ["1" 2 "3"] transform/json-transformer)))
-    (is (= [:1 2 :3] (m/decode [:vector keyword?] ["1" 2 "3"] transform/string-transformer)))
-    (is (= '(:1 2 :3) (m/decode [:list keyword?] '("1" 2 "3") transform/string-transformer)))
-    (is (= '(:1 2 :3) (m/decode [:list keyword?] (seq '("1" 2 "3")) transform/string-transformer)))
-    (is (= '(:1 2 :3) (m/decode [:list keyword?] (lazy-seq '("1" 2 "3")) transform/string-transformer)))
-    (is (= ::invalid (m/decode [:vector keyword?] ::invalid transform/string-transformer))))
+    (is (= #{1 2 3} (m/decode [:set int?] ["1" 2 "3"] mt/string-transformer)))
+    (is (= #{"1" 2 "3"} (m/decode [:set [:enum 1 2]] ["1" 2 "3"] mt/string-transformer)))
+    (is (= #{"1" 2 "3"} (m/decode [:set int?] ["1" 2 "3"] mt/json-transformer)))
+    (is (= [:1 2 :3] (m/decode [:vector keyword?] ["1" 2 "3"] mt/string-transformer)))
+    (is (= '(:1 2 :3) (m/decode [:list keyword?] '("1" 2 "3") mt/string-transformer)))
+    (is (= '(:1 2 :3) (m/decode [:list keyword?] (seq '("1" 2 "3")) mt/string-transformer)))
+    (is (= '(:1 2 :3) (m/decode [:list keyword?] (lazy-seq '("1" 2 "3")) mt/string-transformer)))
+    (is (= ::invalid (m/decode [:vector keyword?] ::invalid mt/string-transformer))))
   (testing "map"
     (testing "decode"
-      (is (= {:c1 1, ::c2 :kikka} (m/decode [:map [:c1 int?] [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} transform/string-transformer)))
-      (is (= {:c1 "1", ::c2 :kikka} (m/decode [:map [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} transform/json-transformer)))
-      (is (= ::invalid (m/decode [:map] ::invalid transform/json-transformer))))
+      (is (= {:c1 1, ::c2 :kikka} (m/decode [:map [:c1 int?] [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} mt/string-transformer)))
+      (is (= {:c1 "1", ::c2 :kikka} (m/decode [:map [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} mt/json-transformer)))
+      (is (= ::invalid (m/decode [:map] ::invalid mt/json-transformer))))
     (testing "encode"
-      (is (= {:c1 "1", ::c2 "kikka"} (m/encode [:map [:c1 int?] [::c2 keyword?]] {:c1 1, ::c2 :kikka} transform/string-transformer)))
-      (is (= {:c1 1, ::c2 "kikka"} (m/encode [:map [::c2 keyword?]] {:c1 1, ::c2 :kikka} transform/json-transformer)))
-      (is (= ::invalid (m/encode [:map] ::invalid transform/json-transformer)))))
+      (is (= {:c1 "1", ::c2 "kikka"} (m/encode [:map [:c1 int?] [::c2 keyword?]] {:c1 1, ::c2 :kikka} mt/string-transformer)))
+      (is (= {:c1 1, ::c2 "kikka"} (m/encode [:map [::c2 keyword?]] {:c1 1, ::c2 :kikka} mt/json-transformer)))
+      (is (= ::invalid (m/encode [:map] ::invalid mt/json-transformer)))))
   #_(testing "s/map-of"
-      (is (= {1 :abba, 2 :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} transform/string-transformer)))
-      (is (= {"1" :abba, "2" :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} transform/json-transformer)))
-      (is (= ::invalid (m/decode (s/map-of int? keyword?) ::invalid transform/json-transformer))))
+      (is (= {1 :abba, 2 :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} mt/string-transformer)))
+      (is (= {"1" :abba, "2" :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} mt/json-transformer)))
+      (is (= ::invalid (m/decode (s/map-of int? keyword?) ::invalid mt/json-transformer))))
   (testing "maybe"
     (testing "decode"
-      (is (= 1 (m/decode [:maybe int?] "1" transform/string-transformer)))
-      (is (= nil (m/decode [:maybe int?] nil transform/string-transformer))))
+      (is (= 1 (m/decode [:maybe int?] "1" mt/string-transformer)))
+      (is (= nil (m/decode [:maybe int?] nil mt/string-transformer))))
     (testing "encode"
-      (is (= "1" (m/encode [:maybe int?] 1 transform/string-transformer)))
-      (is (= nil (m/encode [:maybe int?] nil transform/string-transformer)))))
+      (is (= "1" (m/encode [:maybe int?] 1 mt/string-transformer)))
+      (is (= nil (m/encode [:maybe int?] nil mt/string-transformer)))))
   (testing "tuple"
     (testing "decode"
-      (is (= [1] (m/decode [:tuple int?] ["1"] transform/string-transformer)))
-      (is (= [1 :kikka] (m/decode [:tuple int? keyword?] ["1" "kikka"] transform/string-transformer)))
-      (is (= [:kikka 1] (m/decode [:tuple keyword? int?] ["kikka" "1"] transform/string-transformer)))
-      (is (= "1" (m/decode [:tuple keyword? int?] "1" transform/string-transformer)))
-      (is (= [:kikka 1 "2"] (m/decode [:tuple keyword? int?] ["kikka" "1" "2"] transform/string-transformer))))
+      (is (= [1] (m/decode [:tuple int?] ["1"] mt/string-transformer)))
+      (is (= [1 :kikka] (m/decode [:tuple int? keyword?] ["1" "kikka"] mt/string-transformer)))
+      (is (= [:kikka 1] (m/decode [:tuple keyword? int?] ["kikka" "1"] mt/string-transformer)))
+      (is (= "1" (m/decode [:tuple keyword? int?] "1" mt/string-transformer)))
+      (is (= [:kikka 1 "2"] (m/decode [:tuple keyword? int?] ["kikka" "1" "2"] mt/string-transformer))))
     (testing "encode"
-      (is (= ["1"] (m/encode [:tuple int?] [1] transform/string-transformer)))
-      (is (= ["1" "kikka"] (m/encode [:tuple int? keyword?] [1 :kikka] transform/string-transformer)))
-      (is (= ["kikka" "1"] (m/encode [:tuple keyword? int?] [:kikka 1] transform/string-transformer)))
-      (is (= 1.0 (m/encode [:tuple keyword? int?] 1.0 transform/string-transformer)))
-      (is (= ["kikka" "1" "2"] (m/encode [:tuple keyword? int?] [:kikka 1 "2"] transform/string-transformer))))))
+      (is (= ["1"] (m/encode [:tuple int?] [1] mt/string-transformer)))
+      (is (= ["1" "kikka"] (m/encode [:tuple int? keyword?] [1 :kikka] mt/string-transformer)))
+      (is (= ["kikka" "1"] (m/encode [:tuple keyword? int?] [:kikka 1] mt/string-transformer)))
+      (is (= 1.0 (m/encode [:tuple keyword? int?] 1.0 mt/string-transformer)))
+      (is (= ["kikka" "1" "2"] (m/encode [:tuple keyword? int?] [:kikka 1 "2"] mt/string-transformer))))))
 
 ;; TODO: this is wrong!
 (deftest collection-transform-test
   (testing "decode"
-    (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] transform/collection-transformer))))
+    (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] mt/collection-transformer))))
   (testing "encode"
-    (is (= #{1 2 3} (m/encode [:set int?] [1 2 3] transform/collection-transformer)))))
+    (is (= #{1 2 3} (m/encode [:set int?] [1 2 3] mt/collection-transformer)))))
 
 (deftest composing-transformers
-  (let [strict-json-transformer (transform/transformer
-                                  transform/strip-extra-keys-transformer
-                                  transform/json-transformer)]
+  (let [strict-json-transformer (mt/transformer
+                                  mt/strip-extra-keys-transformer
+                                  mt/json-transformer)]
     (testing "decode"
       (is (= :kikka (m/decode keyword? "kikka" strict-json-transformer)))
       (is (= {:x :kikka} (m/decode [:map [:x keyword?]] {:x "kikka", :y "kukka"} strict-json-transformer))))
@@ -169,10 +169,10 @@
       (is (= "kikka" (m/encode keyword? :kikka strict-json-transformer)))
       (is (= {:x "kikka"} (m/encode [:map [:x keyword?]] {:x :kikka, :y :kukka} strict-json-transformer)))))
 
-  (let [strip-extra-key-transformer (transform/transformer
-                                      transform/string-transformer
-                                      transform/strip-extra-keys-transformer
-                                      (transform/key-transformer
+  (let [strip-extra-key-transformer (mt/transformer
+                                      mt/string-transformer
+                                      mt/strip-extra-keys-transformer
+                                      (mt/key-transformer
                                         #(-> % name (str "_key") keyword)
                                         #(-> % name (str "_key"))))]
     (testing "decode"
@@ -189,7 +189,7 @@
                strip-extra-key-transformer))))))
 
 (deftest key-transformer
-  (let [key-transformer (transform/key-transformer
+  (let [key-transformer (mt/key-transformer
                           #(-> % name (str "_key") keyword)
                           #(-> % name (str "_key")))]
     (testing "decode"

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -68,71 +68,71 @@
 
 (deftest transform-test
   (testing "predicates"
-    (is (= 1 (m/transform int? "1" transform/string-transformer)))
-    (is (= "1" (m/transform int? "1" transform/json-transformer)))
-    (is (= :user/kikka (m/transform keyword? "user/kikka" transform/string-transformer))))
+    (is (= 1 (m/decode int? "1" transform/string-transformer)))
+    (is (= "1" (m/decode int? "1" transform/json-transformer)))
+    (is (= :user/kikka (m/decode keyword? "user/kikka" transform/string-transformer))))
   (testing "comparators"
     (doseq [schema (keys m/comparator-registry)]
-      (is (= 1 (m/transform [schema 1] "1" transform/string-transformer)))))
+      (is (= 1 (m/decode [schema 1] "1" transform/string-transformer)))))
   (testing "and"
-    (is (= 1 (m/transform [:and int?] "1" transform/string-transformer)))
-    (is (= :1 (m/transform [:and keyword?] "1" transform/string-transformer)))
-    (is (= 1 (m/transform [:and int? keyword?] "1" transform/string-transformer)))
-    (is (= 1 (m/transform [:and int? [:enum 1 2]] "1" transform/string-transformer)))
-    (is (= :1 (m/transform [:and keyword? int?] "1" transform/string-transformer)))
-    (is (= [1] (m/transform [:and [:vector int?]] ["1"] transform/string-transformer))))
+    (is (= 1 (m/decode [:and int?] "1" transform/string-transformer)))
+    (is (= :1 (m/decode [:and keyword?] "1" transform/string-transformer)))
+    (is (= 1 (m/decode [:and int? keyword?] "1" transform/string-transformer)))
+    (is (= 1 (m/decode [:and int? [:enum 1 2]] "1" transform/string-transformer)))
+    (is (= :1 (m/decode [:and keyword? int?] "1" transform/string-transformer)))
+    (is (= [1] (m/decode [:and [:vector int?]] ["1"] transform/string-transformer))))
   (testing "or"
-    (is (= 1 (m/transform [:or int? keyword?] "1" transform/string-transformer)))
-    (is (= 1 (m/transform [:or int? [:enum 1 2]] "1" transform/string-transformer)))
-    (is (= :1 (m/transform [:or keyword? int?] "1" transform/string-transformer))))
+    (is (= 1 (m/decode [:or int? keyword?] "1" transform/string-transformer)))
+    (is (= 1 (m/decode [:or int? [:enum 1 2]] "1" transform/string-transformer)))
+    (is (= :1 (m/decode [:or keyword? int?] "1" transform/string-transformer))))
   (testing "collections"
-    (is (= #{1 2 3} (m/transform [:set int?] ["1" 2 "3"] transform/string-transformer)))
-    (is (= #{"1" 2 "3"} (m/transform [:set [:enum 1 2]] ["1" 2 "3"] transform/string-transformer)))
-    (is (= #{"1" 2 "3"} (m/transform [:set int?] ["1" 2 "3"] transform/json-transformer)))
-    (is (= [:1 2 :3] (m/transform [:vector keyword?] ["1" 2 "3"] transform/string-transformer)))
-    (is (= '(:1 2 :3) (m/transform [:list keyword?] '("1" 2 "3") transform/string-transformer)))
-    (is (= '(:1 2 :3) (m/transform [:list keyword?] (seq '("1" 2 "3")) transform/string-transformer)))
-    (is (= '(:1 2 :3) (m/transform [:list keyword?] (lazy-seq '("1" 2 "3")) transform/string-transformer)))
-    (is (= ::invalid (m/transform [:vector keyword?] ::invalid transform/string-transformer))))
+    (is (= #{1 2 3} (m/decode [:set int?] ["1" 2 "3"] transform/string-transformer)))
+    (is (= #{"1" 2 "3"} (m/decode [:set [:enum 1 2]] ["1" 2 "3"] transform/string-transformer)))
+    (is (= #{"1" 2 "3"} (m/decode [:set int?] ["1" 2 "3"] transform/json-transformer)))
+    (is (= [:1 2 :3] (m/decode [:vector keyword?] ["1" 2 "3"] transform/string-transformer)))
+    (is (= '(:1 2 :3) (m/decode [:list keyword?] '("1" 2 "3") transform/string-transformer)))
+    (is (= '(:1 2 :3) (m/decode [:list keyword?] (seq '("1" 2 "3")) transform/string-transformer)))
+    (is (= '(:1 2 :3) (m/decode [:list keyword?] (lazy-seq '("1" 2 "3")) transform/string-transformer)))
+    (is (= ::invalid (m/decode [:vector keyword?] ::invalid transform/string-transformer))))
   (testing "map"
-    (is (= {:c1 1, ::c2 :kikka} (m/transform [:map [:c1 int?] [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} transform/string-transformer)))
-    (is (= {:c1 "1", ::c2 :kikka} (m/transform [:map [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} transform/json-transformer)))
-    (is (= ::invalid (m/transform [:map] ::invalid transform/json-transformer))))
+    (is (= {:c1 1, ::c2 :kikka} (m/decode [:map [:c1 int?] [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} transform/string-transformer)))
+    (is (= {:c1 "1", ::c2 :kikka} (m/decode [:map [::c2 keyword?]] {:c1 "1", ::c2 "kikka"} transform/json-transformer)))
+    (is (= ::invalid (m/decode [:map] ::invalid transform/json-transformer))))
   #_(testing "s/map-of"
-    (is (= {1 :abba, 2 :jabba} (m/transform (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} transform/string-transformer)))
-    (is (= {"1" :abba, "2" :jabba} (m/transform (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} transform/json-transformer)))
-    (is (= ::invalid (m/transform (s/map-of int? keyword?) ::invalid transform/json-transformer))))
+    (is (= {1 :abba, 2 :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} transform/string-transformer)))
+    (is (= {"1" :abba, "2" :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} transform/json-transformer)))
+    (is (= ::invalid (m/decode (s/map-of int? keyword?) ::invalid transform/json-transformer))))
   (testing "maybe"
-    (is (= 1 (m/transform [:maybe int?] "1" transform/string-transformer)))
-    (is (= nil (m/transform [:maybe int?] nil transform/string-transformer))))
+    (is (= 1 (m/decode [:maybe int?] "1" transform/string-transformer)))
+    (is (= nil (m/decode [:maybe int?] nil transform/string-transformer))))
   (testing "tuple"
-    (is (= [1] (m/transform [:tuple int?] ["1"] transform/string-transformer)))
-    (is (= [1 :kikka] (m/transform [:tuple int? keyword?] ["1" "kikka"] transform/string-transformer)))
-    (is (= [:kikka 1] (m/transform [:tuple keyword? int?] ["kikka" "1"] transform/string-transformer)))
-    (is (= "1" (m/transform [:tuple keyword? int?] "1" transform/string-transformer)))
-    (is (= [:kikka 1 "2"] (m/transform [:tuple keyword? int?] ["kikka" "1" "2"] transform/string-transformer)))))
+    (is (= [1] (m/decode [:tuple int?] ["1"] transform/string-transformer)))
+    (is (= [1 :kikka] (m/decode [:tuple int? keyword?] ["1" "kikka"] transform/string-transformer)))
+    (is (= [:kikka 1] (m/decode [:tuple keyword? int?] ["kikka" "1"] transform/string-transformer)))
+    (is (= "1" (m/decode [:tuple keyword? int?] "1" transform/string-transformer)))
+    (is (= [:kikka 1 "2"] (m/decode [:tuple keyword? int?] ["kikka" "1" "2"] transform/string-transformer)))))
 
 (deftest collection-transform-test
-  (is (= #{1 2 3} (m/transform [:set int?] [1 2 3] transform/collection-transformer))))
+  (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] transform/collection-transformer))))
 
 (deftest composing-transformers
   (let [strict-json-transformer (transform/transformer
                                   transform/strip-extra-keys-transformer
                                   transform/json-transformer)]
-    (is (= :kikka (m/transform keyword? "kikka" strict-json-transformer)))
-    (is (= {:x :kikka} (m/transform [:map [:x keyword?]] {:x "kikka"} strict-json-transformer))))
+    (is (= :kikka (m/decode keyword? "kikka" strict-json-transformer)))
+    (is (= {:x :kikka} (m/decode [:map [:x keyword?]] {:x "kikka"} strict-json-transformer))))
 
   (let [strip-extra-key-transformer (transform/transformer
                                       transform/strip-extra-keys-transformer
                                       (transform/key-transformer #(-> % name (str "_key") keyword)))]
     (is (= {:x_key 18 :y_key "john"}
-           (m/transform [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
+           (m/decode [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
                         {:x 18 :y "john" :a "doe"}
                         strip-extra-key-transformer)))))
 
 (deftest key-transformer
   (let [key-transformer (transform/key-transformer #(-> % name (str "_key") keyword))]
     (is (= {:x_key 18 :y_key "john" :a_key "doe"}
-           (m/transform [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
+           (m/decode [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
                         {:x 18 :y "john" :a "doe"}
                         key-transformer)))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -206,8 +206,8 @@
 
 (deftest schema-hinted-tranformation
   (let [schema [string? {:title "lower-upper-string"
-                         :decode/string (constantly str/upper-case)
-                         :encode/string (constantly str/lower-case)}]
+                         :decode/string '(constantly str/upper-case)
+                         :encode/string '(constantly str/lower-case)}]
         value "KiKkA"]
     (testing "defined transformations"
       (is (= "KIKKA" (m/decode schema value mt/string-transformer)))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -227,6 +227,7 @@
                       [[:and P1 string?] "kikka" "KIKKA"]
                       [[:or P1 int? string?] "kikka" "KIKKA"]
                       [[:map PM [:x int?]] {"x" "1", "y" "2"} {:x 1, :y "2"}]
+                      [[:map-of PM string? int?] {"x" "1", "y" "2"} {:x 1, :y 2}]
                       [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]
                       [[:enum P1 "S" "M" "L"] "s" "S"]
                       [[:re P1 ".*"] "kikka" "KIKKA"]

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -227,6 +227,7 @@
                       [[:or P1 int? string?] "kikka" "KIKKA"]
                       [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]
                       [[:enum P1 "S" "M" "L"] "s" "S"]
-                      [[:re P1 ".*"] "kikka" "KIKKA"]]]
+                      [[:re P1 ".*"] "kikka" "KIKKA"]
+                      [[:fn P1 string?] "kikka" "KIKKA"]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -222,19 +222,19 @@
 (deftest transformation-targets
   (let [P1 {:decode/string '(constantly str/upper-case)}
         PS {:decode/string '(constantly (partial mapv str/upper-case))}
-        PM {:decode/string '(constantly (fn [x] (->> (for [[k v] x] [(keyword k) v]) (into {}))))}
-        expectations [[[string? P1] "kikka" "KIKKA"]
-                      [[:and P1 string?] "kikka" "KIKKA"]
-                      [[:or P1 int? string?] "kikka" "KIKKA"]
-                      [[:map PM [:x int?]] {"x" "1", "y" "2"} {:x 1, :y "2"}]
-                      [[:map-of PM string? int?] {"x" "1", "y" "2"} {:x 1, :y 2}]
-                      [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]
+        PM {:decode/string '(constantly (fn [x] (->> (for [[k v] x] [(keyword k) (str/upper-case v)]) (into {}))))}
+        expectations [[[keyword? P1] "kikka" "KIKKA"]
+                      [[:and P1 keyword?] "kikka" :KIKKA]
+                      [[:or P1 int? keyword?] "kikka" :KIKKA]
+                      [[:map PM [:x keyword?]] {"x" "kikka", "y" "kukka"} {:x :KIKKA, :y "KUKKA"}]
+                      [[:map-of PM string? keyword?] {"x" "kikka", "y" "kukka"} {:x :KIKKA, :y :KUKKA}]
+                      [[:tuple PS keyword? int?] ["kikka" "1"] [:KIKKA 1]]
                       [[:enum P1 "S" "M" "L"] "s" "S"]
                       [[:re P1 ".*"] "kikka" "KIKKA"]
-                      [[:fn P1 string?] "kikka" "KIKKA"]
-                      [[:maybe P1 string?] "kikka" "KIKKA"]
-                      [[:vector PS string?] ["kikka"] ["KIKKA"]]
-                      [[:list PS string?] '("kikka") '("KIKKA")]
-                      [[:set PS string?] #{"kikka"} #{"KIKKA"}]]]
+                      [[:fn P1 'string?] "kikka" "KIKKA"]
+                      [[:maybe P1 keyword?] "kikka" :KIKKA]
+                      [[:vector PS keyword?] ["kikka"] [:KIKKA]]
+                      [[:list PS keyword?] '("kikka") '(:KIKKA)]
+                      [[:set PS keyword?] #{"kikka"} #{:KIKKA}]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -228,6 +228,7 @@
                       [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]
                       [[:enum P1 "S" "M" "L"] "s" "S"]
                       [[:re P1 ".*"] "kikka" "KIKKA"]
-                      [[:fn P1 string?] "kikka" "KIKKA"]]]
+                      [[:fn P1 string?] "kikka" "KIKKA"]
+                      [[:maybe P1 string?] "kikka" "KIKKA"]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -220,10 +220,11 @@
       (is (= value (m/encode schema value mt/json-transformer))))))
 
 (deftest transformation-targets
-  (let [PROPS {:decode/string '(constantly str/upper-case)
-               :encode/string '(constantly str/lower-case)}
-        expectations [[[string? PROPS] "kikka" "KIKKA"]
-                      [[:and PROPS string?] "kikka" "KIKKA"]
-                      [[:or PROPS int? string?] "kikka" "KIKKA"]]]
+  (let [P1 {:decode/string '(constantly str/upper-case)}
+        PS {:decode/string '(constantly (partial mapv str/upper-case))}
+        expectations [[[string? P1] "kikka" "KIKKA"]
+                      [[:and P1 string?] "kikka" "KIKKA"]
+                      [[:or P1 int? string?] "kikka" "KIKKA"]
+                      [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -222,13 +222,18 @@
 (deftest transformation-targets
   (let [P1 {:decode/string '(constantly str/upper-case)}
         PS {:decode/string '(constantly (partial mapv str/upper-case))}
+        PM {:decode/string '(constantly (fn [x] (->> (for [[k v] x] [(keyword k) v]) (into {}))))}
         expectations [[[string? P1] "kikka" "KIKKA"]
                       [[:and P1 string?] "kikka" "KIKKA"]
                       [[:or P1 int? string?] "kikka" "KIKKA"]
+                      [[:map PM [:x int?]] {"x" "1", "y" "2"} {:x 1, :y "2"}]
                       [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]
                       [[:enum P1 "S" "M" "L"] "s" "S"]
                       [[:re P1 ".*"] "kikka" "KIKKA"]
                       [[:fn P1 string?] "kikka" "KIKKA"]
-                      [[:maybe P1 string?] "kikka" "KIKKA"]]]
+                      [[:maybe P1 string?] "kikka" "KIKKA"]
+                      [[:vector PS string?] ["kikka"] ["KIKKA"]]
+                      [[:list PS string?] '("kikka") '("KIKKA")]
+                      [[:set PS string?] #{"kikka"} #{"KIKKA"}]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -243,3 +243,12 @@
                       [[:set PS keyword?] #{"kikka"} #{:KIKKA}]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))
+
+(deftest options-in-transformaton
+  (let [schema [:and int? [any? {:decode/string '(fn [_ {::keys [increment]}] (partial + (or increment 0)))}]]
+        transformer (mt/transformer mt/string-transformer)
+        transformer1 (mt/transformer mt/string-transformer {:opts {::increment 1}})
+        transformer1000 (mt/transformer mt/string-transformer {:opts {::increment 1000}})]
+    (is (= 0 (m/decode schema "0" transformer)))
+    (is (= 1 (m/decode schema "0" transformer1)))
+    (is (= 1000 (m/decode schema "0" transformer1000)))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -218,3 +218,12 @@
     (testing "undefined transformations"
       (is (= value (m/decode schema value mt/json-transformer)))
       (is (= value (m/encode schema value mt/json-transformer))))))
+
+(deftest transformation-targets
+  (let [PROPS {:decode/string '(constantly str/upper-case)
+               :encode/string '(constantly str/lower-case)}
+        expectations [[[string? PROPS] "kikka" "KIKKA"]
+                      [[:and PROPS string?] "kikka" "KIKKA"]
+                      [[:or PROPS int? string?] "kikka" "KIKKA"]]]
+    (doseq [[schema value expected] expectations]
+      (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -225,6 +225,7 @@
         expectations [[[string? P1] "kikka" "KIKKA"]
                       [[:and P1 string?] "kikka" "KIKKA"]
                       [[:or P1 int? string?] "kikka" "KIKKA"]
-                      [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]]]
+                      [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]
+                      [[:enum P1 "S" "M" "L"] "s" "S"]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -226,6 +226,7 @@
                       [[:and P1 string?] "kikka" "KIKKA"]
                       [[:or P1 int? string?] "kikka" "KIKKA"]
                       [[:tuple PS string? int?] ["kikka" "1"] ["KIKKA" 1]]
-                      [[:enum P1 "S" "M" "L"] "s" "S"]]]
+                      [[:enum P1 "S" "M" "L"] "s" "S"]
+                      [[:re P1 ".*"] "kikka" "KIKKA"]]]
     (doseq [[schema value expected] expectations]
       (is (= expected (m/decode schema value mt/string-transformer))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -162,7 +162,12 @@
 (deftest composing-transformers
   (let [strict-json-transformer (mt/transformer
                                   mt/strip-extra-keys-transformer
-                                  mt/json-transformer)]
+                                  mt/json-transformer
+                                  {:opts {:random :opts}})]
+
+    (testing "name is taken from the last named transformer"
+      (is (= :json (m/-transformer-name strict-json-transformer))))
+
     (testing "decode"
       (is (= :kikka (m/decode keyword? "kikka" strict-json-transformer)))
       (is (= {:x :kikka} (m/decode [:map [:x keyword?]] {:x "kikka", :y "kukka"} strict-json-transformer))))


### PR DESCRIPTION
* `m/transform` => `m/encode` & `m/decode`
* Support for schema-driven transformations
* #98 should be fixed with this of right after.

```clj
(deftest schema-hinted-tranformation
  (let [schema [string? {:title "lower-upper-string"
                         :decode/string (constantly str/upper-case)
                         :encode/string (constantly str/lower-case)}]
        value "KiKkA"]
    (testing "defined transformations"
      (is (= "KIKKA" (m/decode schema value mt/string-transformer)))
      (is (= "kikka" (m/encode schema value mt/string-transformer)))
      (is (= "kikka" (as-> value $
                           (m/decode schema $ mt/string-transformer)
                           (m/encode schema $ mt/string-transformer)))))
    (testing "undefined transformations"
      (is (= value (m/decode schema value mt/json-transformer)))
      (is (= value (m/encode schema value mt/json-transformer))))))
```