### PR TITLE
Allow specifying gen/gen and friends on map entries

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-554"}
-                               lambdaisland/kaocha-cljs {:mvn/version "0.0-59"}
+                  :extra-deps {lambdaisland/kaocha {:mvn/version "0.0-601"}
+                               lambdaisland/kaocha-cljs {:mvn/version "0.0-71"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
                                metosin/spec-tools {:mvn/version "0.10.0"}
                                metosin/schema-tools {:mvn/version "0.12.0"}

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -51,11 +51,22 @@
       (is (re-matches #"kikka_\d+" (mg/generate [:and {:gen/fmap '(partial str "kikka_")} pos-int?])))))
   (testing "gen/elements"
     (dotimes [_ 1000]
-      (#{1 2} (mg/generate [:and {:gen/elements [1 2]} int?])))
+      (is (#{1 2} (mg/generate [:and {:gen/elements [1 2]} int?]))))
     (dotimes [_ 1000]
-      (#{"1" "2"} (mg/generate [:and {:gen/elements [1 2], :gen/fmap 'str} int?]))))
+      (is (#{"1" "2"} (mg/generate [:and {:gen/elements [1 2], :gen/fmap 'str} int?])))))
   (testing "gen/gen"
     (dotimes [_ 1000]
-      (#{1 2} (mg/generate [:and {:gen/gen (gen/elements [1 2])} int?])))
+      (is (#{1 2} (mg/generate [:and {:gen/gen (gen/elements [1 2])} int?]))))
     (dotimes [_ 1000]
-      (#{"1" "2"} (mg/generate [:and {:gen/gen (gen/elements [1 2]) :gen/fmap str} int?])))))
+      (is (#{"1" "2"} (mg/generate [:and {:gen/gen (gen/elements [1 2]) :gen/fmap str} int?])))))
+
+  (testing "custom generators on map entries"
+    (testing "gen/elements"
+      (dotimes [_ 1000]
+        (is (#{{:foo 1} {:foo 2}} (mg/generate [:map [:foo {:gen/elements [1 2]} int?]])))))
+    (testing "gen/gen"
+      (dotimes [_ 1000]
+        (is (#{{:foo 100} {:foo 101}} (mg/generate [:map [:foo {:gen/gen (gen/choose 100 101)} int?]])))))
+    (testing "gen/fmap"
+      (dotimes [_ 1000]
+        (is (#{{:foo ":a"} {:foo ":b"}} (mg/generate [:map [:foo {:gen/fmap str} [:enum :a :b]]])))))))


### PR DESCRIPTION
Map entry properties are a bit different from properties on regular schemas,
which means the :gen/gen, :gen/elements and :gen/fmap don't work there the way
you might expect. This adds support for these.