### PR TITLE
Add support for closed maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,24 @@ Schemas can have properties:
 ;     :json-schema/example 20}   
 ```
 
+Maps are open by default:
+
+```clj
+(m/validate
+  [:map [:x int?]]
+  {:x 1, :extra "key"})
+; => true
+```
+
+Maps can be closed with `:closed` property:
+
+```clj
+(m/validate
+  [:map {:closed true} [:x int?]]
+  {:x 1, :extra "key"})
+; => false
+``` 
+
 Serializable function schemas using [sci](https://github.com/borkdude/sci):
 
 ```clj

--- a/README.md
+++ b/README.md
@@ -171,8 +171,7 @@ Explain results can be humanized with `malli.error/humanize`:
        :address {:street "Ahlmanintie 29"
                  :zip 33100
                  :lonlat [61.4858322, nil]}})
-    (me/humanize
-      {:wrap :message}))
+    (me/humanize))
 ;{:tags #{["should be keyword"]}
 ; :address {:city ["missing required key"]
 ;           :lonlat [nil ["should be double"]]}}
@@ -189,8 +188,7 @@ Error messages can be customized with `:error/message` and `:error/fn` propertie
             '(fn [x] (and (int? x) (> x 18)))]]]
     (m/explain {:size "XL", :age 10})
     (me/humanize
-      {:wrap :message
-       :errors (-> me/default-errors
+      {:errors (-> me/default-errors
                    (assoc ::m/missing-key {:error/fn (fn [{:keys [in]} _] (str "missing key " (last in)))}))}))
 ;{:id ["missing key :id"]
 ; :size ["should be: S|M|L"]
@@ -211,7 +209,6 @@ Messages can be localized:
     (m/explain {:size "XL", :age 10})
     (me/humanize
       {:locale :fi
-       :wrap :message
        :errors (-> me/default-errors
                    (assoc-in ['int? :error-message :fi] "pitäisi olla numero")
                    (assoc ::m/missing-key {:error/fn {:en '(fn [{:keys [in]} _] (str "missing key " (last in)))
@@ -232,7 +229,7 @@ Top-level humanized map-errors are under `:malli/error`:
          (= password password2))]]
     (m/explain {:password "secret"
                 :password2 "faarao"})
-    (me/humanize {:wrap :message}))
+    (me/humanize))
 ; {:malli/error ["passwords don't match"]}
 ```
 
@@ -248,7 +245,7 @@ Errors can be targetted using `:error/path` property:
          (= password password2))]]
     (m/explain {:password "secret"
                 :password2 "faarao"})
-    (me/humanize {:wrap :message}))
+    (me/humanize))
 ; {:password2 ["passwords don't match"]}
 ```
 

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -130,7 +130,7 @@
 (defn humanize
   ([explanation]
    (humanize explanation nil))
-  ([{:keys [value errors]} {f :wrap :or {f identity} :as opts}]
+  ([{:keys [value errors]} {f :wrap :or {f :message} :as opts}]
    (if errors
      (if (coll? value)
        (reduce

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -5,6 +5,7 @@
   {::unknown {:error/message {:en "unknown error"}}
    ::m/missing-key {:error/message {:en "missing required key"}}
    ::m/invalid-type {:error/message {:en "invalid type"}}
+   ::m/extra-key {:error/message {:en "disallowed key"}}
    'any? {:error/message {:en "should be any"}}
    'some? {:error/message {:en "shoud be some"}}
    'number? {:error/message {:en "should be number"}}

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -76,6 +76,12 @@
                  {:data [{:x ["1" 2 "3"]} {:x ["1" 2 "3"]} {:x [1]} {:x ["1"]} {:x [1]}]})
                (me/humanize {:wrap :message})))))
 
+  (testing "disallowed keys in closed maps"
+    (is (= {:extra ["disallowed key"]}
+           (-> [:map {:closed true} [:x int?]]
+               (m/explain {:x 1, :extra "key"})
+               (me/humanize {:wrap :message})))))
+
   (testing "multiple errors on same key are accumulated into vector"
     (is (= {:x ["missing required key" "missing required key"]}
            (me/humanize

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -29,31 +29,31 @@
   (testing "nil if success"
     (is (nil? (-> int?
                   (m/explain 1)
-                  (me/humanize {:wrap :message})))))
+                  (me/humanize)))))
 
   (testing "top-level error"
     (is (= ["should be int"]
            (-> int?
                (m/explain "1")
-               (me/humanize {:wrap :message})))))
+               (me/humanize)))))
 
   (testing "vector"
     (is (= [nil nil [nil ["should be int"]]]
            (-> [:vector [:vector int?]]
                (m/explain [[1 2] [2 2] [3 "4"]])
-               (me/humanize {:wrap :message})))))
+               (me/humanize)))))
 
   (testing "set"
     (is (= #{#{["should be int"]}}
            (-> [:set [:set int?]]
                (m/explain #{#{1} #{"2"}})
-               (me/humanize {:wrap :message})))))
+               (me/humanize)))))
 
   (testing "invalid type"
     (is (= ["invalid type"]
            (-> [:list int?]
                (m/explain [1])
-               (me/humanize {:wrap :message})))))
+               (me/humanize)))))
 
   (testing "mixed bag"
     (is (= [nil
@@ -64,7 +64,7 @@
                  [{:x [1 2 3]}
                   {:x [1 "2" "3"]}
                   {:x #{"whatever"}}])
-               (me/humanize {:wrap :message})))))
+               (me/humanize)))))
 
   (testing "so nested"
     (is (= {:data [{:x [["should be int"] nil ["should be int"]]}
@@ -74,21 +74,20 @@
            (-> [:map [:data [:vector [:map [:x [:vector int?]]]]]]
                (m/explain
                  {:data [{:x ["1" 2 "3"]} {:x ["1" 2 "3"]} {:x [1]} {:x ["1"]} {:x [1]}]})
-               (me/humanize {:wrap :message})))))
+               (me/humanize)))))
 
   (testing "disallowed keys in closed maps"
     (is (= {:extra ["disallowed key"]}
            (-> [:map {:closed true} [:x int?]]
                (m/explain {:x 1, :extra "key"})
-               (me/humanize {:wrap :message})))))
+               (me/humanize)))))
 
   (testing "multiple errors on same key are accumulated into vector"
     (is (= {:x ["missing required key" "missing required key"]}
            (me/humanize
              {:value {},
               :errors [{:in [:x], :schema [:map [:x int?]], :type :malli.core/missing-key}
-                       {:in [:x], :schema [:map [:x int?]], :type :malli.core/missing-key}]}
-             {:wrap :message})))))
+                       {:in [:x], :schema [:map [:x int?]], :type :malli.core/missing-key}]})))))
 
 (deftest humanize-customization-test
   (let [schema [:map
@@ -112,7 +111,7 @@
               :d {:e ["missing required key"]
                   :f ["SHOULD BE ZIP"]}}
              (-> (m/explain schema value)
-                 (me/humanize {:wrap :message})))))
+                 (me/humanize)))))
 
     (testing "localization is applied, if available"
       (is (= {:a ["NUMERO"]
@@ -122,8 +121,7 @@
                   :f ["PITÄISI OLLA NUMERO"]}}
              (-> (m/explain schema value)
                  (me/humanize
-                   {:wrap :message
-                    :locale :fi
+                   {:locale :fi
                     :errors (-> me/default-errors
                                 (assoc-in ['int? :error/message :fi] "NUMERO")
                                 (assoc-in [::m/missing-key :error/message :fi] "PUUTTUVA AVAIN"))})))))))
