### PR TITLE
Recursive Schemas Impl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 ## UNRELEASED
 
+* ???
+  * **BREAKING:** new `-children` method in `Schema`, to return child schemas as instances (instead of just AST)
 * 17.6.2020
   * **BREAKING:** change all `malli.core/*-registy` defs into `malli.core/*-schemas` defns to enable DCE for clojurescript
 * 9.6.2020 

--- a/README.md
+++ b/README.md
@@ -724,25 +724,25 @@ Any (serializable) function can be used for `:dispatch`:
 [Local Registy](#local-registry) allows an easy way to create recursive schemas:
 
 ```clj
-(mg/generate
+(m/validate
   [:schema {:registry {::cons [:maybe [:tuple pos-int? [:ref ::cons]]]}}
    ::cons]
-  {:size 7, :seed 86})
-; => [16 [64 [26 [1 [13 nil]]]]]
+  [16 [64 [26 [1 [13 nil]]]]])
+; => true
 ```
 
-Mutual recursion works too;
+Mutual recursion works too:
 
 ```clj
-(mg/generate
+(m/validate
   [:schema {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
                        ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
    ::ping]
-  {:size 7, :seed 86})
-; => ["ping" ["pong" ["ping" ["pong" ["ping" nil]]]]]
+  ["ping" ["pong" ["ping" ["pong" ["ping" nil]]]]])
+; => true
 ```
 
-Recursion defined via nesting:
+Recursion defined via nesting, last definition wins:
 
 ```clj
 (mg/generate
@@ -1155,8 +1155,7 @@ Any schema can define a local registry using `:registry` schema property:
 
 ```clj
 (def Adult
-  [:map
-   {:registry {::age [:and int? [:> 18]]}}
+  [:map {:registry {::age [:and int? [:> 18]]}}
    [:age ::age]])
 
 (mg/generate Adult {:size 10, :seed 1})

--- a/README.md
+++ b/README.md
@@ -742,16 +742,16 @@ Mutual recursion works too:
 ; => true
 ```
 
-Recursion defined via nesting, last definition wins:
+Nested registries, last definition wins:
 
 ```clj
-(mg/generate
+(m/validate
   [:schema {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
                        ::pong any?}} ;; effectively unreachable
    [:schema {:registry {::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
     ::ping]]
-  {:size 7, :seed 86})
-; => ["ping" ["pong" ["ping" ["pong" ["ping" nil]]]]]
+  ["ping" ["pong" ["ping" ["pong" ["ping" nil]]]]])
+; => true
 ```
 
 ## Value Generation

--- a/README.md
+++ b/README.md
@@ -869,6 +869,38 @@ All samples are valid against the inferred schema:
 ; => true
 ```
 
+## Map-syntax
+
+Schemas can converted into map-syntax (with keys `:type` and optionally `:properties` and `:children`):
+
+```clj
+(def Schema
+  [:map
+   [:id string?]
+   [:tags [:set keyword?]]
+   [:address
+    [:map
+     [:street string?]
+     [:lonlat [:tuple double? double?]]]]])
+
+(m/to-map-syntax Schema)
+;{:type :map,
+; :children [[:id nil {:type string?}]
+;            [:tags nil {:type :set
+;                        :children [{:type keyword?}]}]
+;            [:address nil {:type :map,
+;                           :children [[:street nil {:type string?}]
+;                                      [:lonlat nil {:type :tuple
+;                                                    :children [{:type double?} {:type double?}]}]]}]]}
+```
+
+... and back:
+
+```clj
+(-> Schema (m/to-map-syntax) (m/from-map-syntax) (mu/equals Schema))
+; => true
+```
+
 ## Schema Transformation
 
 Schemas can be transformed using the [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern).
@@ -1012,38 +1044,6 @@ Full override with `:swagger` property:
   [:map {:swagger {:type "file"}} 
    [:file any?]])
 ; {:type "file"}
-```
-
-## Map-syntax
-
-Schemas can converted into map-syntax (with keys `:type` and optionally `:properties` and `:children`):
-
-```clj
-(def Schema
-  [:map
-   [:id string?]
-   [:tags [:set keyword?]]
-   [:address
-    [:map
-     [:street string?]
-     [:lonlat [:tuple double? double?]]]]])
-
-(m/to-map-syntax Schema)
-;{:type :map,
-; :children [[:id nil {:type string?}]
-;            [:tags nil {:type :set
-;                        :children [{:type keyword?}]}]
-;            [:address nil {:type :map,
-;                           :children [[:street nil {:type string?}]
-;                                      [:lonlat nil {:type :tuple
-;                                                    :children [{:type double?} {:type double?}]}]]}]]}
-```
-
-... and back:
-
-```clj
-(-> Schema (m/to-map-syntax) (m/from-map-syntax) (mu/equals Schema))
-; => true
 ```
 
 ## Performance

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -808,17 +808,6 @@
           RefSchema
           (-deref [_] (-ref)))))))
 
-;; TODO: not needed unless registries are introduced
-(defn- -registry-schema []
-  ^{:type ::into-schema}
-  (reify IntoSchema
-    (-into-schema [_ {local-registry :registry :as properties} [ref :as children] options]
-      (when-not (= 1 (count children))
-        (fail! ::child-error {:type :registry, :properties properties, :children children, :min 1, :max 1}))
-      (when-not local-registry
-        (fail! ::invalid-properties {:type :registry, :properties properties, :keys #{:registry}}))
-      (schema ref (update options :registry (fn [r] (mr/composite-registry local-registry (or r (registry)))))))))
-
 (defn- -register-var [registry v]
   (let [name (-> v meta :name)
         schema (fn-schema name @v)]
@@ -1070,8 +1059,7 @@
    :re (-re-schema false)
    :fn (-fn-schema)
    :string (-string-schema)
-   :ref (-ref-schema)
-   :registry (-registry-schema)})
+   :ref (-ref-schema)})
 
 (defn default-schemas []
   (merge (predicate-schemas) (class-schemas) (comparator-schemas) (base-schemas)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -732,7 +732,9 @@
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
-          (-form [_] form))))))
+          (-form [_] form)
+          MapSchema
+          (-map-entries [_] entries))))))
 
 (defn -string-schema []
   ^{:type ::into-schema}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -147,7 +147,9 @@
         (reify Schema
           (-type [_] :and)
           (-validator [_]
-            (apply every-pred (distinct (map -validator children))))
+            (let [validators (distinct (map -validator children))
+                  f (if (= 1 (count validators)) first (partial apply every-pred))]
+              (f validators)))
           (-explainer [_ path]
             (let [distance (-distance properties)
                   explainers (mapv (fn [[i c]] (-explainer c (into path [(+ i distance)]))) (map-indexed vector children))]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -817,7 +817,8 @@
   (let [registry (registry options)]
     (or (if (satisfies? IntoSchema ?schema) ?schema)
         (mr/-schema registry ?schema)
-        (some-> registry (mr/-schema (clojure.core/type ?schema)) (-into-schema nil [?schema] options)))))
+        (some-> registry (mr/-schema (clojure.core/type ?schema)) (-into-schema nil [?schema] options))
+        (fail! ::invalid-schema {:schema ?schema}))))
 
 (defn ^:no-doc into-transformer [x]
   (cond
@@ -850,7 +851,7 @@
                              schema (into-schema (-schema (first ?schema) options) p c (cond-> options ref (assoc-in [::refs id] ref)))]
                          (when ref (ref schema))
                          schema)
-     :else (or (some-> ?schema (-schema options) (schema options)) (fail! ::invalid-schema {:schema ?schema})))))
+     :else (some-> ?schema (-schema options) (schema options)))))
 
 (defn form
   ([?schema]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -148,7 +148,7 @@
           (-type [_] :and)
           (-validator [_]
             (let [validators (distinct (map -validator children))
-                  f (if (= 1 (count validators)) first (partial apply every-pred))]
+                  f (if (seq (rest validators)) (partial apply every-pred) first)]
               (f validators)))
           (-explainer [_ path]
             (let [distance (-distance properties)
@@ -190,7 +190,9 @@
         (reify Schema
           (-type [_] :or)
           (-validator [_]
-            (apply some-fn (distinct (map -validator children))))
+            (let [validators (distinct (map -validator children))
+                  f (if (seq (rest validators)) (partial apply some-fn) first)]
+              (f validators)))
           (-explainer [_ path]
             (let [distance (-distance properties)
                   explainers (mapv (fn [[i c]] (-explainer c (into path [(+ i distance)]))) (map-indexed vector children))]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -765,9 +765,9 @@
   (reify IntoSchema
     (-into-schema [_ properties [ref :as children] options]
       (when-not (= 1 (count children))
-        (fail! ::child-error {:name :ref, :properties properties, :children children, :min 1, :max 1}))
-      (let [-ref (get-in options [::refs ref])
-            -memoize (fn [f] (let [value (atom nil)] (fn [] (or @value) (reset! value (f)))))
+        (fail! ::child-error {:type :ref, :properties properties, :children children, :min 1, :max 1}))
+      (let [-memoize (fn [f] (let [value (atom nil)] (fn [] (or @value) (reset! value (f)))))
+            -ref (if-let [s (mr/-schema (registry options) ref)] (-memoize (fn [] (schema s options))) (get-in options [::refs ref]))
             form (create-form :ref properties children)]
         (when-not -ref
           (fail! ::invalid-ref {:name :ref, :ref ref, :refs (-> options ::refs keys set)}))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -55,7 +55,7 @@
 ;; impl
 ;;
 
-(declare schema into-schema eval default-registry)
+(declare schema into-schema eval registry default-registry)
 
 (defn keyword->string [x]
   (if (keyword? x)
@@ -643,7 +643,7 @@
   (reify IntoSchema
     (-into-schema [_ properties children options]
       (when-not (= 1 (count children))
-        (fail! ::child-error {:name :maybe, :properties properties, :children children, :min 1, :max 1}))
+        (fail! ::child-error {:type :maybe, :properties properties, :children children, :min 1, :max 1}))
       (let [[schema :as children] (map #(schema % options) children)
             form (create-form :maybe properties (map -form children))]
         ^{:type ::schema}

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -6,8 +6,7 @@
   (-error [this] "error data structure for the Schema"))
 
 (extend-protocol SchemaError
-  #?(:clj  Object
-     :cljs default)
+  #?(:clj Object, :cljs default)
   (-error [_]))
 
 (def default-errors

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -93,7 +93,7 @@
 (defmethod -schema-generator :string [schema options] (-string-gen schema options))
 
 ;; TODO: ref-max need to favor the non-recursive part, not to fail
-(defmethod -schema-generator :ref [schema {::keys [ref-max] :or {ref-max 10} :as options}]
+(defmethod -schema-generator :ref [schema {::keys [ref-max] :or {ref-max 50} :as options}]
   (let [ref (first (m/children schema options))
         ref-count (get-in options [::ref-count ref] 0)]
     (if (< ref-count ref-max)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -91,7 +91,7 @@
 (defmethod -schema-generator :tuple [schema options] (apply gen/tuple (mapv #(generator % options) (m/children schema options))))
 #?(:clj (defmethod -schema-generator :re [schema options] (-re-gen schema options)))
 (defmethod -schema-generator :string [schema options] (-string-gen schema options))
-(defmethod -schema-generator :ref [schema {::keys [ref-max] :or {ref-max 10} :as options}]
+(defmethod -schema-generator :ref [schema {::keys [ref-max] :or {ref-max 100} :as options}]
   (let [ref (first (m/children schema options))
         ref-count (get-in options [::ref-count ref] 0)]
     (if (< ref-count ref-max)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -7,7 +7,7 @@
             [clojure.spec.gen.alpha :as ga]
             [malli.core :as m]))
 
-(declare generator)
+(declare generator -create)
 
 (defprotocol Generator
   (-generator [this options] "returns generator for schema"))
@@ -99,6 +99,8 @@
     (if (< ref-count ref-max)
       (generator (m/-deref schema) (update-in options [::ref-count ref] (fnil inc 0)))
       (gen/fmap (fn [_] (m/fail! :ref-max-exceeded {:ref-max ref-max, :schema schema})) (gen/return nil)))))
+
+(defmethod -schema-generator :schema [schema options] (-create (m/-deref schema) options))
 
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (m/properties schema options)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -91,7 +91,9 @@
 (defmethod -schema-generator :tuple [schema options] (apply gen/tuple (mapv #(generator % options) (m/children schema options))))
 #?(:clj (defmethod -schema-generator :re [schema options] (-re-gen schema options)))
 (defmethod -schema-generator :string [schema options] (-string-gen schema options))
-(defmethod -schema-generator :ref [schema {::keys [ref-max] :or {ref-max 100} :as options}]
+
+;; TODO: ref-max need to favor the non-recursive part, not to fail
+(defmethod -schema-generator :ref [schema {::keys [ref-max] :or {ref-max 10} :as options}]
   (let [ref (first (m/children schema options))
         ref-count (get-in options [::ref-count ref] 0)]
     (if (< ref-count ref-max)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -101,6 +101,7 @@
       (gen/fmap (fn [_] (m/fail! :ref-max-exceeded {:ref-max ref-max, :schema schema})) (gen/return nil)))))
 
 (defmethod -schema-generator :schema [schema options] (-create (m/-deref schema) options))
+(defmethod -schema-generator ::m/schema [schema options] (-create (m/-deref schema) options))
 
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (m/properties schema options)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -352,8 +352,7 @@
                      {:registry (mr/composite-registry (m/default-schemas) registry)})))
 
         (is (true? (m/validate
-                     [:registry
-                      {:registry registry}
+                     [:and {:registry registry}
                       ::ping]
                      ["ping" ["pong" nil]])))))
 
@@ -379,7 +378,7 @@
         (are [type value text]
           (testing text
             (is (m/validate
-                  [:registry
+                  [:and
                    {:registry {::ping [:maybe {:id ::pong} [:tuple [:= "ping"] [:ref {:type type} ::pong]]]
                                ::pong [:maybe {:id ::ping} [:tuple [:= "pong"] [:ref {:type type} ::ping]]]}}
                    ::ping]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -682,6 +682,10 @@
 
              (m/accept schema m/map-syntax-visitor)))
 
+      (is (entries= [[:sized nil [:map [:type keyword?] [:size int?]]]
+                     [:human nil [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]]]
+                    (m/map-entries schema)))
+
       (is (= [:multi
               {:dispatch :type, :decode/string '(fn [x] (update x :type keyword))}
               [:sized [:map [:type 'keyword?] [:size 'int?]]]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -110,6 +110,8 @@
       (is (false? (m/validate schema "1")))
       (is (false? (m/validate schema [1])))
 
+      (is (= pos-int? (m/validator [:and pos-int? pos-int? pos-int?])))
+
       (is (nil? (m/explain schema 1)))
       (is (results= {:schema schema,
                      :value 0,

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -111,6 +111,7 @@
       (is (false? (m/validate schema [1])))
 
       (is (= pos-int? (m/validator [:and pos-int? pos-int? pos-int?])))
+      (is (= pos-int? (m/validator [:or pos-int? pos-int? pos-int?])))
 
       (is (nil? (m/explain schema 1)))
       (is (results= {:schema schema,

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -46,7 +46,11 @@
         [:schema {:registry {::rec [:maybe [:ref ::rec]]}} ::rec]
         [:schema {:registry {::rec [:map [:rec {:optional true} [:ref ::rec]]]}} ::rec]
         [:schema {:registry {::tuple [:tuple boolean? [:ref ::or]]
-                             ::or [:or int? ::tuple]}} ::or])))
+                             ::or [:or int? ::tuple]}} ::or]
+        [:schema {:registry {::multi
+                             [:multi {:dispatch :type}
+                              [:int [:map [:type [:= :int]] [:int int?]]]
+                              [:multi [:map [:type [:= :multi]] [:multi [:ref ::multi]]]]]}} [:ref ::multi]])))
 
   #?(:clj (testing "regex"
             (let [re #"^\d+ \d+$"]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -28,18 +28,17 @@
     (let [schema [:string {:min 1, :max 4}]]
       (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
 
-  ;; TODO: fail on cljs on maximum call stack
-  #?(:clj (testing "ref"
-            (testing "recursion"
-              (let [schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
-                            ::cons]]
-                (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
-            (testing "mutual recursion"
-              (let [schema [:schema
-                            {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
-                                        ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
-                            ::ping]]
-                (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))))
+  (testing "ref"
+    (testing "recursion"
+      (let [schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
+                    ::cons]]
+        (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
+    (testing "mutual recursion"
+      (let [schema [:schema
+                    {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
+                                ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
+                    ::ping]]
+        (is (every? (partial m/validate schema) (mg/sample schema {:size 1000}))))))
 
   #?(:clj (testing "regex"
             (let [re #"^\d+ \d+$"]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1,5 +1,5 @@
 (ns malli.generator-test
-  (:require [clojure.test :refer [deftest testing is]]
+  (:require [clojure.test :refer [deftest testing is are]]
             [clojure.test.check.generators :as gen]
             [malli.json-schema-test :as json-schema-test]
             [malli.generator :as mg]
@@ -38,7 +38,13 @@
                     {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
                                 ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
                     ::ping]]
-        (is (every? (partial m/validate schema) (mg/sample schema {:size 1000}))))))
+        (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
+    (testing "recursion limiting"
+      (are [schema]
+        (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))
+
+        [:schema {:registry {::rec [:maybe [:ref ::rec]]}} ::rec]
+        [:schema {:registry {::rec [:map [:rec {:optional true} [:ref ::rec]]]}} ::rec])))
 
   #?(:clj (testing "regex"
             (let [re #"^\d+ \d+$"]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -35,7 +35,7 @@
                              [:tuple int? [:ref :cons]]]]
                  (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
              (testing "mutual recursion"
-               (let [schema [:registry
+              (let [schema [:and
                              {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
                                          ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
                              ::ping]]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -29,17 +29,17 @@
       (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
 
   ;; TODO: fail on cljs on maximum call stack
-   #?(:clj (testing "ref"
-             (testing "local recursion"
-               (let [schema [:maybe {:id :cons}
-                             [:tuple int? [:ref :cons]]]]
-                 (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
-             (testing "mutual recursion"
-              (let [schema [:and
-                             {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
-                                         ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
-                             ::ping]]
-                 (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))))
+  #?(:clj (testing "ref"
+            (testing "recursion"
+              (let [schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
+                            ::cons]]
+                (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
+            (testing "mutual recursion"
+              (let [schema [:schema
+                            {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
+                                        ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
+                            ::ping]]
+                (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))))
 
   #?(:clj (testing "regex"
             (let [re #"^\d+ \d+$"]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -44,7 +44,9 @@
         (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))
 
         [:schema {:registry {::rec [:maybe [:ref ::rec]]}} ::rec]
-        [:schema {:registry {::rec [:map [:rec {:optional true} [:ref ::rec]]]}} ::rec])))
+        [:schema {:registry {::rec [:map [:rec {:optional true} [:ref ::rec]]]}} ::rec]
+        [:schema {:registry {::tuple [:tuple boolean? [:ref ::or]]
+                             ::or [:or int? ::tuple]}} ::or])))
 
   #?(:clj (testing "regex"
             (let [re #"^\d+ \d+$"]


### PR DESCRIPTION
Displaces impl from #117, which will remain a place to discuss & history. FIxs #20 .

* new `m/Schema` method `-children` to get child schemas instances too
* `:multi` implements `m/MapSchma`
* new `m/RefSchma` protocol with the following impls:
  * `:ref` - a lazy reference, enabling recursion
  * `:schema`, like `m/schema` (entity) but in data, eager 
  * `malli.core/schema`, eager schema (value) ref, used internally. if no properties and child is a qualified keyword, derived form from the child
* support for local `:registry` in any element
* validators, explainers etc are moved from schema creation to actual `m/Schema` methods, to support laziness
* `m/-distance` and `m/-lookup` helpers
* `m/from-map-syntax`  works with non-map child's (enums, refs)
* updated README (local registry, recursive schemas)

# TODO

* [x] `:schema` for non-lazy references (retains original information)
* [x] local recursion using `:id`
* [x] local mutual recursion using `:registy`
* [x] new element to ensure local registries as data
* [x] ambiguity rules
* [x] ensure it's done right

# Current syntax:

```clj
(testing "recursion limiting"
  (are [schema]
    (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))

    ;; maybe
    [:schema {:registry {::rec [:maybe [:ref ::rec]]}}
     ::rec]

    ;; maps
    [:schema {:registry {::rec [:map [:rec {:optional true} [:ref ::rec]]]}}
     ::rec]

    ;; or
    [:schema {:registry {::tuple [:tuple boolean? [:ref ::or]]
                         ::or [:or int? ::tuple]}}
     ::or]

    ;; multi
    [:schema {:registry {::multi
                         [:multi {:dispatch :type}
                          [:int [:map [:type [:= :int]] [:int int?]]]
                          [:multi [:map [:type [:= :multi]] [:multi [:ref ::multi]]]]]}}
     [:ref ::multi]]))
```

# Initial Syntax:

(support for local recursion removed)

<img width="592" alt="malli-rec" src="https://user-images.githubusercontent.com/567532/85326025-3812a080-b4d5-11ea-9ddd-819eb86ea810.png">



