### PR TITLE
s/child/children and pass through opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,29 +464,29 @@ All samples are valid against the inferred schema:
 Schemas can be transformed using the [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern):
 
 ```clj
-(defn visitor [schema childs _]
+(defn visitor [schema children _]
   {:name (m/name schema)
    :properties (or (m/properties schema) {})
-   :childs childs})
+   :children children})
 
 (m/accept Address visitor)
 ;{:name :map,
 ; :properties {},
-; :childs [{:name string?
-;           :properties {}
-;           :childs []}
-;          {:name :set
-;           :properties {}
-;           :childs [{:name keyword?, :properties {}, :childs []}]}
-;          {:name :map,
-;           :properties {},
-;           :childs [{:name string?, :properties {}, :childs []}
-;                    {:name string?, :properties {}, :childs []}
-;                    {:name int?, :properties {}, :childs []}
-;                    {:name :tuple,
-;                     :properties {},
-;                     :childs [{:name double?, :properties {}, :childs []} 
-;                              {:name double?, :properties {}, :childs []}]}]}]}
+; :children [{:name string?
+;             :properties {}
+;             :children []}
+;            {:name :set
+;             :properties {}
+;             :children [{:name keyword?, :properties {}, :children []}]}
+;            {:name :map,
+;             :properties {},
+;             :children [{:name string?, :properties {}, :children []}
+;                        {:name string?, :properties {}, :children []}
+;                        {:name int?, :properties {}, :children []}
+;                        {:name :tuple,
+;                         :properties {},
+;                         :children [{:name double?, :properties {}, :children []}
+;                                    {:name double?, :properties {}, :children []}]}]}]}
 ```
 
 ### JSON Schema

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -14,7 +14,7 @@
 (defn- -double-gen [opts] (gen/double* (merge {:infinite? false, :NaN? false} opts)))
 
 (defn- -coll-gen [schema f opts]
-  (let [{:keys [min max]} (m/properties schema)
+  (let [{:keys [min max]} (m/properties schema opts)
         gen (-> schema m/children first (generator opts))]
     (gen/fmap f (cond
                   (and min (= min max)) (gen/vector gen min)
@@ -24,7 +24,7 @@
                   :else (gen/vector gen)))))
 
 (defn- -coll-distict-gen [schema f opts]
-  (let [{:keys [min max]} (m/properties schema)
+  (let [{:keys [min max]} (m/properties schema opts)
         gen (-> schema m/children first (generator opts))]
     (gen/fmap f (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100}))))
 
@@ -56,29 +56,29 @@
 
 (defmulti -generator (fn [schema opts] (m/name schema opts)) :default ::default)
 
-(defmethod -generator ::default [schema _] (ga/gen-for-pred (m/validator schema)))
+(defmethod -generator ::default [schema opts] (ga/gen-for-pred (m/validator schema opts)))
 
-(defmethod -generator :> [schema _] (-double-gen {:min (-> schema m/children first inc)}))
-(defmethod -generator :>= [schema _] (-double-gen {:min (-> schema m/children first)}))
-(defmethod -generator :< [schema _] (-double-gen {:max (-> schema m/children first dec)}))
-(defmethod -generator :<= [schema _] (-double-gen {:max (-> schema m/children first)}))
-(defmethod -generator := [schema _] (gen/return (first (m/children schema))))
-(defmethod -generator :not= [schema _] (gen/such-that (->> schema m/children first (partial not=)) gen/any-printable 100))
+(defmethod -generator :> [schema opts] (-double-gen {:min (-> schema (m/children opts) first inc)}))
+(defmethod -generator :>= [schema opts] (-double-gen {:min (-> schema (m/children opts) first)}))
+(defmethod -generator :< [schema opts] (-double-gen {:max (-> schema (m/children opts) first dec)}))
+(defmethod -generator :<= [schema opts] (-double-gen {:max (-> schema (m/children opts) first)}))
+(defmethod -generator := [schema opts] (gen/return (first (m/children schema opts))))
+(defmethod -generator :not= [schema opts] (gen/such-that (partial not= (-> schema (m/children opts) first)) gen/any-printable 100))
 
-(defmethod -generator :and [schema opts] (gen/such-that (m/validator schema) (-> schema m/children first (generator opts)) 100))
-(defmethod -generator :or [schema opts] (gen/one-of (->> schema m/children (mapv #(generator % opts)))))
+(defmethod -generator :and [schema opts] (gen/such-that (m/validator schema opts) (-> schema (m/children opts) first (generator opts)) 100))
+(defmethod -generator :or [schema opts] (gen/one-of (mapv #(generator % opts) (m/children schema opts))))
 (defmethod -generator :map [schema opts] (-map-gen schema opts))
 (defmethod -generator :map-of [schema opts] (-map-of-gen schema opts))
 (defmethod -generator :vector [schema opts] (-coll-gen schema identity opts))
 (defmethod -generator :list [schema opts] (-coll-gen schema (partial apply list) opts))
-(defmethod -generator :set [schema _] (-coll-distict-gen schema set))
-(defmethod -generator :enum [schema _] (gen/elements (m/children schema)))
-(defmethod -generator :maybe [schema opts] (gen/one-of [(gen/return nil) (-> schema m/children first (generator opts))]))
-(defmethod -generator :tuple [schema opts] (apply gen/tuple (->> schema m/children (mapv #(generator % opts)))))
+(defmethod -generator :set [schema opts] (-coll-distict-gen schema set opts))
+(defmethod -generator :enum [schema opts] (gen/elements (m/children schema opts)))
+(defmethod -generator :maybe [schema opts] (gen/one-of [(gen/return nil) (-> schema (m/children opts) first (generator opts))]))
+(defmethod -generator :tuple [schema opts] (apply gen/tuple (mapv #(generator % opts) (m/children schema opts))))
 #?(:clj (defmethod -generator :re [schema opts] (-re-gen schema opts)))
 
 (defn- -create [schema opts]
-  (let [{:gen/keys [fmap elements]} (m/properties schema)
+  (let [{:gen/keys [fmap elements]} (m/properties schema opts)
         gen (when-not elements (-generator schema opts))
         elements (when elements (gen/elements elements))]
     (cond

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -15,7 +15,7 @@
 
 (defn- -coll-gen [schema f opts]
   (let [{:keys [min max]} (m/properties schema)
-        gen (-> schema m/childs first (generator opts))]
+        gen (-> schema m/children first (generator opts))]
     (gen/fmap f (cond
                   (and min (= min max)) (gen/vector gen min)
                   (and min max) (gen/vector gen min max)
@@ -25,11 +25,11 @@
 
 (defn- -coll-distict-gen [schema f opts]
   (let [{:keys [min max]} (m/properties schema)
-        gen (-> schema m/childs first (generator opts))]
+        gen (-> schema m/children first (generator opts))]
     (gen/fmap f (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100}))))
 
 (defn -map-gen [schema opts]
-  (let [{:keys [entries]} (m/-parse-keys (m/childs schema opts) opts)
+  (let [{:keys [entries]} (m/-parse-keys (m/children schema opts) opts)
         value-gen (fn [k s] (gen/fmap (fn [v] [k v]) (generator s opts)))
         gen-req (->> entries
                      (remove #(-> % second :optional))
@@ -42,12 +42,12 @@
     (gen/fmap (fn [[req opt]] (into {} (concat req opt))) (gen/tuple gen-req gen-opt))))
 
 (defn -map-of-gen [schema opts]
-  (let [[k-gen v-gen] (map #(generator % opts) (m/childs schema opts))]
+  (let [[k-gen v-gen] (map #(generator % opts) (m/children schema opts))]
     (gen/fmap (partial into {}) (gen/vector-distinct (gen/tuple k-gen v-gen)))))
 
 #?(:clj
    (defn -re-gen [schema opts]
-     (let [re (or (first (m/childs schema opts)) (m/form schema opts))]
+     (let [re (or (first (m/children schema opts)) (m/form schema opts))]
        (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1"))))))
 
 ;;
@@ -58,23 +58,23 @@
 
 (defmethod -generator ::default [schema _] (ga/gen-for-pred (m/validator schema)))
 
-(defmethod -generator :> [schema _] (-double-gen {:min (-> schema m/childs first inc)}))
-(defmethod -generator :>= [schema _] (-double-gen {:min (-> schema m/childs first)}))
-(defmethod -generator :< [schema _] (-double-gen {:max (-> schema m/childs first dec)}))
-(defmethod -generator :<= [schema _] (-double-gen {:max (-> schema m/childs first)}))
-(defmethod -generator := [schema _] (gen/return (first (m/childs schema))))
-(defmethod -generator :not= [schema _] (gen/such-that (->> schema m/childs first (partial not=)) gen/any-printable 100))
+(defmethod -generator :> [schema _] (-double-gen {:min (-> schema m/children first inc)}))
+(defmethod -generator :>= [schema _] (-double-gen {:min (-> schema m/children first)}))
+(defmethod -generator :< [schema _] (-double-gen {:max (-> schema m/children first dec)}))
+(defmethod -generator :<= [schema _] (-double-gen {:max (-> schema m/children first)}))
+(defmethod -generator := [schema _] (gen/return (first (m/children schema))))
+(defmethod -generator :not= [schema _] (gen/such-that (->> schema m/children first (partial not=)) gen/any-printable 100))
 
-(defmethod -generator :and [schema opts] (gen/such-that (m/validator schema) (-> schema m/childs first (generator opts)) 100))
-(defmethod -generator :or [schema opts] (gen/one-of (->> schema m/childs (mapv #(generator % opts)))))
+(defmethod -generator :and [schema opts] (gen/such-that (m/validator schema) (-> schema m/children first (generator opts)) 100))
+(defmethod -generator :or [schema opts] (gen/one-of (->> schema m/children (mapv #(generator % opts)))))
 (defmethod -generator :map [schema opts] (-map-gen schema opts))
 (defmethod -generator :map-of [schema opts] (-map-of-gen schema opts))
 (defmethod -generator :vector [schema opts] (-coll-gen schema identity opts))
 (defmethod -generator :list [schema opts] (-coll-gen schema (partial apply list) opts))
 (defmethod -generator :set [schema _] (-coll-distict-gen schema set))
-(defmethod -generator :enum [schema _] (gen/elements (m/childs schema)))
-(defmethod -generator :maybe [schema opts] (gen/one-of [(gen/return nil) (-> schema m/childs first (generator opts))]))
-(defmethod -generator :tuple [schema opts] (apply gen/tuple (->> schema m/childs (mapv #(generator % opts)))))
+(defmethod -generator :enum [schema _] (gen/elements (m/children schema)))
+(defmethod -generator :maybe [schema opts] (gen/one-of [(gen/return nil) (-> schema m/children first (generator opts))]))
+(defmethod -generator :tuple [schema opts] (apply gen/tuple (->> schema m/children (mapv #(generator % opts)))))
 #?(:clj (defmethod -generator :re [schema opts] (-re-gen schema opts)))
 
 (defn- -create [schema opts]

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -7,7 +7,7 @@
 (defn json-schema-props [schema prefix]
   (as-> (m/properties schema) $ (merge (select-keys $ [:title :description :default]) (unlift-keys $ prefix))))
 
-(defmulti accept (fn [name _schema _childs _opts] name) :default ::default)
+(defmulti accept (fn [name _schema _children _opts] name) :default ::default)
 
 (defmethod accept ::default [_ _ _ _] {})
 (defmethod accept 'any? [_ _ _ _] {})
@@ -66,7 +66,7 @@
 (defmethod accept :or [_ _ children _] {:anyOf children})
 
 (defmethod accept :map [_ schema children opts]
-  (let [{:keys [required keys]} (m/-parse-keys (m/childs schema opts) opts)]
+  (let [{:keys [required keys]} (m/-parse-keys (m/children schema opts) opts)]
     (merge
       {:type "object"
        :properties (apply array-map (interleave keys children))
@@ -80,11 +80,11 @@
 (defmethod accept :enum [_ _ children _] {:enum children})
 (defmethod accept :maybe [_ _ children _] {:oneOf (conj children {:type "null"})})
 (defmethod accept :tuple [_ _ children _] {:type "array", :items children, :additionalItems false})
-(defmethod accept :re [_ schema _ opts] {:type "string", :pattern (first (m/childs schema opts))})
+(defmethod accept :re [_ schema _ opts] {:type "string", :pattern (first (m/children schema opts))})
 (defmethod accept :fn [_ _ _ _] {})
 
-(defn- -json-schema-visitor [schema childs opts]
-  (merge (accept (m/name schema) schema childs opts) (json-schema-props schema "json-schema")))
+(defn- -json-schema-visitor [schema children opts]
+  (merge (accept (m/name schema) schema children opts) (json-schema-props schema "json-schema")))
 
 ;;
 ;; public api

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -2,9 +2,9 @@
   (:require [malli.json-schema :as json-schema]
             [malli.core :as m]))
 
-(defmulti accept (fn [name _schema _childs _opts] name) :default ::default)
+(defmulti accept (fn [name _schema _children _opts] name) :default ::default)
 
-(defmethod accept ::default [name schema childs opts] (json-schema/accept name schema childs opts))
+(defmethod accept ::default [name schema children opts] (json-schema/accept name schema children opts))
 (defmethod accept 'float? [_ _ _ _] {:type "number" :format "float"})
 (defmethod accept 'double? [_ _ _ _] {:type "number" :format "double"})
 (defmethod accept 'nil? [_ _ _ _] {})
@@ -18,8 +18,8 @@
 
 (defmethod accept :tuple [_ _ children _] {:type "array" :items {} :x-items children})
 
-(defn- -swagger-visitor [schema childs opts]
-  (merge (accept (m/name schema) schema childs opts) (json-schema/json-schema-props schema "swagger")))
+(defn- -swagger-visitor [schema children opts]
+  (merge (accept (m/name schema) schema children opts) (json-schema/json-schema-props schema "swagger")))
 
 ;;
 ;; public api

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -166,7 +166,7 @@
 
 (def +strip-extra-keys-decoders+
   {:map (fn [schema]
-          (if-let [keys (seq (:keys (m/-parse-keys (m/childs schema) nil)))]
+          (if-let [keys (seq (:keys (m/-parse-keys (m/children schema) nil)))]
             (fn [x] (select-keys x keys))))})
 
 (defn +key-decoders+ [key-fn]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -33,8 +33,8 @@
     [:x {:optional true} int?] {:optional true}
     [:x {:optional false} int?] {:optional false}))
 
-(defn visitor [schema childs _]
-  (into [(m/name schema)] (seq childs)))
+(defn visitor [schema children _]
+  (into [(m/name schema)] (seq children)))
 
 (deftest eval-test
   (is (= 2 ((m/eval inc) 1)))
@@ -589,11 +589,11 @@
              (m/properties [:and properties int?])
              (m/properties [int? properties]))))))
 
-(deftest childs-test
-  (testing "childs can be set and retrieved"
+(deftest children-test
+  (testing "children can be set and retrieved"
     (is (= ['int? 'pos-int?]
-           (m/childs [:and {:a 1} int? pos-int?])
-           (m/childs [:and int? pos-int?])))))
+           (m/children [:and {:a 1} int? pos-int?])
+           (m/children [:and int? pos-int?])))))
 
 (deftest round-trip-test
   (testing "schemas can be roundtripped"


### PR DESCRIPTION
Rename "childs" to "children", since that is the standard plural for "child".

In `generator` fix more places where `opts` wasn't being passed through, mainly to `m/children` and `m/properties`.

Also fix a callsite to `-coll-distinct-gen` I forget to update in the previous PR which caused the tests to break. They're green again.

Sorry for putting these in one PR, was a bit tedious to split up because I did the rename first.