### PR TITLE
BREAKING: Interceptor compilation

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -39,6 +39,7 @@
 ;;
 
 (declare schema)
+(declare properties)
 (declare default-registry)
 (declare map-key)
 
@@ -50,7 +51,8 @@
     x))
 
 (defn eval [?code]
-  (if (fn? ?code) ?code (sci/eval-string (str ?code) {:preset :termination-safe})))
+  (if (fn? ?code) ?code (sci/eval-string (str ?code) {:preset :termination-safe
+                                                      :bindings {'m/properties properties}})))
 
 (defn error
   ([path in schema value]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -138,11 +138,11 @@
                         :else acc'')))
                   acc explainers))))
           (-transformer [this transformer method]
-            (let [value-transformer  (-value-transformer transformer this method)
+            (let [value-transformer (-value-transformer transformer this method)
                   child-transformers (map #(-transformer % transformer method) child-schemas)
                   build-transformer
                   (fn [phase]
-                    (let [st  (phase value-transformer)
+                    (let [st (phase value-transformer)
                           ?st (or st identity)
                           tvs (into [] (keep phase) child-transformers)]
                       (cond
@@ -150,8 +150,8 @@
                         short-circuit (fn [x]
                                         (let [x (?st x)]
                                           (reduce-kv
-                                          (fn [_ _ t] (let [x' (t x)] (if-not (identical? x' x) (reduced x') x)))
-                                          x tvs)))
+                                            (fn [_ _ t] (let [x' (t x)] (if-not (identical? x' x) (reduced x') x)))
+                                            x tvs)))
                         :else (fn [x] (reduce-kv (fn [x' _ t] (t x')) (?st x) tvs)))))]
               {:enter (build-transformer :enter)
                :leave (build-transformer :leave)}))
@@ -240,11 +240,11 @@
           (-transformer [this transformer method]
             (let [key-transformers (-transformer (map-key) transformer method)
                   value-transformers (some->>
-                                      entries
-                                      (keep (fn [[k _ s]]
-                                              (when-some [t (-transformer s transformer method)]
-                                                [k t])))
-                                      (into {}))
+                                       entries
+                                       (keep (fn [[k _ s]]
+                                               (when-some [t (-transformer s transformer method)]
+                                                 [k t])))
+                                       (into {}))
                   map-transformers (-value-transformer transformer this method)
                   build-transformer
                   (fn [phase]
@@ -257,21 +257,21 @@
                           map-transformer (phase map-transformers)
                           apply-key-transformers (when key-transformer
                                                    #(reduce-kv
-                                                     (fn reduce-key-transformers [m k v]
-                                                       (let [new-k (key-transformer k)]
-                                                         (-> m
-                                                             (assoc new-k v)
-                                                             (cond-> (not (identical? k new-k)) (dissoc k)))))
-                                                     %
-                                                     %))
+                                                      (fn reduce-key-transformers [m k v]
+                                                        (let [new-k (key-transformer k)]
+                                                          (-> m
+                                                              (assoc new-k v)
+                                                              (cond-> (not (identical? k new-k)) (dissoc k)))))
+                                                      %
+                                                      %))
                           apply-value-transformers (when (seq value-transformers)
                                                      #(reduce-kv
-                                                       (fn reduce-value-transformers [m k t]
-                                                         (if-let [entry (find m k)]
-                                                           (assoc m k (t (val entry)))
-                                                           m))
-                                                       %
-                                                       value-transformers))
+                                                        (fn reduce-value-transformers [m k t]
+                                                          (if-let [entry (find m k)]
+                                                            (assoc m k (t (val entry)))
+                                                            m))
+                                                        %
+                                                        value-transformers))
                           transform-order (->> (case phase
                                                  :enter [map-transformer
                                                          apply-value-transformers
@@ -630,9 +630,9 @@
           (-transformer [this transformer method]
             (let [transformers (-value-transformer transformer this method)
                   child-transformers (reduce-kv
-                                      #(assoc %1 %2 (-transformer %3 transformer method))
-                                      {}
-                                      dispatch-map)
+                                       #(assoc %1 %2 (-transformer %3 transformer method))
+                                       {}
+                                       dispatch-map)
                   build-transformer
                   (fn [phase]
                     (let [transform-val (phase transformers)
@@ -643,10 +643,10 @@
                           transform-child (when (seq ts)
                                             (fn [x] (if-let [t (ts (dispatch x))] (t x) x)))
                           transform-order (->>
-                                           (case phase
-                                             :enter [transform-val transform-child]
-                                             :leave [transform-child transform-val])
-                                           (remove nil?))
+                                            (case phase
+                                              :enter [transform-val transform-child]
+                                              :leave [transform-child transform-val])
+                                            (remove nil?))
 
                           transform (when (seq transform-order)
                                       (apply comp (reverse transform-order)))]

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -18,7 +18,7 @@
   (cond
 
     (fn? ?interceptor)
-    {:enter ?interceptor :leave nil}
+    {:enter ?interceptor}
 
     (and (map? ?interceptor) (contains? ?interceptor :compile))
     (let [compiled (::compiled opts 0)

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -24,7 +24,7 @@
                                                    :c {:type "string"}}
                                       :required [:a :c]}]
    [[:multi {:dispatch :type
-             :decode/string '(constantly (fn [x] (update x :type keyword)))}
+             :decode/string '(fn [x] (update x :type keyword))}
      [:sized [:map {:gen/fmap '#(assoc % :type :sized)} [:type keyword?] [:size int?]]]
      [:human [:map {:gen/fmap '#(assoc % :type :human)} [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]]]
     {:oneOf [{:type "object",

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -29,7 +29,7 @@
                                                    :c {:type "string"}}
                                       :required [:a :c]}]
    [[:multi {:dispatch :type
-             :decode/string '(constantly (fn [x] (update x :type keyword)))}
+             :decode/string '(fn [x] (update x :type keyword))}
      [:sized [:map [:type keyword?] [:size int?]]]
      [:human [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]]]
     {:type "object",

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -261,26 +261,25 @@
                        transformer)))))
   (testing "call order"
     (are [schema data call-order]
-        (let [calls       (atom [])
-              record-call (fn [n] (constantly
-                                   {:enter (fn [x]
-                                             (swap! calls conj [:enter n])
-                                             x)
-                                    :leave (fn [x]
-                                             (swap! calls conj [:leave n])
-                                             x)}))
-              transformer (mt/transformer
-                           {:name     :order-test
-                            :decoders {:map     (record-call :map)
-                                       :map-of  (record-call :map-of)
-                                       :vector  (record-call :vector)
-                                       :multi   (record-call :multi)
-                                       :tuple   (record-call :tuple)
-                                       'int?    (record-call :int)
-                                       'string? (record-call :string)}})]
-          (m/decode schema data transformer)
-          (= call-order
-             @calls))
+      (let [calls (atom [])
+            record-call (fn [n] {:enter (fn [x]
+                                          (swap! calls conj [:enter n])
+                                          x)
+                                 :leave (fn [x]
+                                          (swap! calls conj [:leave n])
+                                          x)})
+            transformer (mt/transformer
+                          {:name :order-test
+                           :decoders {:map (record-call :map)
+                                      :map-of (record-call :map-of)
+                                      :vector (record-call :vector)
+                                      :multi (record-call :multi)
+                                      :tuple (record-call :tuple)
+                                      'int? (record-call :int)
+                                      'string? (record-call :string)}})]
+        (m/decode schema data transformer)
+        (= call-order
+           @calls))
       [:map
        [:foo int?]
        [:bar string?]]
@@ -317,8 +316,8 @@
        [:leave :tuple]]
       [:multi {:dispatch :kind}
        [:person [:map [:name string?]]]
-       [:food   [:map [:weight int?]]]]
-      {:kind   :food
+       [:food [:map [:weight int?]]]]
+      {:kind :food
        :weight 42}
       [[:enter :multi]
        [:enter :map]


### PR DESCRIPTION
### Breaking Change (for the better)

Fixes #145  - tranformations can be declared as `value => value` functions instead of `schema opts => value => value` making the 99% case simpler and just the 1% bit harder (but still possible).

Schema properties can be used to override default transformations:

```clj
(m/decode
  [string? {:decode/string 'str/upper-case}]
  "kerran" mt/string-transformer)
; => "KERRAN"
```

Decoders and encoders as interceptors (with `:enter` and `:leave` stages):

```clj
(m/decode
  [string? {:decode/string '{:enter str/upper-case}}]
  "kerran" mt/string-transformer)
; => "KERRAN"
```

```clj
(m/decode
  [string? {:decode/string '{:enter #(str "olipa_" %)
                             :leave #(str % "_avaruus")}}]
  "kerran" mt/string-transformer)
; => "olipa_kerran_avaruus"
```

To access Schema (and options) use `:compile`:

```clj
(m/decode
  [int? {:math/multiplier 10
         :decode/math '{:compile (fn [schema _]
                                  (let [multiplier (:math/multiplier (m/properties schema))]
                                    (fn [x] (* x multiplier))))}}]
  12
  (mt/transformer {:name :math}))
; => 120
```

Going crazy:

```clj
(m/decode
  [:map
   {:decode/math '{:enter #(update % :x inc)
                   :leave #(update % :x (partial * 2))}}
   [:x [int? {:decode/math '{:enter (partial + 2)
                             :leave (partial * 3)}}]]]
  {:x 1} 
  (mt/transformer {:name :math}))
; => {:x 42}
```