### PR TITLE
Replace direct bin/* tool usage with a Makefile instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+KAOCHA-TARGETS :=
+
+node_modules:
+	npm install
+
+kaocha: node_modules
+	./bin/kaocha $(KAOCHA-TARGETS)
+
+.PHONY: test
+test: kaocha
+
+.PHONY: test-clj
+test-clj: KAOCHA-TARGETS := unit
+test-clj: kaocha
+
+.PHONY: test-cljs
+test-cljs: KAOCHA-TARGETS := unit-cljs
+test-cljs: kaocha

--- a/README.md
+++ b/README.md
@@ -828,9 +828,15 @@ So, we decided to spin out our own library, which would do all the things we fee
 
 ## Running tests
 
-We use Kaocha as a test runner. Before running the tests, you need to install NPM dependencies.
+We use Make which handles task management and related dependency installation for you. Simply run
 
 ```bash
-npm install
-bin/kaocha
+make test
+```
+
+to run all tests. You can also run only Clojure or ClojureScript specific tests:
+
+```bash
+make test-clj
+make test-cljs
 ```


### PR DESCRIPTION
While providing commands for running complex utilities and such is preferrable to just trusting people know how to run things, Makefile is a step better as it encapsulates the commands into a single file which has IDE tooling available for listing potential targets etc.

---

## Why, in a few extra words

If you expect a person to take two steps, you usually need to tell which foot to put forwards first. We are all human, and part of humanity is the social problem of _"of course I already did that!"_ While really simple, this Makefile is in part an avoidance of that scenario but also a helper for the users - being literally older than I am, Makefile integrations are _everywhere_, especially in shell environments, where autocompletion can easily tell you what can be done with the Makefile without knowledge of what hoops you need to jump through to get the actual command working.

Good example of where Makefile is beneficial is the installation of npm dependencies; as a new user who's curious about the project you would just _need to know_ you have to run `npm install` before trying to use Kaocha, but once you've done that, you don't really know how to invoke Kaocha either. For this purpose the `bin/kaocha` existed, but unfortunately these utilities tend to either be "good enough" or very scatter-brained - what does the word "kaocha" have to do with "run all tests"? What if I only want to run cljs tests?

I might sound cynical here, but this is just how I tend to approach things - how things look for people who have never before touched anything you've built but want to jump in and contribute. Also top/root level commands are easier to use than bits and pieces in subdirectories because they're less of strain to one's working memory.

## And a few notes

 - This Makefile doesn't install the tools themselves. That'd be borderline dangerous.
 - I'm not a Makefile expert by any means, but I'd say this is good enough for now if accepted.
 - There's no `clean` target defined as I'm not sure which parts of the repository tree are expected to be removable without side effects. Normally this would be a
    ```bash
    .PHONY: clean
    clean:
        git clean -Xdf
    ```
    but I wasn't sure if the `.gitignore` is up to date so I left it this one out