### PR TITLE
First cut of `:not` schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ Comparator functions as keywords: `:>`, `:>=`, `:<`, `:<=`, `:=` and `:not=`.
 
 #### `malli.core/base-registry`
 
-Contains `:and`, `:or`, `:map`, `:map-of`, `:vector`, `:list`, `:sequential`, `:set`, `:tuple`, `:enum`, `:maybe`, `:multi`, `:re` and `:fn`.
+Contains `:and`, `:or`, `:not`, `:map`, `:map-of`, `:vector`, `:list`, `:sequential`, `:set`, `:tuple`, `:enum`, `:maybe`, `:multi`, `:re` and `:fn`.
 
 ### Custom registry
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -67,6 +67,7 @@
 
 (defmethod -generator :and [schema opts] (gen/such-that (m/validator schema opts) (-> schema (m/children opts) first (generator opts)) 100))
 (defmethod -generator :or [schema opts] (gen/one-of (mapv #(generator % opts) (m/children schema opts))))
+(defmethod -generator :not [schema opts] (gen/such-that (m/validator schema opts) gen/any-printable 100))
 (defmethod -generator :map [schema opts] (-map-gen schema opts))
 (defmethod -generator :map-of [schema opts] (-map-of-gen schema opts))
 (defmethod -generator :multi [schema opts] (gen/one-of (mapv #(generator (second %) opts) (m/children schema opts))))


### PR DESCRIPTION
Hi, all! 
The `malli` is an awesome library. Great job. Thanks.

I want to help you with native support for `complements`. This is my first cut of `:not` schema. I've tried implementing with `composite-schema`, but `complements` needs some different logic and I don't know about your plans with `composite-schema`. So I decided to leave refactoring for later.

