### PR TITLE
chore: .gitignore .nrepl-port + .dir-locals.el

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 .idea
 node_modules
 out
+.nrepl-port
+.dir-locals.el


### PR DESCRIPTION
Adds some emacs-specific config files to the .gitignore so that tooling
doesn't accidentally make its way into the repo