### PR TITLE
More correct :and and :or transformations

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -218,7 +218,7 @@
 
                               ;; decode, on the way out, we take the first transformed value that is valid
                               decode? (fn [xs]
-                                        (let [xs (mapv ?->this xs)]
+                                        (?->this
                                           (reduce-kv
                                             (fn [acc i x]
                                               (let [x' ((nth ->children i) x)]
@@ -227,16 +227,17 @@
 
                               ;; encode, on the way in, we take the first valid valud and it's index
                               (= :enter phase) (fn [x]
-                                                 (reduce-kv
-                                                   (fn [acc i v]
-                                                     (if (v x)
-                                                       (reduced [((nth ->children i) x) i]) acc))
-                                                   [x] validators))
+                                                 (let [x (?->this x)]
+                                                   (reduce-kv
+                                                     (fn [acc i v]
+                                                       (if (v x)
+                                                         (reduced [((nth ->children i) x) i]) acc))
+                                                     [x] validators)))
 
                               ;; encode, on the way out, we transform the value using the index
                               :else (fn [[x i]]
-                                      (let [x (?->this x)]
-                                        (if i ((nth ->children i) x) x))))))]
+                                      (?->this (if i ((nth ->children i) x) x))))))]
+
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor in options]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -154,15 +154,7 @@
             (let [this-transformer (-value-transformer transformer this method options)
                   child-transformers (map #(-transformer % transformer method options) child-schemas)
                   build (fn [phase]
-                          (let [->this (phase this-transformer)
-                                ?->this (or ->this identity)
-                                ->children (into [] (keep phase) child-transformers)]
-                            (if (not (seq ->children))
-                              ->this
-                              (fn [x]
-                                (reduce-kv
-                                  (fn [x' _ t] (t x'))
-                                  (?->this x) ->children)))))]
+                          (-chain phase (apply vector (phase this-transformer) (map phase child-transformers))))]
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor in options]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -125,18 +125,19 @@
         (fail! ::child-error {:name name, :properties properties, :children children, :min 1, :max 1}))
       [#(try (f % child) (catch #?(:clj Exception, :cljs js/Error) _ false)) children])))
 
-(defn- -composite-schema [name f short-circuit]
+(defn- -and-schema []
   ^{:type ::into-schema}
   (reify IntoSchema
     (-into-schema [_ properties children options]
       (when-not (seq children)
-        (fail! ::no-children {:name name, :properties properties}))
+        (fail! ::no-children {:name :and, :properties properties}))
       (let [child-schemas (mapv #(schema % options) children)
             validators (distinct (map -validator child-schemas))
-            validator (apply f validators)]
+            validator (apply every-pred validators)
+            form (create-form :and properties (map -form child-schemas))]
         ^{:type ::schema}
         (reify Schema
-          (-name [_] name)
+          (-name [_] :and)
           (-validator [_] validator)
           (-explainer [_ path]
             (let [distance (if (seq properties) 2 1)
@@ -146,7 +147,6 @@
                   (fn [acc' explainer]
                     (let [acc'' (explainer x in acc')]
                       (cond
-                        (and short-circuit (identical? acc' acc'')) (reduced acc)
                         (nil? acc'') acc'
                         :else acc'')))
                   acc explainers))))
@@ -157,31 +157,80 @@
                           (let [->this (phase this-transformer)
                                 ?->this (or ->this identity)
                                 ->children (into [] (keep phase) child-transformers)]
-                            (cond
-                              (not (seq ->children)) ->this
-                              short-circuit (fn [x]
-                                              (let [x (?->this x)]
-                                                (reduce-kv
-                                                  (fn [_ _ t]
-                                                    (let [x' (t x)]
-                                                      (if-not (identical? x' x)
-                                                        (reduced x')
-                                                        x)))
-                                                  x ->children)))
-                              :else (fn [x]
-                                      (reduce-kv
-                                        (fn [x' _ t] (t x'))
-                                        (?->this x) ->children)))))]
+                            (if (not (seq ->children))
+                              ->this
+                              (fn [x]
+                                (reduce-kv
+                                  (fn [x' _ t] (t x'))
+                                  (?->this x) ->children)))))]
               {:enter (build :enter)
                :leave (build :leave)}))
           (-accept [this visitor in options]
             (visitor this (mapv #(-accept % visitor in options) child-schemas) in options))
           (-properties [_] properties)
           (-options [_] options)
-          (-form [_] (create-form name properties (map -form child-schemas)))
+          (-form [_] form)
           LensSchema
           (-get [_ key default] (get child-schemas key default))
-          (-set [_ key value] (into-schema name properties (assoc child-schemas key value))))))))
+          (-set [_ key value] (into-schema :and properties (assoc child-schemas key value))))))))
+
+(defn- -or-schema []
+  ^{:type ::into-schema}
+  (reify IntoSchema
+    (-into-schema [_ properties children options]
+      (when-not (seq children)
+        (fail! ::no-children {:name :or, :properties properties}))
+      (let [child-schemas (mapv #(schema % options) children)
+            validators (distinct (map -validator child-schemas))
+            validator (apply some-fn validators)
+            form (create-form :or properties (map -form child-schemas))]
+        ^{:type ::schema}
+        (reify Schema
+          (-name [_] :or)
+          (-validator [_] validator)
+          (-explainer [_ path]
+            (let [distance (if (seq properties) 2 1)
+                  explainers (mapv (fn [[i c]] (-explainer c (into path [(+ i distance)]))) (map-indexed vector child-schemas))]
+              (fn explain [x in acc]
+                (reduce
+                  (fn [acc' explainer]
+                    (let [acc'' (explainer x in acc')]
+                      (cond
+                        (identical? acc' acc'') (reduced acc)
+                        (nil? acc'') acc'
+                        :else acc'')))
+                  acc explainers))))
+          (-transformer [this transformer method options]
+            (let [this-transformer (-value-transformer transformer this method options)
+                  child-transformers (map #(-transformer % transformer method options) child-schemas)
+                  build (fn [phase]
+                          (let [->this (phase this-transformer)
+                                ?->this (or ->this identity)
+                                ->children (mapv #(or (phase %) identity) child-transformers)
+                                validators (mapv -validator child-schemas)]
+                            (cond
+                              (not (seq ->children)) ->this
+                              ;; on the way in, we transforma all values into vector + the original
+                              (= :enter phase) (let [->children (conj ->children identity)]
+                                                 (fn [x] (let [x (?->this x)] (mapv #(% x) ->children))))
+                              ;; on the way out, we take the first transformed value that is valid
+                              :else (fn [xs]
+                                      (let [xs (mapv ?->this xs)]
+                                        (reduce-kv
+                                          (fn [acc i x]
+                                            (let [x' ((nth ->children i) x)]
+                                              (if ((nth validators i) x') (reduced x') acc)))
+                                          (peek xs) (pop xs)))))))]
+              {:enter (build :enter)
+               :leave (build :leave)}))
+          (-accept [this visitor in options]
+            (visitor this (mapv #(-accept % visitor in options) child-schemas) in options))
+          (-properties [_] properties)
+          (-options [_] options)
+          (-form [_] form)
+          LensSchema
+          (-get [_ key default] (get child-schemas key default))
+          (-set [_ key value] (into-schema :or properties (assoc child-schemas key value))))))))
 
 (defn- -properties-and-children [xs]
   (if ((some-fn map? nil?) (first xs))
@@ -200,7 +249,7 @@
 
 (defn- -parse-map-entries [children options]
   (when-let [children (seq (remove -valid-child? children))]
-     (fail! ::child-error {:children children}))
+    (fail! ::child-error {:children children}))
   (->> children (mapv #(-expand-key % options identity))))
 
 (defn ^:no-doc map-entry-forms [entries]
@@ -323,7 +372,8 @@
                          (fn [_ key value]
                            (or (and (key-valid? key) (value-valid? value)) (reduced false)))
                          true m))
-            distance (if (seq properties) 2 1)]
+            distance (if (seq properties) 2 1)
+            form (create-form :map-of properties (mapv -form schemas))]
         ^{:type ::schema}
         (reify Schema
           (-name [_] :map-of)
@@ -362,7 +412,7 @@
             (visitor this (mapv #(-accept % visitor in options) schemas) in options))
           (-properties [_] properties)
           (-options [_] options)
-          (-form [_] (create-form :map-of properties (mapv -form schemas))))))))
+          (-form [_] form))))))
 
 (defn- -collection-schema [name fpred fwrap fempty]
   ^{:type ::into-schema}
@@ -483,7 +533,8 @@
       (when-not (seq children)
         (fail! ::no-children {:name :enum, :properties properties}))
       (let [schema (set children)
-            validator (fn [x] (contains? schema x))]
+            validator (fn [x] (contains? schema x))
+            form (create-form :enum properties children)]
         ^{:type ::schema}
         (reify Schema
           (-name [_] :enum)
@@ -498,7 +549,7 @@
             (visitor this (vec children) in options))
           (-properties [_] properties)
           (-options [_] options)
-          (-form [_] (create-form :enum properties children)))))))
+          (-form [_] form))))))
 
 (defn- -re-schema [class?]
   ^{:type ::into-schema}
@@ -536,7 +587,8 @@
       (when-not (= 1 (count children))
         (fail! ::child-error {:name :fn, :properties properties, :children children, :min 1, :max 1}))
       (let [f (eval (first children))
-            validator (fn [x] (try (f x) (catch #?(:clj Exception, :cljs js/Error) _ false)))]
+            validator (fn [x] (try (f x) (catch #?(:clj Exception, :cljs js/Error) _ false)))
+            form (create-form :fn properties children)]
         ^{:type ::schema}
         (reify Schema
           (-name [_] :fn)
@@ -555,7 +607,7 @@
             (visitor this (vec children) in options))
           (-properties [_] properties)
           (-options [_] options)
-          (-form [_] (create-form :fn properties children)))))))
+          (-form [_] form))))))
 
 (defn- -maybe-schema []
   ^{:type ::into-schema}
@@ -856,8 +908,8 @@
        (reduce-kv -register nil)))
 
 (def base-registry
-  {:and (-composite-schema :and every-pred false)
-   :or (-composite-schema :or some-fn true)
+  {:and (-and-schema)
+   :or (-or-schema)
    :map (-map-schema)
    :map-of (-map-of-schema)
    :vector (-collection-schema :vector vector? vec [])

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -163,12 +163,10 @@
                                            :leave (fn [m] (update m :leave #(or % true)))}}
                       [:map
                        [:x keyword?]
-                       [:enter boolean?]
-                       [:leave boolean?]]
+                       [:enter boolean?]]
                       [:map
                        [:y keyword?]
-                       [:enter boolean?]
-                       [:leave boolean?]]])
+                       [:enter boolean?]]])
                    input
                    mt/string-transformer)
                  result))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -409,6 +409,17 @@
       (is (= value (m/decode schema value mt/json-transformer)))
       (is (= value (m/encode schema value mt/json-transformer)))))
 
