### PR TITLE
#37 decode int? on cljs different from clj

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -82,7 +82,9 @@
   (if (string? x)
     (try
       #?(:clj  (Long/parseLong x)
-         :cljs (let [x' (js/parseInt x 10)]
+         :cljs (let [x' (if (re-find #"\D" (subs x 1))
+                          ##NaN
+                          (js/parseInt x 10))]
                  (if (js/isNaN x') x x')))
       (catch #?(:clj Exception, :cljs js/Error) _ x))
     x))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -97,6 +97,10 @@
   (testing "predicates"
     (testing "decode"
       (is (= 1 (m/decode int? "1" mt/string-transformer)))
+      (is (= "1abc" (m/decode int? "1abc" mt/string-transformer)))
+      (is (= "+1-2" (m/decode int? "+1-2" mt/string-transformer)))
+      (is (= 1 (m/decode int? "+1" mt/string-transformer)))
+      (is (= -1 (m/decode int? "-1" mt/string-transformer)))
       (is (= "1" (m/decode int? "1" mt/json-transformer)))
       (is (= 1.0 (m/decode double? 1 mt/json-transformer)))
       (is (= 1 (m/decode double? 1 mt/string-transformer)))


### PR DESCRIPTION
Javascript  parseInt is lenient with "+1-2" "1abc" resulting integer one.
Long/parseLong recognizes the sign at the start of the string.
So I've made a \D expression ignoring the first character and return ##Nan if it's found.
Just to be more like clojure. I think we can do this because we are parsing base 10 numbers.
The if string? already guards for string so its safe to call subs and re-find.