### PR TITLE
Transformer Chains

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -20,7 +20,7 @@
   (-form [this] "returns original form of the schema"))
 
 (defprotocol Transformer
-  (-transformer-chain [this] "returns transformer chain as a vector of maps")
+  (-transformer-chain [this] "returns transformer chain as a vector of maps with :name, :encoders, :decoders and :opts")
   (-value-transformer [this schema method] "returns an value transforming interceptor for the given schema and method"))
 
 (defrecord SchemaError [path in schema value type message])

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -137,10 +137,10 @@
                   acc explainers))))
           (-transformer [this transformer method]
             (let [build-transformer
-                  (fn [i-key]
-                    (let [st (i-key (-value-transformer transformer this method))
+                  (fn [stage]
+                    (let [st (stage (-value-transformer transformer this method))
                           ?st (or st identity)
-                          tvs (into [] (keep #(i-key (-transformer % transformer method)) child-schemas))]
+                          tvs (into [] (keep #(stage (-transformer % transformer method)) child-schemas))]
                       (cond
                         (not (seq tvs)) st
                         short-circuit (fn [x]
@@ -235,14 +235,14 @@
                     acc explainers)))))
           (-transformer [this transformer method]
             (let [build-transformer
-                  (fn [i-key]
-                    (let [key-transformer (i-key (-transformer (map-key) transformer method))
+                  (fn [stage]
+                    (let [key-transformer (stage (-transformer (map-key) transformer method))
                           value-transformers
                           (some->> entries
-                                   (mapcat (fn [[k _ s]] (if-let [t (i-key (-transformer s transformer method))] [k t])))
+                                   (mapcat (fn [[k _ s]] (if-let [t (stage (-transformer s transformer method))] [k t])))
                                    (seq)
                                    (apply array-map))
-                          map-transformer (i-key (-value-transformer transformer this method))
+                          map-transformer (stage (-value-transformer transformer this method))
                           apply-key-transformers (fn [m k v]
                                                    (let [k' (key-transformer k)]
                                                      (-> m
@@ -342,12 +342,12 @@
                     acc m)))))
           (-transformer [this transformer method]
             (let [build-transformer
-                  (fn [i-key]
-                    (let [tt (i-key (-value-transformer transformer this method))
+                  (fn [stage]
+                    (let [tt (stage (-value-transformer transformer this method))
                           ?tt (or tt identity)
-                          key-transformer (if-let [t (i-key (-transformer key-schema transformer method))]
+                          key-transformer (if-let [t (stage (-transformer key-schema transformer method))]
                                             (fn [x] (t (keyword->string x))))
-                          value-transformer (i-key (-transformer value-schema transformer method))]
+                          value-transformer (stage (-transformer value-schema transformer method))]
                       (cond
                         (and tt (not key-transformer) (not value-transformer))
                         tt
@@ -421,10 +421,10 @@
                               acc)))))))
           (-transformer [this transformer method]
             (let [build-transformer
-                  (fn [i-key]
-                    (let [tt (i-key (-value-transformer transformer this method))
+                  (fn [stage]
+                    (let [tt (stage (-value-transformer transformer this method))
                           ?tt (or tt identity)
-                          t (i-key (-transformer schema transformer method))]
+                          t (stage (-transformer schema transformer method))]
                       (cond
                         (and (not t) tt) (comp fwrap tt)
                         (not t) fwrap ;; should wrapping be optional?
@@ -475,10 +475,10 @@
                           (cond-> (e x (conj in i) acc) xs (recur (inc i) xs es)))))))
           (-transformer [this transformer method]
             (let [build-transformer
-                  (fn [i-key]
-                    (let [?tt (or (i-key (-value-transformer transformer this method)) identity)
+                  (fn [stage]
+                    (let [?tt (or (stage (-value-transformer transformer this method)) identity)
                           ts (->> schemas
-                                  (mapv #(i-key (-transformer % transformer method)))
+                                  (mapv #(stage (-transformer % transformer method)))
                                   (map-indexed vector)
                                   (filter second)
                                   (mapcat identity)
@@ -586,9 +586,9 @@
               (if-not (or (nil? x) (validator' x)) (conj acc (error path in this x)) acc)))
           (-transformer [this transformer method]
             (let [build-transformer
-                  (fn [i-key]
-                    (let [tt (i-key (-value-transformer transformer this method))
-                          t (i-key (-transformer schema' transformer method))]
+                  (fn [stage]
+                    (let [tt (stage (-value-transformer transformer this method))
+                          t (stage (-transformer schema' transformer method))]
                       (if (and tt t) (comp t tt) (or tt t))))]
               {:enter (build-transformer :enter)
                :leave (build-transformer :leave)}))
@@ -623,9 +623,9 @@
                   (conj acc (error path in this x ::invalid-dispatch-value))))))
           (-transformer [this transformer method]
             (let [build-transformer
-                  (fn [i-key]
-                    (let [tt (i-key (-value-transformer transformer this method))
-                          ts (reduce-kv (fn [acc k s] (assoc acc k (i-key (-transformer s transformer method)))) {} dispatch-map)
+                  (fn [stage]
+                    (let [tt (stage (-value-transformer transformer this method))
+                          ts (reduce-kv (fn [acc k s] (assoc acc k (stage (-transformer s transformer method)))) {} dispatch-map)
                           t (fn [x] (if-let [t (ts (dispatch x))] (t x) x))]
                       (cond
                         (and tt (not (seq ts))) tt

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -20,9 +20,8 @@
   (-form [this] "returns original form of the schema"))
 
 (defprotocol Transformer
-  (-context-names [this] "vector of context names attached to the transformer")
-  (-transformer-options [this] "returns transformer options")
-  (-value-transformer [this schema stage] "returns an interceptor map with :enter and :leave functions to transform the value for the given schema and s"))
+  (-transformer-chain [this] "returns transformer chain as a vector of maps")
+  (-value-transformer [this schema method] "returns an value transforming interceptor for the given schema and method"))
 
 (defrecord SchemaError [path in schema value type message])
 

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -41,7 +41,7 @@
                      :decode (some->> transformer-name name (str "decode/") keyword)}]
     (reify
       m/Transformer
-      (-transformer-name [_] transformer-name)
+      (-context-names [_] [transformer-name])
       (-transformer-options [_] {:name transformer-name, :decoders decoders, :encoders encoders, :opts opts})
       (-value-transformer [_ schema context]
         (if-let [->transformer (or (some-> (get (m/properties schema) (schema-keys context)) (m/eval))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -262,6 +262,8 @@
                       mt/string-transformer
                       {:decoders {'int? (constantly inc)}}
                       {:name :after})]
+    (testing "nil punning"
+      (is (= identity (m/decoder string? transformer))))
     (is (= 23 (m/decode
                 [int? {:decode/before '(constantly {:leave inc})
                        :decode/after '(constantly (partial * 2))}]

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -180,8 +180,8 @@
                                   mt/json-transformer
                                   {:opts {:random :opts}})]
 
-    (testing "name is taken from the last named transformer"
-      (is (= :json (m/-transformer-name strict-json-transformer))))
+    (testing "-context-names is taken from the last named transformer"
+      (is (= [:json] (m/-context-names strict-json-transformer))))
 
     (testing "decode"
       (is (= :kikka (m/decode keyword? "kikka" strict-json-transformer)))


### PR DESCRIPTION
Related to #136:

* polish naming: 
  * `method` (internal), defines what we are about to do. Valid values: `:decode`, `:encode`
  * `phase`, interceptor pipeline, either `:enter` or `:leave`
  * `name`, a transformer name

* simplified `malli.core/Transformer` Protocol:

```clj
(defprotocol Transformer
  (-transformer-chain [this] "returns transformer chain as a vector of maps with :name, :encoders, :decoders and :opts")
  (-value-transformer [this schema method] "returns an value transforming interceptor for the given schema and method"))
```

* `malli.transform/transformer` allows a chain of transformers to be defined
    * `:encoders` and `:decoders` are chained together, in order (instead or merging per schemas as before)
    * each named transformer allow schema-based transformations that can override the default `:encoders` and `:decoders`

```clj
(m/decode
  [int? {:decode/before '(constantly {:leave inc})
         :decode/after '(constantly (partial * 2))}]
  "10"
  (mt/transformer
    {:name :before}
    mt/string-transformer
    {:decoders {'int? (constantly inc)}} ;; anonymous
    {:name :after}))
; => 23

;; :enter
;;  :string   "10" => 10
;;  anonymous   10 => 11
;;  :after      11 => 22
;; :leave
;;  :before     22 => 23
```