### PR TITLE
Creating transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Transform map keys:
              :city "Tampere"
              :zip 33100
              :lonlat [61.4858322 23.7854658]}}
-  (mt/key-transformer name))
+  (mt/key-transformer {:decode name}))
 ;{"id" "Lillan",
 ; "tags" #{:coffee :artesan :garden},
 ; "address" {"street" "Ahlmanintie 29"

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -614,6 +614,12 @@
       (get registry ?schema)
       (some-> registry (get (type ?schema)) (-into-schema nil [?schema] options))))
 
+(defn ^:no-doc into-transformer [x]
+  (cond
+    (satisfies? Transformer x) x
+    (fn? x) (into-transformer (x))
+    :else (fail! ::invalid-transformer {:value x})))
+
 ;;
 ;; public api
 ;;
@@ -715,7 +721,7 @@
   ([?schema t]
    (decoder ?schema nil t))
   ([?schema options t]
-   (let [{:keys [enter leave]} (-transformer (schema ?schema options) t :decode options)]
+   (let [{:keys [enter leave]} (-transformer (schema ?schema options) (into-transformer t) :decode options)]
      (cond
        (and enter leave) (comp leave enter)
        (or enter leave) (or enter leave)
@@ -735,7 +741,7 @@
   ([?schema t]
    (encoder ?schema nil t))
   ([?schema options t]
-   (let [{:keys [enter leave]} (-transformer (schema ?schema options) t :encode options)]
+   (let [{:keys [enter leave]} (-transformer (schema ?schema options) (into-transformer t) :encode options)]
      (cond
        (and enter leave) (comp leave enter)
        (or enter leave) (or enter leave)

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -166,11 +166,6 @@
   (if-not (nil? x)
     (str x)))
 
-(defn number->double [x]
-  (if (number? x)
-    (double x)
-    x))
-
 (defn any->any [x] x)
 
 (defn coerce-map-keys [transform]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -94,23 +94,27 @@
       (m/options schema))))
 
 (defn closed-schema
-  "Closes all :map Schemas recursively."
+  "Closes recursively all :map schemas by adding `{:closed true}`
+  property, unless schema explicitely open with `{:closed false}`"
   [schema]
   (m/accept
     schema
     (m/schema-visitor
       (fn [schema]
-        (if (= :map (m/name schema))
+        (if (and (= :map (m/name schema))
+                 (-> schema m/properties :closed false? not))
           (update-properties schema assoc :closed true)
           schema)))))
 
 (defn open-schema
-  "Opens up all :map Schemas recursively."
+  "Closes recursively all :map schemas by removing `:closed`
+  property, unless schema explicitely open with `{:closed false}`"
   [schema]
   (m/accept
     schema
     (m/schema-visitor
       (fn [schema]
-        (if (= :map (m/name schema))
+        (if (and (= :map (m/name schema))
+                 (-> schema m/properties :closed false? not))
           (update-properties schema dissoc :closed)
           schema)))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -355,8 +355,7 @@
       (is (= {:x true, :y 1} (m/decode schema {:x true, :y 1, :a 1} mt/strip-extra-keys-transformer)))
       (is (= {:x_key true, :y_key 2} (m/decode schema {:x true, :y 2}
                                                (mt/key-transformer
-                                                 (fn [key]
-                                                   (-> key name (str "_key") keyword))))))
+                                                 {:decode #(-> % name (str "_key") keyword)}))))
 
       (is (= {:x 24}
              (m/decode

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -202,7 +202,10 @@
                               string?] ["a" "b" "c"] mt/string-transformer)))))
 
 (deftest composing-transformers
+  (is (= nil (mt/transformer nil)))
+
   (let [strict-json-transformer (mt/transformer
+                                  nil
                                   mt/strip-extra-keys-transformer
                                   mt/json-transformer
                                   {:opts {:random :opts}})]

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -201,9 +201,15 @@
     (is (= "a,b,c" (m/encode [:vector {:encode/string {:leave #(str/join "," %)}}
                               string?] ["a" "b" "c"] mt/string-transformer)))))
 
+(deftest failing-fast-with-invalid-transformers
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (mt/transformer mt/strip-extra-keys-transformer)))
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (m/decoder int? mt/strip-extra-keys-transformer))))
+
 (deftest composing-transformers
   (let [strict-json-transformer (mt/transformer
-                                  mt/strip-extra-keys-transformer
+                                  (mt/strip-extra-keys-transformer)
                                   mt/json-transformer
                                   {:opts {:random :opts}})]
 
@@ -217,29 +223,49 @@
       (is (= "kikka" (m/encode keyword? :kikka strict-json-transformer)))
       (is (= {:x "kikka"} (m/encode [:map [:x keyword?]] {:x :kikka, :y :kukka} strict-json-transformer)))))
 
-  (let [strip-extra-key-transformer (mt/transformer
-                                      mt/string-transformer
-                                      mt/strip-extra-keys-transformer
-                                      (mt/key-transformer
-                                        #(-> % name (str "_key") keyword)
-                                        #(-> % name (str "_key"))))]
+  (let [transformer (mt/transformer
+                      mt/string-transformer
+                      (mt/strip-extra-keys-transformer)
+                      (mt/key-transformer
+                        {:decode #(-> % name (str "_key") keyword)
+                         :encode #(-> % name (str "_key"))}))]
     (testing "decode"
       (is (= {:x_key 18 :y_key "john"}
              (m/decode
                [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
                {:x "18" :y "john" :a "doe"}
-               strip-extra-key-transformer))))
+               transformer))))
     (testing "encode"
       (is (= {"x_key" "18" "y_key" "john"}
              (m/encode
                [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
                {:x 18 :y "john" :a "doe"}
-               strip-extra-key-transformer))))))
+               transformer))))))
+
+(deftest strip-extra-keys-transformer-test
+  (let [strip-default (mt/strip-extra-keys-transformer)
+        strip-closed (mt/strip-extra-keys-transformer {:accept (comp :closed m/properties)})
+        strip-all (mt/strip-extra-keys-transformer {:accept (constantly true)})]
+
+    (are [expected transformer schema]
+      (is (= expected (m/decode schema {:x 1, :y 2} transformer)))
+
+      {:x 1} strip-default [:map [:x int?]]
+      {:x 1, :y 2} strip-default [:map {:closed false} [:x int?]]
+      {:x 1} strip-default [:map {:closed true} [:x int?]]
+
+      {:x 1, :y 2} strip-closed [:map [:x int?]]
+      {:x 1, :y 2} strip-closed [:map {:closed false} [:x int?]]
+      {:x 1} strip-closed [:map {:closed true} [:x int?]]
+
+      {:x 1} strip-all [:map [:x int?]]
+      {:x 1} strip-all [:map {:closed false} [:x int?]]
+      {:x 1} strip-all [:map {:closed true} [:x int?]])))
 
 (deftest key-transformer
   (let [key-transformer (mt/key-transformer
-                          #(-> % name (str "_key") keyword)
-                          #(-> % name (str "_key")))]
+                          {:decode #(-> % name (str "_key") keyword)
+                           :encode #(-> % name (str "_key"))})]
     (testing "decode"
       (is (= {:x_key 18 :y_key "john" :a_key "doe"}
              (m/decode [:map [:x int?] [:y string?] [[:opt :z] boolean?]]

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -201,15 +201,9 @@
     (is (= "a,b,c" (m/encode [:vector {:encode/string {:leave #(str/join "," %)}}
                               string?] ["a" "b" "c"] mt/string-transformer)))))
 
-(deftest failing-fast-with-invalid-transformers
-  (is (thrown? #?(:clj Exception, :cljs js/Error)
-               (mt/transformer mt/strip-extra-keys-transformer)))
-  (is (thrown? #?(:clj Exception, :cljs js/Error)
-               (m/decoder int? mt/strip-extra-keys-transformer))))
-
 (deftest composing-transformers
   (let [strict-json-transformer (mt/transformer
-                                  (mt/strip-extra-keys-transformer)
+                                  mt/strip-extra-keys-transformer
                                   mt/json-transformer
                                   {:opts {:random :opts}})]
 
@@ -225,7 +219,7 @@
 
   (let [transformer (mt/transformer
                       mt/string-transformer
-                      (mt/strip-extra-keys-transformer)
+                      mt/strip-extra-keys-transformer
                       (mt/key-transformer
                         {:decode #(-> % name (str "_key") keyword)
                          :encode #(-> % name (str "_key"))}))]

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -124,4 +124,14 @@
                      [:d int?]]]]]
 
     (is (mu/equals closed (mu/closed-schema open)))
-    (is (mu/equals open (mu/open-schema closed)))))
+    (is (mu/equals open (mu/open-schema closed))))
+
+  (testing "explicitely open maps not effected"
+    (let [schema [:map {:title "map", :closed false}
+                  [:a int?]
+                  [:b {:optional true} int?]
+                  [:c [:map {, :closed false}
+                       [:d int?]]]]]
+
+      (is (mu/equals schema (mu/closed-schema schema)))
+      (is (mu/equals schema (mu/open-schema schema))))))


### PR DESCRIPTION
* **BREAKING**: `malli.transform/key-transformer` takes options map with `:encode` & `:decode`
* **BREAKING**: all transformers are functions of `=> Transformer` or `options => Transformer`
* **BREAKING**: `malli.util/closed-schema` and `malli.util/open-schema` can be configured which `:map` schemas are effected, defaulting to everything except explicitely open `{:closed false}` schemas.
* functions expecting a Transfromer (`m/decoder`, `m/encoder`, `mt/transformer`) can automatically coerce Transformer from a 0-arity function:

The following both work:

```clj
(m/decode int? "1" mt/string-transformer)
; => 1

(m/decode int? "1" (mt/string-transformer))
; => 1
```
