### PR TITLE
Add validation for -parse-map-entries

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -192,7 +192,15 @@
   (let [[p v] (if (or (nil? ?p) (map? ?p)) [?p ?v] [nil ?p])]
     [k p (f (schema v options))]))
 
+(defn- -valid-child? [child]
+  (or (== 2 (count child))
+      (and (== 3 (count child))
+           (or (nil? (second child))
+               (map? (second child))))))
+
 (defn- -parse-map-entries [children options]
+  (when-let [children (seq (remove -valid-child? children))]
+     (fail! ::child-error {:children children}))
   (->> children (mapv #(-expand-key % options identity))))
 
 (defn ^:no-doc map-entry-forms [entries]


### PR DESCRIPTION
## Problem
I have the following (invalid) schema:

``` clojure
[:map 
 [:human/name]]
```
`:human/name` is missing the `string?` schema in this case. Resulting in the following error:

<img width="677" alt="Screenshot 2020-04-05 at 16 47 15" src="https://user-images.githubusercontent.com/629436/78501751-7366c400-775d-11ea-903e-40ce1d2fd5db.png">

This error is technically speaking correct, the schema of `:human/name` is in fact missing. It is also very misleading because the end-user might assume the _entire_ schema is missing.

## Solution

Validate the children before parsing them. Thow a new error if one or more children are invalid.

<img width="825" alt="Screenshot 2020-04-05 at 16 47 53" src="https://user-images.githubusercontent.com/629436/78501819-cfc9e380-775d-11ea-9fbb-03bcb1c23b4f.png">

## Notes

* The validation function is a bit premature, maybe you have some suggestions to improve this? We could destructure the vector in the arguments, and add a `:pre` condition? This would mean it would crash when it's not a vector though.
```clojure
(defn- -valid-child? [[k p s]]
  (and (some? k)
       (and (some? s)
            (or (map? p)
                (nil? p)))))
```
* Possibly improve the ex-info map? There isn't much data at this point to return though.
* A better name could be `-valid-map-entry?` ?