### PR TITLE
fix: double transformer invokation + :leave order

### DIFF
--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -129,10 +129,10 @@
       (is (= {:c1 "1", ::c2 "kikka"} (m/encode [:map [:c1 int?] [::c2 keyword?]] {:c1 1, ::c2 :kikka} mt/string-transformer)))
       (is (= {:c1 1, ::c2 "kikka"} (m/encode [:map [::c2 keyword?]] {:c1 1, ::c2 :kikka} mt/json-transformer)))
       (is (= ::invalid (m/encode [:map] ::invalid mt/json-transformer)))))
-  #_(testing "s/map-of"
-      (is (= {1 :abba, 2 :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} mt/string-transformer)))
-      (is (= {"1" :abba, "2" :jabba} (m/decode (s/map-of int? keyword?) {"1" "abba", "2" "jabba"} mt/json-transformer)))
-      (is (= ::invalid (m/decode (s/map-of int? keyword?) ::invalid mt/json-transformer))))
+  (testing "map-of"
+    (is (= {1 :abba, 2 :jabba} (m/decode [:map-of int? keyword?] {"1" "abba", "2" "jabba"} mt/string-transformer)))
+    (is (= {"1" :abba, "2" :jabba} (m/decode [:map-of int? keyword?] {"1" "abba", "2" "jabba"} mt/json-transformer)))
+    (is (= ::invalid (m/decode [:map-of int? keyword?] ::invalid mt/json-transformer))))
   (testing "maybe"
     (testing "decode"
       (is (= 1 (m/decode [:maybe int?] "1" mt/string-transformer)))


### PR DESCRIPTION
This commit fixes two issues:

1) It no longer invokes `transformer` related methods twice while
creating parent transformers. This fixes errors with stateful
transformers that depend on sharing data between enter and leave.

2) It fixes the order in which interceptors call their children for the
`map-of`, `sequence`, `tuple` and `map` interceptors - causing the child
transformers to be invoked first on the `leave`.

Closes #140, #132