### PR TITLE
fix: custom registry on encode / decode

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -752,7 +752,7 @@
   ([?schema value t]
    (decode ?schema value nil t))
   ([?schema value opts t]
-   (if-let [transform (decoder (schema ?schema) opts t)]
+   (if-let [transform (decoder ?schema opts t)]
      (transform value)
      value)))
 
@@ -772,7 +772,7 @@
   ([?schema value t]
    (encode ?schema value nil t))
   ([?schema value opts t]
-   (if-let [transform (encoder (schema ?schema) opts t)]
+   (if-let [transform (encoder ?schema opts t)]
      (transform value)
      value)))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -823,6 +823,14 @@
          [:body-params
           [:map [:z int?]]]]]])))
 
+(deftest encode-decode-test
+  (testing "works with custom registry"
+    (let [opts {:registry (merge m/default-registry {:test keyword?}) }
+          encoded (m/encode :test :foo opts transform/string-transformer)
+          decoded (m/decode :test encoded opts transform/string-transformer)]
+      (is (= "foo" encoded))
+      (is (= :foo decoded)))))
+
 (def sequential (#'m/-collection-schema `sequential sequential? seq nil))
 
 (deftest custom-into-schema-test


### PR DESCRIPTION
Fixes an error where a schema would be resolved before options were
taken into account on `encode` and `decode` - causing custom registries
to be ignored.

Since `(schema ?schema opts)` is called in `encoder` and `decoder` it seemed redundant to call it at all in the outer functions.