### PR TITLE
allow generator with unsupported features to be overridden

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -47,12 +47,9 @@
 
 #?(:clj
    (defn -re-gen [schema opts]
-     (let [re (or (first (m/childs schema opts)) (m/form schema opts))]
-       (try
-         (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1")))
-         (catch Exception ex
-           #(throw ex)                                      ;; throw only if bad regex generator is actually used
-           )))))
+     (when-not (-> schema m/properties :gen/elements)
+       (let [re (or (first (m/childs schema opts)) (m/form schema opts))]
+         (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1")))))))
 
 ;;
 ;; generators

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -48,7 +48,11 @@
 #?(:clj
    (defn -re-gen [schema opts]
      (let [re (or (first (m/childs schema opts)) (m/form schema opts))]
-       (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1"))))))
+       (try
+         (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1")))
+         (catch Exception ex
+           #(throw ex)                                      ;; throw only if bad regex generator is actually used
+           )))))
 
 ;;
 ;; generators

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -47,9 +47,8 @@
 
 #?(:clj
    (defn -re-gen [schema opts]
-     (when-not (-> schema m/properties :gen/elements)
-       (let [re (or (first (m/childs schema opts)) (m/form schema opts))]
-         (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1")))))))
+     (let [re (or (first (m/childs schema opts)) (m/form schema opts))]
+       (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1"))))))
 
 ;;
 ;; generators
@@ -79,9 +78,9 @@
 #?(:clj (defmethod -generator :re [schema opts] (-re-gen schema opts)))
 
 (defn- -create [schema opts]
-  (let [gen (-generator schema opts)
-        {:gen/keys [fmap elements]} (m/properties schema)
-        elements (if elements (gen/elements elements))]
+  (let [{:gen/keys [fmap elements]} (m/properties schema)
+        gen (when-not elements (-generator schema opts))
+        elements (when elements (gen/elements elements))]
     (cond
       fmap (gen/fmap (m/eval fmap) (or elements gen (gen/return nil)))
       elements elements

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -30,6 +30,7 @@
             (let [re-test #"(?=.{8,})"                      ;; contains unsupported feature
                   elements ["abcdefgh" "01234567"]
                   fmap '(fn [s] (str "prefix_" s))]
+              (is (thrown-with-msg? Exception #"Unsupported-feature" (mg/generator [:re re-test])))
               (m/validate #".{8,}" (mg/generate [:re {:gen/elements elements} re-test]))
               (m/validate #"prefix_.{8,}" (mg/generate [:re {:gen/fmap fmap, :gen/elements elements} re-test])))))
 

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -25,7 +25,13 @@
 
   #?(:clj (testing "regex"
             (let [re #"^\d+ \d+$"]
-              (m/validate re (mg/generate re)))))
+              (m/validate re (mg/generate re)))
+
+            (let [re-test #"(?=.{8,})"                      ;; contains unsupported feature
+                  elements ["abcdefgh" "01234567"]
+                  fmap '(fn [s] (str "prefix_" s))]
+              (m/validate #".{8,}" (mg/generate [:re {:gen/elements elements} re-test]))
+              (m/validate #"prefix_.{8,}" (mg/generate [:re {:gen/fmap fmap, :gen/elements elements} re-test])))))
 
   (testing "no generator"
     (is (thrown-with-msg?


### PR DESCRIPTION
If a regular expression contains a feature that isn't supported by test.chuck, then an exception will be thrown even if a `:gen/elements` value is provided. The PR allows the default generator to be overridden in this case.