### PR TITLE
fix: check type before transforming collections

### DIFF
--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -159,7 +159,20 @@
   (testing "decode"
     (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] mt/collection-transformer))))
   (testing "encode"
-    (is (= #{1 2 3} (m/encode [:set int?] [1 2 3] mt/collection-transformer)))))
+    (is (= #{1 2 3} (m/encode [:set int?] [1 2 3] mt/collection-transformer))))
+
+  (testing "does not interprit strings as collections"
+    (is (= "123" (m/encode [:set string?] "123" mt/collection-transformer)))
+    (is (= "abc" (m/encode [:vector keyword?] "abc" mt/json-transformer))))
+
+
+  (testing "does not raise with bad input"
+    (is (= 2 (m/encode [:set string?] 2 mt/collection-transformer))))
+
+  (testing "allows transformers to change their type"
+    (is (= "a,b,c" (m/encode [:vector {:encode/string
+                                       (constantly {:leave #(str/join "," %)})}
+                              string?] ["a" "b" "c"] mt/string-transformer)))))
 
 (deftest composing-transformers
   (let [strict-json-transformer (mt/transformer


### PR DESCRIPTION
Fixes an error where collection transformers could either inadvertantly
coerce seqable input into collections (eg. strings) or explode when
trying to coerce truly invalid input (which is bad if you use a
collection transformer in an `:or` schema with a non collection transformer).

This is also the same issue that @roklenarcic described in the slack today.