### PR TITLE
Rename :opts to :options

### DIFF
--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -6,11 +6,11 @@
 (defn write-string
   ([?schema]
    (write-string ?schema nil))
-  ([?schema opts]
-   (pr-str (m/form ?schema opts))))
+  ([?schema options]
+   (pr-str (m/form ?schema options))))
 
 (defn read-string
   ([form]
    (read-string form nil))
-  ([form opts]
-   (m/schema (edamame/parse-string form {:dispatch {\# {\" #(re-pattern %)}}}) opts)))
+  ([form options]
+   (m/schema (edamame/parse-string form {:dispatch {\# {\" #(re-pattern %)}}}) options)))

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -54,8 +54,8 @@
 (defn- -maybe-localized [x locale]
   (if (map? x) (get x locale) x))
 
-(defn- -message [error x locale opts]
-  (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn) error opts))
+(defn- -message [error x locale options]
+  (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn) error options))
       (-maybe-localized (:error/message x) locale)))
 
 (defn- -ensure [x k]
@@ -96,8 +96,8 @@
 (defn error-path
   ([error]
    (error-path error nil))
-  ([error opts]
-   (into (:in error) (-path error opts))))
+  ([error options]
+   (into (:in error) (-path error options))))
 
 (defn error-message
   ([error]
@@ -105,36 +105,36 @@
   ([{:keys [schema type] :as error}
     {:keys [errors locale default-locale]
      :or {errors default-errors
-          default-locale :en} :as opts}]
-   (or (-message error (m/properties schema) locale opts)
-       (-message error (errors (m/name schema)) locale opts)
-       (-message error (errors type) locale opts)
-       (-message error (m/properties schema) default-locale opts)
-       (-message error (errors (m/name schema)) default-locale opts)
-       (-message error (errors type) default-locale opts)
-       (-message error (errors ::unknown) locale opts)
-       (-message error (errors ::unknown) default-locale opts))))
+          default-locale :en} :as options}]
+   (or (-message error (m/properties schema) locale options)
+       (-message error (errors (m/name schema)) locale options)
+       (-message error (errors type) locale options)
+       (-message error (m/properties schema) default-locale options)
+       (-message error (errors (m/name schema)) default-locale options)
+       (-message error (errors type) default-locale options)
+       (-message error (errors ::unknown) locale options)
+       (-message error (errors ::unknown) default-locale options))))
 
 (defn with-error-message
   ([error]
    (with-error-message error nil))
-  ([error opts]
-   (assoc error :message (error-message error opts))))
+  ([error options]
+   (assoc error :message (error-message error options))))
 
 (defn with-error-messages
   ([explanation]
    (with-error-messages explanation nil))
-  ([explanation {f :wrap :or {f identity} :as opts}]
-   (update explanation :errors (partial map #(f (with-error-message % opts))))))
+  ([explanation {f :wrap :or {f identity} :as options}]
+   (update explanation :errors (partial map #(f (with-error-message % options))))))
 
 (defn humanize
   ([explanation]
    (humanize explanation nil))
-  ([{:keys [value errors]} {f :wrap :or {f :message} :as opts}]
+  ([{:keys [value errors]} {f :wrap :or {f :message} :as options}]
    (if errors
      (if (coll? value)
        (reduce
          (fn [acc error]
-           (-assoc-in acc value (error-path error opts) [(f (with-error-message error opts))]))
+           (-assoc-in acc value (error-path error options) [(f (with-error-message error options))]))
          nil errors)
-       [(f (with-error-message (first errors) opts))]))))
+       [(f (with-error-message (first errors) options))]))))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -10,7 +10,7 @@
 (defn json-schema-props [schema prefix]
   (as-> (m/properties schema) $ (merge (select-keys $ [:title :description :default]) (unlift-keys $ prefix))))
 
-(defmulti accept (fn [name _schema _children _opts] name) :default ::default)
+(defmulti accept (fn [name _schema _children _options] name) :default ::default)
 
 (defmethod accept ::default [_ _ _ _] {})
 (defmethod accept 'any? [_ _ _ _] {})
@@ -85,12 +85,12 @@
 (defmethod accept :enum [_ _ children _] {:enum children})
 (defmethod accept :maybe [_ _ children _] {:oneOf (conj children {:type "null"})})
 (defmethod accept :tuple [_ _ children _] {:type "array", :items children, :additionalItems false})
-(defmethod accept :re [_ schema _ opts] {:type "string", :pattern (first (m/children schema opts))})
+(defmethod accept :re [_ schema _ options] {:type "string", :pattern (first (m/children schema options))})
 (defmethod accept :fn [_ _ _ _] {})
 
-(defn- -json-schema-visitor [schema children opts]
+(defn- -json-schema-visitor [schema children options]
   (or (maybe-prefix schema :json-schema)
-      (merge (accept (m/name schema) schema children opts)
+      (merge (accept (m/name schema) schema children options)
              (json-schema-props schema "json-schema"))))
 
 ;;
@@ -100,5 +100,5 @@
 (defn transform
   ([?schema]
    (transform ?schema nil))
-  ([?schema opts]
-   (m/accept ?schema -json-schema-visitor opts)))
+  ([?schema options]
+   (m/accept ?schema -json-schema-visitor options)))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -2,9 +2,9 @@
   (:require [malli.json-schema :as json-schema]
             [malli.core :as m]))
 
-(defmulti accept (fn [name _schema _children _opts] name) :default ::default)
+(defmulti accept (fn [name _schema _children _options] name) :default ::default)
 
-(defmethod accept ::default [name schema children opts] (json-schema/accept name schema children opts))
+(defmethod accept ::default [name schema children options] (json-schema/accept name schema children options))
 (defmethod accept 'float? [_ _ _ _] {:type "number" :format "float"})
 (defmethod accept 'double? [_ _ _ _] {:type "number" :format "double"})
 (defmethod accept 'nil? [_ _ _ _] {})
@@ -19,10 +19,10 @@
 
 (defmethod accept :tuple [_ _ children _] {:type "array" :items {} :x-items children})
 
-(defn- -swagger-visitor [schema children opts]
+(defn- -swagger-visitor [schema children options]
   (or (json-schema/maybe-prefix schema :swagger)
       (json-schema/maybe-prefix schema :json-schema)
-      (merge (accept (m/name schema) schema children opts)
+      (merge (accept (m/name schema) schema children options)
              (json-schema/json-schema-props schema "swagger"))))
 
 ;;
@@ -32,5 +32,5 @@
 (defn transform
   ([?schema]
    (transform ?schema nil))
-  ([?schema opts]
-   (m/accept ?schema -swagger-visitor opts)))
+  ([?schema options]
+   (m/accept ?schema -swagger-visitor options)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -827,13 +827,13 @@
            (m/children [:and {} int? pos-int?])
            (m/children [:and int? pos-int?])))))
 
-(deftest opts-test
-  (testing "opts can be set and retrieved"
+(deftest options-test
+  (testing "options can be set and retrieved"
     (let [opts {:tyyris "tyllero"
                 :registry m/default-registry}
           schema (m/into-schema 'int? {} nil opts)]
       (is (= opts
-             (m/opts schema))))))
+             (m/options schema))))))
 
 (deftest round-trip-test
   (testing "schemas can be roundtripped"

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -411,8 +411,8 @@
 (deftest options-in-transformaton
   (let [schema [:and int? [any? {:decode/string '{:compile (fn [_ {::keys [increment]}] (partial + (or increment 0)))}}]]
         transformer (mt/transformer mt/string-transformer)
-        transformer1 (mt/transformer mt/string-transformer {:opts {::increment 1}})
-        transformer1000 (mt/transformer mt/string-transformer {:opts {::increment 1000}})]
+        transformer1 (mt/transformer mt/string-transformer {:options {::increment 1}})
+        transformer1000 (mt/transformer mt/string-transformer {:options {::increment 1000}})]
     (is (= 0 (m/decode schema "0" transformer)))
     (is (= 1 (m/decode schema "0" transformer1)))
     (is (= 1000 (m/decode schema "0" transformer1000)))))


### PR DESCRIPTION
since `m/opts` => `m/options` is part of the public api now.