### PR TITLE
Wrap humamized erros always in vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ Explain results can be humanized with `malli.error/humanize`:
                  :lonlat [61.4858322, nil]}})
     (me/humanize
       {:wrap :message}))
-;{:tags #{"should be keyword"}
-; :address {:city "missing required key"
-;           :lonlat [nil "should be double"]}}
+;{:tags #{["should be keyword"]}
+; :address {:city ["missing required key"]
+;           :lonlat [nil ["should be double"]]}}
 ```
 
 Error messages can be customized with `:error/message` and `:error/fn` properties:
@@ -174,9 +174,9 @@ Error messages can be customized with `:error/message` and `:error/fn` propertie
       {:wrap :message
        :errors (-> me/default-errors
                    (assoc ::m/missing-key {:error/fn (fn [{:keys [in]} _] (str "missing key " (last in)))}))}))
-;{:id "missing key :id"
-; :size "should be: S|M|L"
-; :age "10, should be > 18"}
+;{:id ["missing key :id"]
+; :size ["should be: S|M|L"]
+; :age ["10, should be > 18"]}
 ```
 
 Messages can be localized:
@@ -198,9 +198,9 @@ Messages can be localized:
                    (assoc-in ['int? :error-message :fi] "pitäisi olla numero")
                    (assoc ::m/missing-key {:error/fn {:en '(fn [{:keys [in]} _] (str "missing key " (last in)))
                                                       :fi '(fn [{:keys [in]} _] (str "puuttuu avain " (last in)))}}))}))
-;{:id "puuttuu avain :id"
-; :size "pitäisi olla: S|M|L"
-; :age "10, pitäisi olla > 18"}
+;{:id ["puuttuu avain :id"]
+; :size ["pitäisi olla: S|M|L"]
+; :age ["10, pitäisi olla > 18"]}
 ```
 
 Top-level humanized map-errors are under `:malli/error`:
@@ -215,7 +215,7 @@ Top-level humanized map-errors are under `:malli/error`:
     (m/explain {:password "secret"
                 :password2 "faarao"})
     (me/humanize {:wrap :message}))
-; {:malli/error "passwords don't match"}
+; {:malli/error ["passwords don't match"]}
 ```
 
 Errors can be targetted using `:error/path` property:
@@ -231,7 +231,7 @@ Errors can be targetted using `:error/path` property:
     (m/explain {:password "secret"
                 :password2 "faarao"})
     (me/humanize {:wrap :message}))
-; {:password2 "passwords don't match"}
+; {:password2 ["passwords don't match"]}
 ```
 
 ## Value Transformation

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -63,15 +63,14 @@
       (if (> k size') (into (vec x) (repeat (- (inc k) size') nil)) x))
     x))
 
+(defn- -just-error? [x]
+  (and (vector? x) (= 1 (count x)) (string? (first x))))
+
 (defn- -get [x k]
   (if (set? x) (-> x vec (get k)) (get x k)))
 
 (defn- -put [x k v]
-  (if (set? x) (conj x v) (update x k (fn [e]
-                                        (cond (string? e) [e v]
-                                              (sequential? v) v
-                                              (nil? e) v
-                                              :else (conj e v))))))
+  (if (set? x) (conj x v) (update x k (fn [e] (if (-just-error? v) (into (vec e) v) v)))))
 
 (defn- -assoc-in [acc value [p & ps] error]
   (cond
@@ -135,6 +134,6 @@
      (if (coll? value)
        (reduce
          (fn [acc error]
-           (-assoc-in acc value (error-path error opts) (f (with-error-message error opts))))
+           (-assoc-in acc value (error-path error opts) [(f (with-error-message error opts))]))
          nil errors)
-       (f (with-error-message (first errors) opts))))))
+       [(f (with-error-message (first errors) opts))]))))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -32,33 +32,33 @@
                   (me/humanize {:wrap :message})))))
 
   (testing "top-level error"
-    (is (= "should be int"
+    (is (= ["should be int"]
            (-> int?
                (m/explain "1")
                (me/humanize {:wrap :message})))))
 
   (testing "vector"
-    (is (= [nil nil [nil "should be int"]]
+    (is (= [nil nil [nil ["should be int"]]]
            (-> [:vector [:vector int?]]
                (m/explain [[1 2] [2 2] [3 "4"]])
                (me/humanize {:wrap :message})))))
 
   (testing "set"
-    (is (= #{#{"should be int"}}
+    (is (= #{#{["should be int"]}}
            (-> [:set [:set int?]]
                (m/explain #{#{1} #{"2"}})
                (me/humanize {:wrap :message})))))
 
   (testing "invalid type"
-    (is (= "invalid type"
+    (is (= ["invalid type"]
            (-> [:list int?]
                (m/explain [1])
                (me/humanize {:wrap :message})))))
 
   (testing "mixed bag"
     (is (= [nil
-            {:x [nil "should be int" "should be int"]}
-            {:x "invalid type"}]
+            {:x [nil ["should be int"] ["should be int"]]}
+            {:x ["invalid type"]}]
            (-> [:vector [:map [:x [:vector int?]]]]
                (m/explain
                  [{:x [1 2 3]}
@@ -67,10 +67,10 @@
                (me/humanize {:wrap :message})))))
 
   (testing "so nested"
-    (is (= {:data [{:x ["should be int" nil "should be int"]}
-                   {:x ["should be int" nil "should be int"]}
+    (is (= {:data [{:x [["should be int"] nil ["should be int"]]}
+                   {:x [["should be int"] nil ["should be int"]]}
                    nil
-                   {:x ["should be int"]}]}
+                   {:x [["should be int"]]}]}
            (-> [:map [:data [:vector [:map [:x [:vector int?]]]]]]
                (m/explain
                  {:data [{:x ["1" 2 "3"]} {:x ["1" 2 "3"]} {:x [1]} {:x ["1"]} {:x [1]}]})
@@ -100,20 +100,20 @@
                :d {:f "invalid"}}]
 
     (testing "with default locale"
-      (is (= {:a "should be int"
-              :b "should be positive int"
-              :c "STAY POSITIVE",
-              :d {:e "missing required key"
-                  :f "SHOULD BE ZIP"}}
+      (is (= {:a ["should be int"]
+              :b ["should be positive int"]
+              :c ["STAY POSITIVE"],
+              :d {:e ["missing required key"]
+                  :f ["SHOULD BE ZIP"]}}
              (-> (m/explain schema value)
                  (me/humanize {:wrap :message})))))
 
     (testing "localization is applied, if available"
-      (is (= {:a "NUMERO"
-              :b "should be positive int"
-              :c "POSITIIVINEN",
-              :d {:e "PUUTTUVA AVAIN"
-                  :f "PITÄISI OLLA NUMERO"}}
+      (is (= {:a ["NUMERO"]
+              :b ["should be positive int"]
+              :c ["POSITIIVINEN"],
+              :d {:e ["PUUTTUVA AVAIN"]
+                  :f ["PITÄISI OLLA NUMERO"]}}
              (-> (m/explain schema value)
                  (me/humanize
                    {:wrap :message
@@ -132,7 +132,7 @@
                   [:fn {:error/message "(> x y)"}
                    '(fn [{:keys [x y]}] (> x y))]]]
 
-      (is (= {:z "should be int", :malli/error "(> x y)"}
+      (is (= {:z ["should be int"], :malli/error ["(> x y)"]}
              (-> schema
                  (m/explain {:x 1 :y 2, :z "1"})
                  (me/humanize {:wrap :message})))))
@@ -146,7 +146,7 @@
                      '(fn [{:keys [password password2]}]
                         (= password password2))]]]
 
-        (is (= {:password2 "passwords don't match"}
+        (is (= {:password2 ["passwords don't match"]}
                (-> schema
                    (m/explain {:password "secret"
                                :password2 "faarao"})
@@ -159,15 +159,15 @@
                    '(fn [[x]] (pos? x))]
                   [:fn {:error/message "first should be positive (masked)"}
                    '(fn [[x]] (pos? x))]]]
-      (is (= "first should be positive"
+      (is (= ["first should be positive"]
              (-> schema
                  (m/explain [-2 1])
                  (me/humanize {:wrap :message}))))
-      (is (= [nil "should be int"]
+      (is (= [nil ["should be int"]]
              (-> schema
                  (m/explain [-2 "1"])
                  (me/humanize {:wrap :message}))))
-      (is (= "invalid type"
+      (is (= ["invalid type"]
              (-> schema
                  (m/explain '(-2 "1"))
                  (me/humanize {:wrap :message}))))))
@@ -178,15 +178,15 @@
                   int?
                   [:fn {:error/message "should be >= 2"} '(fn [x] (or (not (int? x)) (>= x 2)))]]]
 
-      (is (= "should be >= 1"
+      (is (= ["should be >= 1"]
              (-> schema
                  (m/explain 0)
                  (me/humanize {:wrap :message}))))
-      (is (= "should be int"
+      (is (= ["should be int"]
              (-> schema
                  (m/explain "kikka")
                  (me/humanize {:wrap :message}))))
-      (is (= "should be >= 2"
+      (is (= ["should be >= 2"]
              (-> schema
                  (m/explain 1)
                  (me/humanize {:wrap :message}))))


### PR DESCRIPTION
Humanized errors are not intented for apps, but if they were, this would make parsing easier. Related to https://github.com/metosin/reitit/pull/341