### PR TITLE
Allow properties to be nil

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -145,7 +145,7 @@
                   acc explainers))))
           (-transformer [this transformer method options]
             (let [this-transformer (-value-transformer transformer this method options)
-                  child-transformers (map #(-transformer % transformer method options) child-schemas )
+                  child-transformers (map #(-transformer % transformer method options) child-schemas)
                   build (fn [phase]
                           (let [->this (phase this-transformer)
                                 ?->this (or ->this identity)
@@ -174,7 +174,7 @@
           (-form [_] (create-form name properties (map -form child-schemas))))))))
 
 (defn- -properties-and-children [xs]
-  (if (map? (first xs))
+  (if ((some-fn map? nil?) (first xs))
     [(first xs) (rest xs)]
     [nil xs]))
 
@@ -183,7 +183,7 @@
     [k p (f (schema v options))]))
 
 (defn- -parse-map-entries [children options]
-  (->> children (keep identity) (mapv #(-expand-key % options identity))))
+  (->> children (mapv #(-expand-key % options identity))))
 
 (defn ^:no-doc map-entry-forms [entries]
   (mapv (fn [[k p v]] (let [v' (-form v)] (if p [k p v'] [k v']))) entries))
@@ -628,7 +628,7 @@
   ([name properties children]
    (into-schema name properties children nil))
   ([name properties children options]
-   (-into-schema (-schema name options) properties children options)))
+   (-into-schema (-schema name options) (if (seq properties) properties) children options)))
 
 (defn schema? [x]
   (satisfies? Schema x))
@@ -640,8 +640,8 @@
    (cond
      (schema? ?schema) ?schema
      (satisfies? IntoSchema ?schema) (-into-schema ?schema nil nil options)
-     (vector? ?schema) (apply -into-schema (concat [(-schema (first ?schema) options)]
-                                                   (-properties-and-children (rest ?schema)) [options]))
+     (vector? ?schema) (apply into-schema (concat [(-schema (first ?schema) options)]
+                                                  (-properties-and-children (rest ?schema)) [options]))
      :else (or (some-> ?schema (-schema options) (schema options)) (fail! ::invalid-schema {:schema ?schema})))))
 
 (defn form

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer [deftest testing is are]]
             [malli.core :as m]
             [malli.edn :as me]
-            [malli.transform :as mt]
-            [malli.util :as mu]))
+            [malli.transform :as mt]))
 
 (defn with-schema-forms [result]
   (some-> result
@@ -820,7 +819,14 @@
     (let [properties {:title "kikka"}]
       (is (= properties
              (m/properties [:and properties int?])
-             (m/properties [int? properties]))))))
+             (m/properties [int? properties]))))
+    (is (= nil
+           (m/properties [:and {} int?])
+           (m/properties [:and nil int?])
+           (m/properties [:and int?])
+           (m/properties [:enum {} 1 2 3])
+           (m/properties [:enum nil 1 2 3])
+           (m/properties [:enum 1 2 3])))))
 
 (deftest children-test
   (testing "children can be set and retrieved"

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -187,6 +187,11 @@
       #_(is (= 1 (m/decode schema "1" mt/string-transformer)))
       #_(is (= "1" (m/decode schema "1" mt/json-transformer)))
 
+      (testing "map enums require nil properties"
+        (let [schema [:enum nil {:a 1} {:b 2}]]
+          (is (= nil (m/properties schema)))
+          (is (= [{:a 1} {:b 2}] (m/children schema)))))
+
       (is (true? (m/validate (over-the-wire schema) 1)))
 
       (is (= {:name :enum, :children [1 2]}


### PR DESCRIPTION
* Properties can be `nil` in Schema syntax
* **BREAKING**: Don't allow `nil` as child in `:map`