### PR TITLE
fix: type changing transformers

### DIFF
--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -182,12 +182,14 @@
 ;; TODO: this is wrong!
 (deftest collection-transform-test
   (testing "decode"
-    (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] mt/collection-transformer))))
+    (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] mt/collection-transformer)))
+    (is (= #{1 2 3} (m/decode [:set {:decode/string #(map str %)} int?]
+                              "123" mt/string-transformer))))
   (testing "encode"
     (is (= #{1 2 3} (m/encode [:set int?] [1 2 3] mt/collection-transformer))))
 
   (testing "does not interprit strings as collections"
-    (is (= "123" (m/encode [:set string?] "123" mt/collection-transformer)))
+    (is (= "123" (m/encode [:set int?] "123" mt/collection-transformer)))
     (is (= "abc" (m/encode [:vector keyword?] "abc" mt/json-transformer))))
 
   (testing "does not raise with bad input"


### PR DESCRIPTION
This commit introduces code and testing for two fixes:

1) It removes the check on the type of the data before calling the
`this-transformer` for the `tuple`, `map-of`, `map` and
`sequence`-related transformers. This is necessary to allow for encoded
/ decoded data to be in shapes that differ in type from their root
schema. Eg. a map schema that is encoded as a tuple of values (common in
financial candle data).

2) Introduces the ability for a `-chain` to take a tuple with a
`predicate` and a `sub-chain`. This allows schemas to specify groups of
child-transformations that depend on a certain predicate. This fixes an
error where post `this-transformer` functions would change their type to
a shape that would cause invoking the children to crash.