### PR TITLE
Visitor path in

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -407,7 +407,7 @@
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor in options]
-            (visitor this [(-accept schema visitor (conj in ::in) options)] in options))
+            (visitor this [(-accept schema visitor (conj in 0) options)] in options))
           (-properties [_] properties)
           (-options [_] options)
           (-form [_] form)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -351,8 +351,7 @@
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor in options]
-            (visitor this [#(-accept key-schema visitor in options)
-                           #(-accept value-schema visitor in options)] in options))
+            (visitor this (mapv #(-accept % visitor in options) schemas) in options))
           (-properties [_] properties)
           (-options [_] options)
           (-form [_] (create-form :map-of properties (mapv -form schemas))))))))
@@ -407,7 +406,7 @@
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor in options]
-            (visitor this [(-accept schema visitor (conj in 0) options)] in options))
+            (visitor this [(-accept schema visitor (conj in ::in) options)] in options))
           (-properties [_] properties)
           (-options [_] options)
           (-form [_] form)
@@ -462,7 +461,7 @@
                :leave (build :leave)}))
           (-accept [this visitor in options]
             (visitor this (mapv
-                            (fn [[i s]] (-accept s visitor (conj in (+ i distance)) options))
+                            (fn [[i s]] (-accept s visitor (conj in i) options))
                             (map-indexed vector schemas)) in options))
           (-properties [_] properties)
           (-options [_] options)
@@ -814,12 +813,12 @@
 ;;
 
 (defn schema-visitor [f]
-  (fn [schema children _ _ options]
+  (fn [schema children _ options]
     (f (into-schema (name schema) (properties schema) children options))))
 
-(defn ^:no-doc map-syntax-visitor [schema children in _]
+(defn ^:no-doc map-syntax-visitor [schema children _ _]
   (let [properties (properties schema)]
-    (cond-> {:name (name schema), :in in}
+    (cond-> {:name (name schema)}
             (seq properties) (assoc :properties properties)
             (seq children) (assoc :children children))))
 

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -88,7 +88,7 @@
 (defmethod accept :re [_ schema _ options] {:type "string", :pattern (first (m/children schema options))})
 (defmethod accept :fn [_ _ _ _] {})
 
-(defn- -json-schema-visitor [schema children options]
+(defn- -json-schema-visitor [schema children _in options]
   (or (maybe-prefix schema :json-schema)
       (merge (accept (m/name schema) schema children options)
              (json-schema-props schema "json-schema"))))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -19,7 +19,7 @@
 
 (defmethod accept :tuple [_ _ children _] {:type "array" :items {} :x-items children})
 
-(defn- -swagger-visitor [schema children options]
+(defn- -swagger-visitor [schema children _in options]
   (or (json-schema/maybe-prefix schema :swagger)
       (json-schema/maybe-prefix schema :json-schema)
       (merge (accept (m/name schema) schema children options)


### PR DESCRIPTION
Add `:in` arg into visitors to enable collecting the target value paths (useful in ui-generation).

```clj
(m/accept
  [:map
   [:id string?]
   [:tags [:set keyword?]]
   [:address
    [:maybe
     [:vector
      [:map
       [:street string?]
       [:lonlat [:tuple double? double?]]]]]]]
  (fn [schema children in options]
    (m/into-schema
      (m/name schema)
      (assoc (m/properties schema) :in in)
      children
      options)))
;[:map {:in []}
; [:id [string? {:in [:id]}]]
; [:tags [:set {:in [:tags]} [keyword? {:in [:tags :malli.core/in]}]]]
; [:address
;  [:maybe {:in [:address]}
;   [:vector {:in [:address]}
;    [:map {:in [:address :malli.core/in]}
;     [:street [string? {:in [:address :malli.core/in :street]}]]
;     [:lonlat
;      [:tuple {:in [:address :malli.core/in :lonlat]}
;       [double? {:in [:address :malli.core/in :lonlat 0]}]
;       [double? {:in [:address :malli.core/in :lonlat 1]}]]]]]]]]
```