### PR TITLE
Support :error/path in humanized errors. Fix #105

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,37 @@ Messages can be localized:
 ; :age "10, pitäisi olla > 18"}
 ```
 
+Top-level humanized map-errors are under `:malli/error`:
+
+```clj
+(-> [:and [:map
+           [:password string?]
+           [:password2 string?]]
+     [:fn {:error/message "passwords don't match"}
+      '(fn [{:keys [password password2]}]
+         (= password password2))]]
+    (m/explain {:password "secret"
+                :password2 "faarao"})
+    (me/humanize {:wrap :message}))
+; {:malli/error "passwords don't match"}
+```
+
+Errors can be targetted using `:error/path` property:
+
+```clj
+(-> [:and [:map
+           [:password string?]
+           [:password2 string?]]
+     [:fn {:error/message "passwords don't match"
+           :error/path [:password2]}
+      '(fn [{:keys [password password2]}]
+         (= password password2))]]
+    (m/explain {:password "secret"
+                :password2 "faarao"})
+    (me/humanize {:wrap :message}))
+; {:password2 "passwords don't match"}
+```
+
 ## Value Transformation
 
 Schema-driven value transformations with `m/transform`:

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -78,9 +78,22 @@
     acc acc
     :else error))
 
+(defn- -path [{:keys [schema]}
+              {:keys [locale default-locale]
+               :or {default-locale :en}}]
+  (let [properties (m/properties schema)]
+    (or (-maybe-localized (:error/path properties) locale)
+        (-maybe-localized (:error/path properties) default-locale))))
+
 ;;
 ;; public api
 ;;
+
+(defn error-path
+  ([error]
+   (error-path error nil))
+  ([error opts]
+   (into (:in error) (-path error opts))))
 
 (defn error-message
   ([error]
@@ -118,6 +131,6 @@
      (if (coll? value)
        (reduce
          (fn [acc error]
-           (-assoc-in acc value (:in error) (f (with-error-message error opts))))
+           (-assoc-in acc value (error-path error opts) (f (with-error-message error opts))))
          nil errors)
        (f (with-error-message (first errors) opts))))))


### PR DESCRIPTION

Top-level humanized map-errors are under `:malli/error`:

```clj
(-> [:and [:map
           [:password string?]
           [:password2 string?]]
     [:fn {:error/message "passwords don't match"}
      '(fn [{:keys [password password2]}]
         (= password password2))]]
    (m/explain {:password "secret"
                :password2 "faarao"})
    (me/humanize {:wrap :message}))
; {:malli/error "passwords don't match"}
```

Errors can be targetted using `:error/path` property:

```clj
(-> [:and [:map
           [:password string?]
           [:password2 string?]]
     [:fn {:error/message "passwords don't match"
           :error/path [:password2]}
      '(fn [{:keys [password password2]}]
         (= password password2))]]
    (m/explain {:password "secret"
                :password2 "faarao"})
    (me/humanize {:wrap :message}))
; {:password2 "passwords don't match"}
```