@@ -141,7 +139,7 @@
       (is (= {:z ["should be int"], :malli/error ["(> x y)"]}
              (-> schema
                  (m/explain {:x 1 :y 2, :z "1"})
-                 (me/humanize {:wrap :message})))))
+                 (me/humanize)))))
 
     (testing ":error/path contributes to path"
       (let [schema [:and [:map
@@ -156,7 +154,7 @@
                (-> schema
                    (m/explain {:password "secret"
                                :password2 "faarao"})
-                   (me/humanize {:wrap :message})))))))
+                   (me/humanize)))))))
 
   (testing "on collections, first error wins"
     (let [schema [:and
@@ -168,15 +166,15 @@
       (is (= ["first should be positive"]
              (-> schema
                  (m/explain [-2 1])
-                 (me/humanize {:wrap :message}))))
+                 (me/humanize))))
       (is (= [nil ["should be int"]]
              (-> schema
                  (m/explain [-2 "1"])
-                 (me/humanize {:wrap :message}))))
+                 (me/humanize))))
       (is (= ["invalid type"]
              (-> schema
                  (m/explain '(-2 "1"))
-                 (me/humanize {:wrap :message}))))))
+                 (me/humanize))))))
 
   (testing "on non-collections, first error wins"
     (let [schema [:and
@@ -187,16 +185,16 @@
       (is (= ["should be >= 1"]
              (-> schema
                  (m/explain 0)
-                 (me/humanize {:wrap :message}))))
+                 (me/humanize))))
       (is (= ["should be int"]
              (-> schema
                  (m/explain "kikka")
-                 (me/humanize {:wrap :message}))))
+                 (me/humanize))))
       (is (= ["should be >= 2"]
              (-> schema
                  (m/explain 1)
-                 (me/humanize {:wrap :message}))))
+                 (me/humanize))))
       (is (= nil
              (-> schema
                  (m/explain 2)
-                 (me/humanize {:wrap :message})))))))
+                 (me/humanize)))))))


### PR DESCRIPTION
Maps are open by default:

```clj
(m/validate
  [:map [:x int?]]
  {:x 1, :extra "key"})
; => true
```

Maps can be closed with `:closed` property:

```clj
(m/validate
  [:map {:closed true} [:x int?]]
  {:x 1, :extra "key"})
; => false

(m/explain
  [:map {:closed true} [:x int?]]
  {:x 1, :extra "key"})
;{:schema [:map {:closed true} [:x int?]],
; :value {:x 1, :extra "key"},
; :errors [#Error{:path []
;                 :in [:extra]
;                 :schema [:map {:closed true} [:x int?]]
;                 :type :malli.core/extra-key}]}
```

also:

```clj
(-> [:map {:closed true} [:x int?]]
    (m/explain {:x 1, :extra "key"})
    (me/humanize))
; => {:extra ["disallowed key"]}
```