### PR TITLE
BREAKING: don't coerce map-of keywords to strings

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -328,7 +328,7 @@
                   build (fn [phase]
                           (let [->this (phase this-transformer)
                                 ->key (if-let [t (phase key-transformer)]
-                                        (fn [x] (t (keyword->string x))))
+                                        (fn [x] (t x)))
                                 ->child (phase child-transformer)
                                 ->key-child (cond
                                               (and ->key ->child) #(assoc %1 (->key %2) (->child %3))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -169,6 +169,16 @@
 
 (defn any->any [x] x)
 
+(defn coerce-map-keys [transform]
+  (fn [x]
+    (if (map? x)
+      (into {}
+            (map
+             (fn [[k v]] [(transform k) v]))
+            x)
+      x)))
+
+
 ;;
 ;; decoders
 ;;
@@ -188,7 +198,9 @@
 
    'uuid? string->uuid
 
-   'inst? string->date})
+   'inst? string->date
+
+   :map-of (coerce-map-keys m/keyword->string)})
 
 (def +json-encoders+
   {'keyword? m/keyword->string


### PR DESCRIPTION
Removes the default (and somewhat surprising) behaviour of coercing keywords to strings before passing them to their transformers.

This had the unintended side-effect of making intentional keyword-like schemas in map-of schemas have to be aware of how to coerce themselves from both keywords and strings.

This behavior is only breaking for people writing their own custom transformers with `map-of` keys. You now no longer need to handle both strings and keyword inputs.

For end users using `mt/json-transformers` or `mt/string-transformers`, adds a default `map-of` transformer which keeps the behavior that was previously hard coded.

Closes #131