### PR TITLE
Protocol Extensions

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -1,13 +1,16 @@
 (ns malli.generator
   (:require [clojure.test.check.generators :as gen]
-            [com.gfredericks.test.chuck.generators :as gen2]
+            #?(:clj [com.gfredericks.test.chuck.generators :as gen2])
+            #?(:clj [clojure.string :as str])
             [clojure.test.check.random :as random]
             [clojure.test.check.rose-tree :as rose]
             [clojure.spec.gen.alpha :as ga]
-            [malli.core :as m]
-            [clojure.string :as str]))
+            [malli.core :as m]))
 
 (declare generator)
+
+(defprotocol Generator
+  (-generator [this] "returns generator for schema"))
 
 (defn- -random [seed] (if seed (random/make-random seed) (random/make-random)))
 
@@ -63,35 +66,34 @@
 ;; generators
 ;;
 
-(defmulti -generator (fn [schema options] (m/name schema options)) :default ::default)
+(defmulti -schema-generator (fn [schema options] (m/name schema options)) :default ::default)
 
-(defmethod -generator ::default [schema options] (ga/gen-for-pred (m/validator schema options)))
+(defmethod -schema-generator ::default [schema options] (ga/gen-for-pred (m/validator schema options)))
 
-(defmethod -generator :> [schema options] (-double-gen {:min (-> schema (m/children options) first inc)}))
-(defmethod -generator :>= [schema options] (-double-gen {:min (-> schema (m/children options) first)}))
-(defmethod -generator :< [schema options] (-double-gen {:max (-> schema (m/children options) first dec)}))
-(defmethod -generator :<= [schema options] (-double-gen {:max (-> schema (m/children options) first)}))
-(defmethod -generator := [schema options] (gen/return (first (m/children schema options))))
-(defmethod -generator :not= [schema options] (gen/such-that (partial not= (-> schema (m/children options) first)) gen/any-printable 100))
+(defmethod -schema-generator :> [schema options] (-double-gen {:min (-> schema (m/children options) first inc)}))
+(defmethod -schema-generator :>= [schema options] (-double-gen {:min (-> schema (m/children options) first)}))
+(defmethod -schema-generator :< [schema options] (-double-gen {:max (-> schema (m/children options) first dec)}))
+(defmethod -schema-generator :<= [schema options] (-double-gen {:max (-> schema (m/children options) first)}))
+(defmethod -schema-generator := [schema options] (gen/return (first (m/children schema options))))
+(defmethod -schema-generator :not= [schema options] (gen/such-that (partial not= (-> schema (m/children options) first)) gen/any-printable 100))
 