+  (testing "encoding or shortcircuits"
+    (are [x expected]
+      (is (= expected
+             (m/encode [:or
+                        keyword?
+                        [pos-int? {:encode/string {:enter #(str "<<" %), :leave #(str % ">>")}}]
+                        int?] x mt/string-transformer)))
+
+      1 "<<1>>"
+      -1 "-1"))
+
   (let [transformer (mt/transformer
                       {:name :before}
                       mt/string-transformer

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -422,6 +422,29 @@
                 "10"
                 transformer))))
 
+  (testing "and"
+    (testing "decode"
+      (are [x expected]
+        (is (= expected
+               (m/decode [:and {:decode/string {:enter #(if (re-matches #"\d{2}" %) (str % "0") %)
+                                                :leave #(if (>= % 100) (* 10 %) %)}}
+                          int?
+                          [any? {:decode/string {:enter inc
+                                                 :leave (partial * 2)}}]]
+                         x mt/string-transformer)))
+        "1" 4
+        "11" 2220))
+    (testing "encode"
+      (are [x expected]
+        (is (= expected
+               (m/encode [:and {:encode/string {:enter #(if (> % 10) (* % 10) %)
+                                                :leave #(if (re-matches #"<<\d{3}>>" %) (str "<<" % ">>") %)}}
+                          keyword?
+                          [pos-int? {:encode/string {:enter #(str "<<" %), :leave #(str % ">>")}}]
+                          int?] x mt/string-transformer)))
+        1 "<<1>>"
+        11 "<<<<110>>>>")))
+
   (testing "or"
     (testing "decode"
       (are [x expected]


### PR DESCRIPTION
* separated implementations for `:and` and `:or`, lots of derivation
* fixes https://github.com/metosin/reitit/issues/407

# :or transformation

## decode

1. apply top-level `:enter` transformation to the value
2. transform values separately with **all** child `:enter` transformations
3. transform values separately with **all** child `:leave` transformations
4. select the first transformed value that is valid against the corresponding child validator (default result from 1)
5. apply top-level `:leave` transformation to the value


## encode

1. apply top-level `:enter` transformation to the value
2. map value with **all** child `:enter` transformations
3. map value with **all** child `:leave` transformations
4. apply top-level `:leave` transformation to the value

# :and transformation

## decode

1. apply top-level `:enter` transformation to the value
2. map value with **all** child `:enter` transformations
3. map value with **all** child `:leave` transformations
4. apply top-level `:leave` transformation to the value

## encode

1. apply top-level `:enter` transformation to the value
2. map value with **all** child `:enter` transformations
3. map value with **all** child `:leave` transformations
4. apply top-level `:leave` transformation to the value