### PR TITLE
to-map-syntax and from-map-syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ The identity visitor:
 ;   [:lonlat [:tuple double? double?]]]]]
 ```
 
-Transforming schemas into map-syntax:
+Transforming schemas into [map-syntax](#map-syntax):
 
 ```clj
 (m/accept
@@ -922,9 +922,9 @@ Full override with `:swagger` property:
 ; {:type "file"}
 ```
 
-## Map-syntax for Schemas
+## Map-syntax
 
-Schemas can converted into map-syntax (with keys `:name`, `:properties` and `:children`):
+Schemas can converted into map-syntax (with keys `:name` and optionally `:properties` and `:children`):
 
 ```clj
 (def Schema

--- a/README.md
+++ b/README.md
@@ -922,6 +922,38 @@ Full override with `:swagger` property:
 ; {:type "file"}
 ```
 
+## Map-syntax for Schemas
+
+Schemas can converted into map-syntax (with keys `:name`, `:properties` and `:children`):
+
+```clj
+(def Schema
+  [:map
+   [:id string?]
+   [:tags [:set keyword?]]
+   [:address
+    [:map
+     [:street string?]
+     [:lonlat [:tuple double? double?]]]]])
+
+(m/to-map-syntax Schema)
+;{:name :map,
+; :children [[:id nil {:name string?}]
+;            [:tags nil {:name :set
+;                        :children [{:name keyword?}]}]
+;            [:address nil {:name :map,
+;                           :children [[:street nil {:name string?}]
+;                                      [:lonlat nil {:name :tuple
+;                                                    :children [{:name double?} {:name double?}]}]]}]]}
+```
+
+... and back:
+
+```clj
+(-> Schema (m/to-map-syntax) (m/from-map-syntax) (mu/equals Schema))
+; => true
+```
+
 ## Performance
 
 Validation:

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -896,6 +896,20 @@
             (seq children) (assoc :children children))))
 
 ;;
+;; map-syntax
+;;
+
+(defn ^:no-doc to-map-syntax
+  ([?schema] (to-map-syntax ?schema nil))
+  ([?schema options] (accept ?schema map-syntax-visitor options)))
+
+(defn ^:no-doc from-map-syntax
+  ([m] (from-map-syntax m nil))
+  ([{:keys [name properties children]} options]
+   (let [<-child (if (-> children first vector?) (fn [f] #(update % 2 f)) identity)]
+     (into-schema name properties (mapv (<-child #(from-map-syntax % options)) children)))))
+
+;;
 ;; registries
 ;;
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -960,3 +960,28 @@
                    (assoc (m/properties schema) :in in)
                    children
                    options))))))
+
+(deftest to-from-maps-test
+  (let [schema [:map
+                [:id string?]
+                [:tags [:set keyword?]]
+                [:address
+                 [:vector
+                  [:map
+                   [:street string?]
+                   [:lonlat [:tuple double? double?]]]]]]]
+
+    (testing "to-map-syntax"
+      (is (= {:name :map,
+              :children [[:id nil {:name 'string?}]
+                         [:tags nil {:name :set
+                                     :children [{:name 'keyword?}]}]
+                         [:address nil {:name :vector,
+                                        :children [{:name :map,
+                                                    :children [[:street nil {:name 'string?}]
+                                                               [:lonlat nil {:name :tuple
+                                                                             :children [{:name 'double?} {:name 'double?}]}]]}]}]]}
+             (m/to-map-syntax schema))))
+
+    (testing "from-map-syntax"
+      (is (true? (mu/equals schema (-> schema (m/to-map-syntax) (m/from-map-syntax))))))))


### PR DESCRIPTION
## Map-syntax

Schemas can converted into map-syntax (with keys `:name` and optionally `:properties` and `:children`):

```clj
(def Schema
  [:map
   [:id string?]
   [:tags [:set keyword?]]
   [:address
    [:map
     [:street string?]
     [:lonlat [:tuple double? double?]]]]])

(m/to-map-syntax Schema)
;{:name :map,
; :children [[:id nil {:name string?}]
;            [:tags nil {:name :set
;                        :children [{:name keyword?}]}]
;            [:address nil {:name :map,
;                           :children [[:street nil {:name string?}]
;                                      [:lonlat nil {:name :tuple
;                                                    :children [{:name double?} {:name double?}]}]]}]]}
```

... and back:

```clj
(-> Schema (m/to-map-syntax) (m/from-map-syntax) (mu/equals Schema))
; => true
```