-(defmethod -generator :and [schema options] (gen/such-that (m/validator schema options) (-> schema (m/children options) first (generator options)) 100))
-(defmethod -generator :or [schema options] (gen/one-of (mapv #(generator % options) (m/children schema options))))
-(defmethod -generator :map [schema options] (-map-gen schema options))
-(defmethod -generator :map-of [schema options] (-map-of-gen schema options))
-(defmethod -generator :multi [schema options] (gen/one-of (mapv #(generator (second %) options) (m/children schema options))))
-(defmethod -generator :vector [schema options] (-coll-gen schema identity options))
-(defmethod -generator :list [schema options] (-coll-gen schema (partial apply list) options))
-(defmethod -generator :sequential [schema options] (-coll-gen schema identity options))
-(defmethod -generator :set [schema options] (-coll-distict-gen schema set options))
-(defmethod -generator :enum [schema options] (gen/elements (m/children schema options)))
-(defmethod -generator :maybe [schema options] (gen/one-of [(gen/return nil) (-> schema (m/children options) first (generator options))]))
-(defmethod -generator :tuple [schema options] (apply gen/tuple (mapv #(generator % options) (m/children schema options))))
-#?(:clj (defmethod -generator :re [schema options] (-re-gen schema options)))
-(defmethod -generator :string [schema options] (-string-gen schema options))
+(defmethod -schema-generator :and [schema options] (gen/such-that (m/validator schema options) (-> schema (m/children options) first (generator options)) 100))
+(defmethod -schema-generator :or [schema options] (gen/one-of (mapv #(generator % options) (m/children schema options))))
+(defmethod -schema-generator :map [schema options] (-map-gen schema options))
+(defmethod -schema-generator :map-of [schema options] (-map-of-gen schema options))
+(defmethod -schema-generator :multi [schema options] (gen/one-of (mapv #(generator (second %) options) (m/children schema options))))
+(defmethod -schema-generator :vector [schema options] (-coll-gen schema identity options))
+(defmethod -schema-generator :list [schema options] (-coll-gen schema (partial apply list) options))
+(defmethod -schema-generator :sequential [schema options] (-coll-gen schema identity options))
+(defmethod -schema-generator :set [schema options] (-coll-distict-gen schema set options))
+(defmethod -schema-generator :enum [schema options] (gen/elements (m/children schema options)))
+(defmethod -schema-generator :maybe [schema options] (gen/one-of [(gen/return nil) (-> schema (m/children options) first (generator options))]))
+(defmethod -schema-generator :tuple [schema options] (apply gen/tuple (mapv #(generator % options) (m/children schema options))))
+#?(:clj (defmethod -schema-generator :re [schema options] (-re-gen schema options)))
 
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (m/properties schema options)
-        gen (or gen (when-not elements (-generator schema options)))
+        gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema) (-schema-generator schema options))))
         elements (when elements (gen/elements elements))]
     (cond
       fmap (gen/fmap (m/eval fmap) (or elements gen (gen/return nil)))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -10,7 +10,7 @@
 (declare generator)
 
 (defprotocol Generator
-  (-generator [this] "returns generator for schema"))
+  (-generator [this options] "returns generator for schema"))
 
 (defn- -random [seed] (if seed (random/make-random seed) (random/make-random)))
 
@@ -93,7 +93,7 @@
 
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (m/properties schema options)
-        gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema) (-schema-generator schema options))))
+        gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema options) (-schema-generator schema options))))
         elements (when elements (gen/elements elements))]
     (cond
       fmap (gen/fmap (m/eval fmap) (or elements gen (gen/return nil)))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -1,7 +1,7 @@
 (ns malli.generator
   (:require [clojure.test.check.generators :as gen]
             #?(:clj [com.gfredericks.test.chuck.generators :as gen2])
-            #?(:clj [clojure.string :as str])
+            [clojure.string :as str]
             [clojure.test.check.random :as random]
             [clojure.test.check.rose-tree :as rose]
             [clojure.spec.gen.alpha :as ga]
@@ -19,11 +19,11 @@
 (defn- -string-gen [schema options]
   (let [{:keys [min max]} (m/properties schema options)]
     (cond
-      (and min (= min max)) (gen/fmap str/join (gen/vector gen/char-alphanumeric min))
-      (and min max) (gen/fmap str/join (gen/vector gen/char-alphanumeric min max))
-      min (gen/fmap str/join (gen/vector gen/char-alphanumeric min (* 2 max)))
-      max (gen/fmap str/join (gen/vector gen/char-alphanumeric 0 max))
-      :else gen/string-alpha-numeric)))
+      (and min (= min max)) (gen/fmap str/join (gen/vector gen/char min))
+      (and min max) (gen/fmap str/join (gen/vector gen/char min max))
+      min (gen/fmap str/join (gen/vector gen/char min (* 2 max)))
+      max (gen/fmap str/join (gen/vector gen/char 0 max))
+      :else gen/string)))
 
 (defn- -coll-gen [schema f options]
   (let [{:keys [min max]} (m/properties schema options)
@@ -90,6 +90,7 @@
 (defmethod -schema-generator :maybe [schema options] (gen/one-of [(gen/return nil) (-> schema (m/children options) first (generator options))]))
 (defmethod -schema-generator :tuple [schema options] (apply gen/tuple (mapv #(generator % options) (m/children schema options))))
 #?(:clj (defmethod -schema-generator :re [schema options] (-re-gen schema options)))
+(defmethod -schema-generator :string [schema options] (-string-gen schema options))
 
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (m/properties schema options)

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -2,6 +2,9 @@
   (:require [malli.core :as m]
             [clojure.set :as set]))
 
+(defprotocol JsonSchema
+  (-accept [this children options] "transforms schema to JSON Schema"))
+
 (defn unlift-keys [m ns-str]
   (reduce-kv #(if (= ns-str (namespace %2)) (assoc %1 (keyword (name %2)) %3) %1) {} m))
 
@@ -94,7 +97,9 @@
 
 (defn- -json-schema-visitor [schema children _in options]
   (or (maybe-prefix schema :json-schema)
-      (merge (accept (m/name schema) schema children options)
+      (merge (if (satisfies? JsonSchema schema)
+               (-accept schema children options)
+               (accept (m/name schema) schema children options))
              (json-schema-props schema "json-schema"))))
 
 ;;

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -11,8 +11,11 @@
 (defn maybe-prefix [schema prefix]
   (some-> schema m/properties (get prefix)))
 
+(defn schema-props [schema]
+  (select-keys (m/properties schema) [:title :description :default]))
+
 (defn json-schema-props [schema prefix]
-  (as-> (m/properties schema) $ (merge (select-keys $ [:title :description :default]) (unlift-keys $ prefix))))
+  (unlift-keys (m/properties schema) prefix))
 
 (defmulti accept (fn [name _schema _children _options] name) :default ::default)
 
@@ -97,7 +100,8 @@
 
 (defn- -json-schema-visitor [schema children _in options]
   (or (maybe-prefix schema :json-schema)
-      (merge (if (satisfies? JsonSchema schema)
+      (merge (schema-props schema)
+             (if (satisfies? JsonSchema schema)
                (-accept schema children options)
                (accept (m/name schema) schema children options))
              (json-schema-props schema "json-schema"))))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -14,6 +14,15 @@
              [[int? {:error/fn fn1}] "kikka" "should be an int, was kikka"]
              [[int? {:error/fn fn2}] "kikka" "should be an int, was kikka"]
              [[int? {:error/message msg, :error/fn fn2}] "kikka" "should be an int, was kikka"]
+             [(reify
+                m/Schema
+                (-name [_])
+                (-properties [_])
+                (-explainer [this path]
+                  (fn [value in acc]
+                    (if-not (int? value) (conj acc (m/error path in this value)) acc)))
+                me/SchemaError
+                (-error [_] {:error/message "from schema"})) "kikka" "from schema"]
              ;; via defaults
              [[int?] "kikka" "should be an int" {:errors {'int? {:error/message msg}}}]
              [[int?] "kikka" "should be an int, was kikka" {:errors {'int? {:error/fn fn1}}}]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -57,12 +57,23 @@
 
   (testing "gen/elements"
     (dotimes [_ 1000]
-      (#{1 2} (mg/generate [:and {:gen/elements [1 2]} int?])))
+      (is (#{1 2} (mg/generate [:and {:gen/elements [1 2]} int?]))))
     (dotimes [_ 1000]
-      (#{"1" "2"} (mg/generate [:and {:gen/elements [1 2], :gen/fmap 'str} int?]))))
+      (is (#{"1" "2"} (mg/generate [:and {:gen/elements [1 2], :gen/fmap 'str} int?])))))
 
   (testing "gen/gen"
     (dotimes [_ 1000]
-      (#{1 2} (mg/generate [:and {:gen/gen (gen/elements [1 2])} int?])))
+      (is (#{1 2} (mg/generate [:and {:gen/gen (gen/elements [1 2])} int?]))))
     (dotimes [_ 1000]
-      (#{"1" "2"} (mg/generate [:and {:gen/gen (gen/elements [1 2]) :gen/fmap str} int?])))))
+      (is (#{"1" "2"} (mg/generate [:and {:gen/gen (gen/elements [1 2]) :gen/fmap str} int?]))))))
+
+(deftest protocol-test
+  (let [values #{1 2 3 5 8 13}
+        schema (reify
+                 m/Schema
+                 (-validator [_] int?)
+                 (-properties [_])
+                 mg/Generator
+                 (-generator [_ _] (gen/elements values)))]
+    (dotimes [_ 1000]
+      (is (values (mg/generate schema))))))

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -59,6 +59,9 @@
    [(reify
       m/Schema
       (-properties [_])
+      (-name [_])
+      (-form [_])
+      (-validator [_] int?)
       (-accept [t v i o] (v t nil i o))
       json-schema/JsonSchema
       (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -1,6 +1,7 @@
 (ns malli.json-schema-test
   (:require [clojure.test :refer [deftest testing is are]]
-            [malli.json-schema :as json-schema]))
+            [malli.json-schema :as json-schema]
+            [malli.core :as m]))
 
 (def expectations
   [;; predicates
@@ -53,7 +54,14 @@
                               :items [{:type "string"} {:type "string"}]
                               :additionalItems false}]
    [[:re "^[a-z]+\\.[a-z]+$"] {:type "string", :pattern "^[a-z]+\\.[a-z]+$"}]
-   [[:string {:min 1, :max 4}] {:type "string", :minLength 1, :maxLenght 4}]])
+   [[:string {:min 1, :max 4}] {:type "string", :minLength 1, :maxLenght 4}]
+   ;; protocols
+   [(reify
+      m/Schema
+      (-properties [_])
+      (-accept [t v i o] (v t nil i o))
+      json-schema/JsonSchema
+      (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
 
 (deftest json-schema-test
   (doseq [[schema json-schema] expectations]

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -1,6 +1,7 @@
 (ns malli.swagger-test
   (:require [clojure.test :refer [deftest testing is are]]
-            [malli.swagger :as swagger]))
+            [malli.swagger :as swagger]
+            [malli.core :as m]))
 
 (def expectations
   [;; predicates
@@ -64,22 +65,29 @@
                               :x-items [{:type "string"}
                                         {:type "string"}]}]
    [[:re "^[a-z]+\\.[a-z]+$"] {:type "string", :pattern "^[a-z]+\\.[a-z]+$"}]
-   [[:string {:min 1, :max 4}] {:type "string", :minLength 1, :maxLenght 4}]])
+   [[:string {:min 1, :max 4}] {:type "string", :minLength 1, :maxLenght 4}]
+   ;; protocols
+   [(reify
+      m/Schema
+      (-properties [_])
+      (-accept [t v i o] (v t nil i o))
+      swagger/SwaggerSchema
+      (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
 
 (deftest swagger-test
   (doseq [[schema swagger-schema] expectations]
     (is (= swagger-schema (swagger/transform schema))))
   (testing "full override"
     (is (= {:type "file"}
-           (swagger/transform 
+           (swagger/transform
              [:map {:swagger {:type "file"}} [:file any?]])))
     (is (= {:type "file"}
-           (swagger/transform 
+           (swagger/transform
              [:map {:json-schema {:type "file"}} [:file any?]])))
     (is (= {:type "file"}
-           (swagger/transform 
+           (swagger/transform
              [:map {:swagger {:type "file"}
-           	        :json-schema {:type "file2"}} [:file any?]]))))
+                    :json-schema {:type "file2"}} [:file any?]]))))
   (testing "with properties"
     (is (= {:title "age"
             :type "integer"
@@ -91,19 +99,37 @@
              [:and {:title "age"
                     :description "blabla"
                     :default 42} int?])))
-    (is (= {:title "age"
+    (is (= {:title "age2"
             :type "integer"
             :format "int64"
-            :description "blabla"
+            :description "blabla2"
             :default 422
             :example 422
             :x-allOf [{:type "integer", :format "int64"}]}
            (swagger/transform
              [:and {:title "age"
                     :json-schema/title "age2"
-                    :json-schema/swagger "age3"
                     :description "blabla"
                     :json-schema/description "blabla2"
                     :default 42
-                    :swagger/default 422
-                    :swagger/example 422} int?])))))
+                    :json-schema/default 422
+                    :json-schema/example 422} int?])))
+    (is (= {:title "age3"
+            :type "integer"
+            :format "int64"
+            :description "blabla3"
+            :default 4222
+            :example 4222
+            :x-allOf [{:type "integer", :format "int64"}]}
+           (swagger/transform
+             [:and {:title "age"
+                    :json-schema/title "age2"
+                    :swagger/title "age3"
+                    :description "blabla"
+                    :json-schema/description "blabla2"
+                    :swagger/description "blabla3"
+                    :default 42
+                    :json-schema/default 422
+                    :swagger/default 4222
+                    :json-schema/example 422
+                    :swagger/example 4222} int?])))))


### PR DESCRIPTION
To make creating custom Schemas in user-space easier, add the following protocols:

* `malli.json-schma/JsonSchema`
* `malli.swagger/SwaggerSchema`
* `malli.generator/Generator`
* `malli.error/SchemaError`

enabling one to implement all extensions just via one reification, instead of 1-2 reification + installing new methods to various multimethods.

```
(reify
  malli.core/Schema
  ...
  malli.core/LensSchma
  ...
  malli.json-schema/JsonSchema
  ...
  malli.swagger/SwaggerSchema
  ...
  malli.generator/Generator
  ...
  malli.error/ErrorSchema
  ...)
```
