### PR TITLE
Rename opts with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,63 @@ Schema unions (merged values of both schemas are valid for union schema):
 ;            [:country [:or [:enum "finland" "poland"] string?]]]]]
 ```
 
+Updating Schema properties:
+
+```clj
+(mu/update-properties [:vector int?] assoc :min 1)
+; => [:vector {:min 1} int?]
+```
+
+Closing and opening all `:map` schemas recursively:
+
+```clj
+(def abcd
+  [:map {:title "abcd"}
+   [:a int?]
+   [:b {:optional true} int?]
+   [:c [:map
+        [:d int?]]]])
+
+(mu/closed-schema abcd)
+;[:map {:title "abcd", :closed true}
+; [:a int?]
+; [:b {:optional true} int?]
+; [:c [:map {:closed true}
+;      [:d int?]]]]
+
+(-> abcd mu/closed-schema mu/open-schema)
+;[:map {:title "abcd"}
+; [:a int?]
+; [:b {:optional true} int?]
+; [:c [:map
+;      [:d int?]]]]
+```
+
+Adding generated example values to Schemas:
+
+```clj
+(m/accept
+  [:map
+   [:name string?]
+   [:description string?]
+   [:address
+    [:map
+     [:street string?]
+     [:country [:enum "finland" "poland"]]]]]
+  (m/schema-visitor
+    (fn [schema]
+      (mu/update-properties schema assoc :examples (mg/sample schema {:size 2, :seed 20})))))
+;[:map
+; {:examples ({:name "", :description "", :address {:street "", :country "poland"}}
+;             {:name "W", :description "x", :address {:street "8", :country "finland"}})}
+; [:name [string? {:examples ("" "")}]]
+; [:description [string? {:examples ("" "")}]]
+; [:address
+;  [:map
+;   {:examples ({:street "", :country "finland"} {:street "W", :country "poland"})}
+;   [:street [string? {:examples ("" "")}]]
+;   [:country [:enum {:examples ("finland" "poland")} "finland" "poland"]]]]]
+```
 
 ## Persisting Schemas 
 

--- a/README.md
+++ b/README.md
@@ -662,28 +662,23 @@ Schemas can be transformed using the [Visitor Pattern](https://en.wikipedia.org/
 
 ```clj
 (defn visitor [schema children _]
-  {:name (m/name schema)
-   :properties (or (m/properties schema) {})
-   :children children})
+  (let [properties (m/properties schema)]
+    (cond-> {:name (m/name schema)}
+            (seq properties) (assoc :properties properties)
+            (seq children) (assoc :children children))))
 
 (m/accept Address visitor)
 ;{:name :map,
-; :properties {},
-; :children [{:name string?
-;             :properties {}
-;             :children []}
-;            {:name :set
-;             :properties {}
-;             :children [{:name keyword?, :properties {}, :children []}]}
-;            {:name :map,
-;             :properties {},
-;             :children [{:name string?, :properties {}, :children []}
-;                        {:name string?, :properties {}, :children []}
-;                        {:name int?, :properties {}, :children []}
-;                        {:name :tuple,
-;                         :properties {},
-;                         :children [{:name double?, :properties {}, :children []}
-;                                    {:name double?, :properties {}, :children []}]}]}]}
+; :children [[:id nil {:name string?}]
+;            [:tags nil {:name :set
+;                        :children [{:name keyword?}]}]
+;            [:address nil {:name :map,
+;                           :children [[:street nil {:name string?}]
+;                                      [:city nil {:name string?}]
+;                                      [:zip nil {:name int?}]
+;                                      [:lonlat nil {:name :tuple
+;                                                    :children [{:name double?} 
+;                                                               {:name double?}]}]]}]]}
 ```
 
 ### JSON Schema

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -275,7 +275,7 @@
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor opts]
-            (visitor this (->> entries (map last) (mapv #(-accept % visitor opts))) opts))
+            (visitor this (mapv (fn [[k p s]] [k p (-accept s visitor opts)]) entries) opts))
           (-properties [_] properties)
           (-opts [_] opts)
           (-form [_] form)
@@ -592,7 +592,7 @@
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor opts]
-            (visitor this (->> entries (map last) (mapv #(-accept % visitor opts))) opts))
+            (visitor this (mapv (fn [[k p s]] [k p (-accept s visitor opts)]) entries) opts))
           (-properties [_] properties)
           (-opts [_] opts)
           (-form [_] form))))))
@@ -669,7 +669,7 @@
    (let [schema (schema ?schema opts)
          form (-form schema)]
      (if (vector? form)
-       (->> form (drop (if (-properties schema) 2 1)))))))
+       (->> form (drop (if (seq (-properties schema)) 2 1)))))))
 
 (defn name
   ([?schema]
@@ -765,6 +765,19 @@
                                                                  'm/name name
                                                                  'm/children children
                                                                  'm/map-entries map-entries}})))
+;;
+;; Visitors
+;;
+
+(defn schema-visitor [f]
+  (fn [schema children opts]
+    (f (into-schema (name schema) (properties schema) children opts))))
+
+(defn ^:no-doc map-syntax-visitor [schema children _]
+  (let [properties (properties schema)]
+    (cond-> {:name (name schema)}
+            (seq properties) (assoc :properties properties)
+            (seq children) (assoc :children children))))
 
 ;;
 ;; registries

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -17,6 +17,7 @@
   (-transformer [this transformer method] "returns an interceptor map with :enter and :leave functions to transform the value for the given schema and method")
   (-accept [this visitor opts] "accepts the visitor to visit schema and it's children")
   (-properties [this] "returns original schema properties")
+  (-opts [this] "returns original opts")
   (-form [this] "returns original form of the schema"))
 
 (defprotocol MapSchema
@@ -98,6 +99,7 @@
             (-value-transformer transformer this method))
           (-accept [this visitor opts] (visitor this (vec children) opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] form))))))
 
 (defn fn-schema [name f]
@@ -168,6 +170,7 @@
           (-accept [this visitor opts]
             (visitor this (mapv #(-accept % visitor opts) child-schemas) opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] (create-form name properties (map -form child-schemas))))))))
 
 (defn- -properties-and-children [xs]
@@ -274,6 +277,7 @@
           (-accept [this visitor opts]
             (visitor this (->> entries (map last) (mapv #(-accept % visitor opts))) opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] form)
           MapSchema
           (-map-entries [_] entries))))))
@@ -330,6 +334,7 @@
           (-accept [this visitor opts]
             (visitor this (mapv #(-accept % visitor opts) schemas) opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] (create-form :map-of properties (mapv -form schemas))))))))
 
 (defn- -collection-schema [name fpred fwrap fempty]
@@ -383,6 +388,7 @@
                :leave (build :leave)}))
           (-accept [this visitor opts] (visitor this [(-accept schema visitor opts)] opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] form))))))
 
 (defn- -tuple-schema []
@@ -432,12 +438,13 @@
                :leave (build :leave)}))
           (-accept [this visitor opts] (visitor this (mapv #(-accept % visitor opts) schemas) opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] form))))))
 
 (defn- -enum-schema []
   ^{:type ::into-schema}
   (reify IntoSchema
-    (-into-schema [_ properties children _]
+    (-into-schema [_ properties children opts]
       (when-not (seq children)
         (fail! ::no-children {:name :enum, :properties properties}))
       (let [schema (set children)
@@ -454,12 +461,13 @@
             (-value-transformer transformer this method))
           (-accept [this visitor opts] (visitor this (vec children) opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] (create-form :enum properties children)))))))
 
 (defn- -re-schema [class?]
   ^{:type ::into-schema}
   (reify IntoSchema
-    (-into-schema [_ properties [child :as children] _]
+    (-into-schema [_ properties [child :as children] opts]
       (when-not (= 1 (count children))
         (fail! ::child-error {:name :re, :properties properties, :children children, :min 1, :max 1}))
       (let [re (re-pattern child)
@@ -481,12 +489,13 @@
             (-value-transformer transformer this method))
           (-accept [this visitor opts] (visitor this [] opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] form))))))
 
 (defn- -fn-schema []
   ^{:type ::into-schema}
   (reify IntoSchema
-    (-into-schema [_ properties children _]
+    (-into-schema [_ properties children opts]
       (when-not (= 1 (count children))
         (fail! ::child-error {:name :fn, :properties properties, :children children, :min 1, :max 1}))
       (let [f (eval (first children))
@@ -507,6 +516,7 @@
             (-value-transformer transformer this method))
           (-accept [this visitor opts] (visitor this [] opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] (create-form :fn properties children)))))))
 
 (defn- -maybe-schema []
@@ -538,6 +548,7 @@
                :leave (build :leave)}))
           (-accept [this visitor opts] (visitor this [(-accept schema' visitor opts)] opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] form))))))
 
 (defn- -multi-schema []
@@ -583,6 +594,7 @@
           (-accept [this visitor opts]
             (visitor this (->> entries (map last) (mapv #(-accept % visitor opts))) opts))
           (-properties [_] properties)
+          (-opts [_] opts)
           (-form [_] form))))))
 
 (defn- -register [registry k schema]
@@ -643,6 +655,12 @@
    (properties ?schema nil))
   ([?schema opts]
    (-properties (schema ?schema opts))))
+
+(defn opts
+  ([?schema]
+   (opts ?schema nil))
+  ([?schema opts]
+   (-opts (schema ?schema opts))))
 
 (defn children
   ([?schema]

--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -6,11 +6,11 @@
 (defn write-string
   ([?schema]
    (write-string ?schema nil))
-  ([?schema opts]
-   (pr-str (m/form ?schema opts))))
+  ([?schema options]
+   (pr-str (m/form ?schema options))))
 
 (defn read-string
   ([form]
    (read-string form nil))
-  ([form opts]
-   (m/schema (edamame/parse-string form {:dispatch {\# {\" #(re-pattern %)}}}) opts)))
+  ([form options]
+   (m/schema (edamame/parse-string form {:dispatch {\# {\" #(re-pattern %)}}}) options)))

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -54,8 +54,8 @@
 (defn- -maybe-localized [x locale]
   (if (map? x) (get x locale) x))
 
-(defn- -message [error x locale opts]
-  (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn) error opts))
+(defn- -message [error x locale options]
+  (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn) error options))
       (-maybe-localized (:error/message x) locale)))
 
 (defn- -ensure [x k]
@@ -96,8 +96,8 @@
 (defn error-path
   ([error]
    (error-path error nil))
-  ([error opts]
-   (into (:in error) (-path error opts))))
+  ([error options]
+   (into (:in error) (-path error options))))
 
 (defn error-message
   ([error]
@@ -105,36 +105,36 @@
   ([{:keys [schema type] :as error}
     {:keys [errors locale default-locale]
      :or {errors default-errors
-          default-locale :en} :as opts}]
-   (or (-message error (m/properties schema) locale opts)
-       (-message error (errors (m/name schema)) locale opts)
-       (-message error (errors type) locale opts)
-       (-message error (m/properties schema) default-locale opts)
-       (-message error (errors (m/name schema)) default-locale opts)
-       (-message error (errors type) default-locale opts)
-       (-message error (errors ::unknown) locale opts)
-       (-message error (errors ::unknown) default-locale opts))))
+          default-locale :en} :as options}]
+   (or (-message error (m/properties schema) locale options)
+       (-message error (errors (m/name schema)) locale options)
+       (-message error (errors type) locale options)
+       (-message error (m/properties schema) default-locale options)
+       (-message error (errors (m/name schema)) default-locale options)
+       (-message error (errors type) default-locale options)
+       (-message error (errors ::unknown) locale options)
+       (-message error (errors ::unknown) default-locale options))))
 
 (defn with-error-message
   ([error]
    (with-error-message error nil))
-  ([error opts]
-   (assoc error :message (error-message error opts))))
+  ([error options]
+   (assoc error :message (error-message error options))))
 
 (defn with-error-messages
   ([explanation]
    (with-error-messages explanation nil))
-  ([explanation {f :wrap :or {f identity} :as opts}]
-   (update explanation :errors (partial map #(f (with-error-message % opts))))))
+  ([explanation {f :wrap :or {f identity} :as options}]
+   (update explanation :errors (partial map #(f (with-error-message % options))))))
 
 (defn humanize
   ([explanation]
    (humanize explanation nil))
-  ([{:keys [value errors]} {f :wrap :or {f :message} :as opts}]
+  ([{:keys [value errors]} {f :wrap :or {f :message} :as options}]
    (if errors
      (if (coll? value)
        (reduce
          (fn [acc error]
-           (-assoc-in acc value (error-path error opts) [(f (with-error-message error opts))]))
+           (-assoc-in acc value (error-path error options) [(f (with-error-message error options))]))
          nil errors)
-       [(f (with-error-message (first errors) opts))]))))
+       [(f (with-error-message (first errors) options))]))))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -69,16 +69,14 @@
 (defmethod accept :or [_ _ children _] {:anyOf children})
 
 (defmethod accept :map [_ schema children _]
-  (let [entries (m/map-entries schema)
-        required (->> entries (filter (comp not :optional second)) (mapv first))
-        keys (->> entries (mapv first))]
+  (let [required (->> children (filter (comp not :optional second)) (mapv first))]
     (merge
       {:type "object"
-       :properties (apply array-map (interleave keys children))
+       :properties (apply array-map (mapcat (fn [[k _ s]] [k s]) children))
        :required required}
       (json-schema-props schema "json-schema"))))
 
-(defmethod accept :multi [_ _ children _] {:oneOf children})
+(defmethod accept :multi [_ _ children _] {:oneOf (mapv last children)})
 (defmethod accept :map-of [_ _ children _] {:type "object", :additionalProperties (second children)})
 (defmethod accept :vector [_ _ children _] {:type "array", :items (first children)})
 (defmethod accept :list [_ _ children _] {:type "array", :items (first children)})

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -10,7 +10,7 @@
 (defn json-schema-props [schema prefix]
   (as-> (m/properties schema) $ (merge (select-keys $ [:title :description :default]) (unlift-keys $ prefix))))
 
-(defmulti accept (fn [name _schema _children _opts] name) :default ::default)
+(defmulti accept (fn [name _schema _children _options] name) :default ::default)
 
 (defmethod accept ::default [_ _ _ _] {})
 (defmethod accept 'any? [_ _ _ _] {})
@@ -85,12 +85,12 @@
 (defmethod accept :enum [_ _ children _] {:enum children})
 (defmethod accept :maybe [_ _ children _] {:oneOf (conj children {:type "null"})})
 (defmethod accept :tuple [_ _ children _] {:type "array", :items children, :additionalItems false})
-(defmethod accept :re [_ schema _ opts] {:type "string", :pattern (first (m/children schema opts))})
+(defmethod accept :re [_ schema _ options] {:type "string", :pattern (first (m/children schema options))})
 (defmethod accept :fn [_ _ _ _] {})
 
-(defn- -json-schema-visitor [schema children opts]
+(defn- -json-schema-visitor [schema children options]
   (or (maybe-prefix schema :json-schema)
-      (merge (accept (m/name schema) schema children opts)
+      (merge (accept (m/name schema) schema children options)
              (json-schema-props schema "json-schema"))))
 
 ;;
@@ -100,5 +100,5 @@
 (defn transform
   ([?schema]
    (transform ?schema nil))
-  ([?schema opts]
-   (m/accept ?schema -json-schema-visitor opts)))
+  ([?schema options]
+   (m/accept ?schema -json-schema-visitor options)))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -11,7 +11,7 @@
 
 (defmethod accept :and [_ _ children _] (assoc (first children) :x-allOf children))
 (defmethod accept :or [_ _ children _] (assoc (first children) :x-anyOf children))
-(defmethod accept :multi [_ _ children _] (assoc (first children) :x-anyOf children))
+(defmethod accept :multi [_ _ children _] (let [cs (mapv last children)] (assoc (first cs) :x-anyOf cs)))
 
 (defmethod accept :maybe [_ _ children {:keys [type in]}]
   (let [k (if (and (= type :parameter) (not= in :body)) :allowEmptyValue :x-nullable)]

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -2,9 +2,9 @@
   (:require [malli.json-schema :as json-schema]
             [malli.core :as m]))
 
-(defmulti accept (fn [name _schema _children _opts] name) :default ::default)
+(defmulti accept (fn [name _schema _children _options] name) :default ::default)
 
-(defmethod accept ::default [name schema children opts] (json-schema/accept name schema children opts))
+(defmethod accept ::default [name schema children options] (json-schema/accept name schema children options))
 (defmethod accept 'float? [_ _ _ _] {:type "number" :format "float"})
 (defmethod accept 'double? [_ _ _ _] {:type "number" :format "double"})
 (defmethod accept 'nil? [_ _ _ _] {})
@@ -19,10 +19,10 @@
 
 (defmethod accept :tuple [_ _ children _] {:type "array" :items {} :x-items children})
 
-(defn- -swagger-visitor [schema children opts]
+(defn- -swagger-visitor [schema children options]
   (or (json-schema/maybe-prefix schema :swagger)
       (json-schema/maybe-prefix schema :json-schema)
-      (merge (accept (m/name schema) schema children opts)
+      (merge (accept (m/name schema) schema children options)
              (json-schema/json-schema-props schema "swagger"))))
 
 ;;
@@ -32,5 +32,5 @@
 (defn transform
   ([?schema]
    (transform ?schema nil))
-  ([?schema opts]
-   (m/accept ?schema -swagger-visitor opts)))
+  ([?schema options]
+   (m/accept ?schema -swagger-visitor options)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -20,6 +20,9 @@
 (defn entries= [& entries]
   (apply = (map (partial map #(update % 2 m/form)) entries)))
 
+(defn form= [& entries]
+  (apply = (map m/form entries)))
+
 (defn over-the-wire [?schema]
   (-> ?schema (me/write-string) (me/read-string)))
 
@@ -50,6 +53,10 @@
   (is (= :maybe (m/eval "(m/name [:maybe int?])")))
   (is (= ['int? 'string?] (m/eval "(m/children [:or {:some \"props\"} int? string?])")))
   (is (entries= [[:x nil 'int?] [:y nil 'string?]] (m/eval "(m/map-entries [:map [:x int?] [:y string?]])"))))
+
+(deftest into-schema-test
+  (is (form= [:map {:closed true} [:x int?]]
+             (m/into-schema :map {:closed true} [[:x int?]]))))
 
 (deftest validation-test
 
@@ -799,7 +806,7 @@
       (is (= true
              (m/validate schema valid)
              (m/validate schema' valid)))
-      (is (= (m/form schema) (m/form schema'))))))
+      (is (form= schema schema')))))
 
 (deftest custom-registry-test
   (let [registry (merge

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer [deftest testing is are]]
             [malli.core :as m]
             [malli.edn :as me]
-            [malli.transform :as mt]))
+            [malli.transform :as mt]
+            [malli.util :as mu]))
 
 (defn with-schema-forms [result]
   (some-> result
@@ -39,9 +40,6 @@
     [:x {:optional true} int?] {:optional true}
     [:x {:optional false} int?] {:optional false}))
 
-(defn visitor [schema children _]
-  (into [(m/name schema)] (seq children)))
-
 (deftest eval-test
   (is (= 2 ((m/eval inc) 1)))
   (is (= 2 ((m/eval 'inc) 1)))
@@ -57,6 +55,10 @@
 (deftest into-schema-test
   (is (form= [:map {:closed true} [:x int?]]
              (m/into-schema :map {:closed true} [[:x int?]]))))
+
+(deftest schema-visitor-test
+  (is (form= [:map {:closed true} [:x int?]]
+             (m/accept [:map {:closed true} [:x int?]] (m/schema-visitor identity)))))
 
 (deftest validation-test
 
@@ -94,7 +96,8 @@
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
-      (is (= ['int?] (m/accept schema visitor)))
+      (is (= {:name 'int?}
+             (m/accept schema m/map-syntax-visitor)))
 
       (is (= 'int? (m/form schema)))))
 
@@ -124,7 +127,12 @@
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
-      (is (= [:and ['int?] [:or ['pos-int?] ['neg-int?]]] (m/accept schema visitor)))
+      (is (= {:name :and
+              :children [{:name 'int?}
+                         {:name :or
+                          :children [{:name 'pos-int?}
+                                     {:name 'neg-int?}]}]}
+             (m/accept schema m/map-syntax-visitor)))
 
       (is (= [:and 'int? [:or 'pos-int? 'neg-int?]] (m/form schema))))
 
@@ -160,7 +168,8 @@
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
-      (is (= [:> 0] (m/accept schema visitor)))
+      (is (= {:name :>, :children [0]}
+             (m/accept schema m/map-syntax-visitor)))
 
       (is (= [:> 0] (m/form schema)))))
 
@@ -181,7 +190,8 @@
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
-      (is (= [:enum 1 2] (m/accept schema visitor)))
+      (is (= {:name :enum, :children [1 2]}
+             (m/accept schema m/map-syntax-visitor)))
 
       (is (= [:enum 1 2] (m/form schema)))))
 
@@ -205,7 +215,8 @@
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 
-      (is (= [:maybe ['int?]] (m/accept schema visitor)))
+      (is (= {:name :maybe, :children [{:name 'int?}]}
+             (m/accept schema m/map-syntax-visitor)))
 
       (is (= [:maybe 'int?] (m/form schema)))))
 
@@ -230,7 +241,8 @@
 
         (is (true? (m/validate (over-the-wire schema) "a.b")))
 
-        (is (= [:re] (m/accept schema visitor)))
+        (is (= {:name :re}
+               (m/accept schema m/map-syntax-visitor)))
 
         (is (= form (m/form schema))))))
 
@@ -254,7 +266,8 @@
 
         (is (true? (m/validate (over-the-wire schema) 12)))
 
-        (is (= [:fn] (m/accept schema visitor)))
+        (is (= {:name :fn, :properties {:description "number between 10 and 18"}}
+               (m/accept schema m/map-syntax-visitor)))
 
         (is (= [:fn {:description "number between 10 and 18"} fn]
                (m/form schema)))))
@@ -354,7 +367,11 @@
 
       (is (true? (m/validate (over-the-wire schema) valid)))
 
-      (is (= [:map ['boolean?] ['int?] ['string?]] (m/accept schema visitor)))
+      (is (= {:name :map
+              :children [[:x nil {:name 'boolean?}]
+                         [:y {:optional true} {:name 'int?}]
+                         [:z {:optional false} {:name 'string?}]]}
+             (m/accept schema m/map-syntax-visitor)))
 
       (is (= [:map
               [:x 'boolean?]
@@ -445,7 +462,19 @@
 
       (is (true? (m/validate (over-the-wire schema) valid1)))
 
-      (is (= [:multi [:map ['keyword?] ['int?]] [:map ['keyword?] ['string?] [:map ['keyword?]]]] (m/accept schema visitor)))
+      (is (= {:name :multi
+              :properties {:dispatch :type, :decode/string '(fn [x] (update x :type keyword))}
+              :children [[:sized nil {:name :map
+                                      :children [[:type nil {:name 'keyword?}]
+                                                 [:size nil {:name 'int?}]]}]
+                         [:human nil {:name :map
+                                      :children [[:type nil {:name 'keyword?}]
+                                                 [:name nil {:name 'string?}]
+                                                 [:address nil {:name :map
+                                                                :children [[:country nil {:name 'keyword?}]]}]]}]]}
+
+
+             (m/accept schema m/map-syntax-visitor)))
 
       (is (= [:multi
               {:dispatch :type, :decode/string '(fn [x] (update x :type keyword))}
@@ -491,7 +520,8 @@
 
     (is (true? (m/validate (over-the-wire [:map-of string? int?]) {"age" 18})))
 
-    (is (= [:map-of ['int?] ['pos-int?]] (m/accept [:map-of int? pos-int?] visitor)))
+    (is (= {:name :map-of, :children [{:name 'int?} {:name 'pos-int?}]}
+           (m/accept [:map-of int? pos-int?] m/map-syntax-visitor)))
 
     (testing "keyword keys are transformed via strings"
       (is (= {1 1} (m/decode [:map-of int? pos-int?] {:1 "1"} mt/string-transformer)))))
@@ -762,8 +792,10 @@
 
     (testing "visit"
       (doseq [name [:vector :list :sequential :set]]
-        (is (= [name ['int?]] (m/accept [name int?] visitor))))
-      (is (= [:tuple ['int?] ['int?]] (m/accept [:tuple int? int?] visitor))))))
+        (is (= {:name name, :children [{:name 'int?}]}
+               (m/accept [name int?] m/map-syntax-visitor))))
+      (is (= {:name :tuple, :children [{:name 'int?} {:name 'int?}]}
+             (m/accept [:tuple int? int?] m/map-syntax-visitor))))))
 
 (deftest path-with-properties-test
   (let [?path #(-> % :errors first :path)]
@@ -792,6 +824,7 @@
   (testing "children can be set and retrieved"
     (is (= ['int? 'pos-int?]
            (m/children [:and {:a 1} int? pos-int?])
+           (m/children [:and {} int? pos-int?])
            (m/children [:and int? pos-int?])))))
 
 (deftest opts-test

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -794,6 +794,14 @@
            (m/children [:and {:a 1} int? pos-int?])
            (m/children [:and int? pos-int?])))))
 
+(deftest opts-test
+  (testing "opts can be set and retrieved"
+    (let [opts {:tyyris "tyllero"
+                :registry m/default-registry}
+          schema (m/into-schema 'int? {} nil opts)]
+      (is (= opts
+             (m/opts schema))))))
+
 (deftest round-trip-test
   (testing "schemas can be roundtripped"
     (let [schema (m/schema

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -827,13 +827,13 @@
            (m/children [:and {} int? pos-int?])
            (m/children [:and int? pos-int?])))))
 
-(deftest opts-test
-  (testing "opts can be set and retrieved"
+(deftest options-test
+  (testing "options can be set and retrieved"
     (let [opts {:tyyris "tyllero"
                 :registry m/default-registry}
           schema (m/into-schema 'int? {} nil opts)]
       (is (= opts
-             (m/opts schema))))))
+             (m/options schema))))))
 
 (deftest round-trip-test
   (testing "schemas can be roundtripped"

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -411,8 +411,8 @@
 (deftest options-in-transformaton
   (let [schema [:and int? [any? {:decode/string '{:compile (fn [_ {::keys [increment]}] (partial + (or increment 0)))}}]]
         transformer (mt/transformer mt/string-transformer)
-        transformer1 (mt/transformer mt/string-transformer {:opts {::increment 1}})
-        transformer1000 (mt/transformer mt/string-transformer {:opts {::increment 1000}})]
+        transformer1 (mt/transformer mt/string-transformer {:options {::increment 1}})
+        transformer1000 (mt/transformer mt/string-transformer {:options {::increment 1000}})]
     (is (= 0 (m/decode schema "0" transformer)))
     (is (= 1 (m/decode schema "0" transformer1)))
     (is (= 1000 (m/decode schema "0" transformer1000)))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -1,6 +1,5 @@
 (ns malli.util-test
   (:require [clojure.test :refer [deftest testing is are]]
-            [malli.core :as m]
             [malli.util :as mu]))
 
 (deftest equals-test
@@ -104,3 +103,25 @@
         [:map [:x [:or int? string?]] [:y int?]]]
        [:body-params
         [:map [:z int?]]]]]]))
+
+(deftest update-properties-test
+  (let [schema [:and {:x 0} int?]]
+    (is (mu/equals [:and {:x 1} int?]
+                   (mu/update-properties schema update :x inc)))
+    (is (mu/equals [:and {:x 0, :joulu "loma"} int?]
+                   (mu/update-properties schema assoc :joulu "loma")))))
+
+(deftest open-closed-schema-test
+  (let [open [:map {:title "map"}
+              [:a int?]
+              [:b {:optional true} int?]
+              [:c [:map
+                   [:d int?]]]]
+        closed [:map {:title "map", :closed true}
+                [:a int?]
+                [:b {:optional true} int?]
+                [:c [:map {:closed true}
+                     [:d int?]]]]]
+
+    (is (mu/equals closed (mu/closed-schema open)))
+    (is (mu/equals open (mu/open-schema closed)))))


### PR DESCRIPTION
... since the options became part of the public api via `m/opts` => `m/options`.

This is on top of #158 