### PR TITLE
[#203] make sci optional for smaller JS builds

### DIFF
--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-clojure -A:test -m kaocha.runner "$@"
+clojure -A:test:sci -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -27,10 +27,10 @@
                                com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.4.1"}}
                   :jvm-opts ["-server"
                              "-Xmx4096m"
-                             "-Dclojure.compiler.direct-linking=true"]}}
+                             "-Dclojure.compiler.direct-linking=true"]}
+           :sci {:extra-deps {borkdude/sci {:git/url "https://github.com/borkdude/sci"
+                                            :sha "eb97e01a5913fb81859da814ba55a25b807dd6cc"}}}}
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        borkdude/sci {:git/url "https://github.com/borkdude/sci"
-                      :sha "eb97e01a5913fb81859da814ba55a25b807dd6cc"}
         borkdude/edamame {:mvn/version "0.0.11-alpha.12"}
         org.clojure/test.check {:mvn/version "1.0.0"}
         com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,7 +1,8 @@
 (ns malli.core
   (:refer-clojure :exclude [eval type])
-  (:require [sci.core :as sci]
-            [malli.registry :as mr])
+  (:require [malli.registry :as mr]
+            #?(:clj [malli.impl.clj.dynaload :as dynaload]
+               :cljs [malli.impl.cljs.dynaload :as dynaload]))
   #?(:clj (:import (java.util.regex Pattern))))
 
 ;;
@@ -909,11 +910,12 @@
        (-map-entries schema)))))
 
 (defn ^:no-doc eval [?code]
-  (if (fn? ?code) ?code (sci/eval-string (str ?code) {:preset :termination-safe
-                                                      :bindings {'m/properties properties
-                                                                 'm/type type
-                                                                 'm/children children
-                                                                 'm/map-entries map-entries}})))
+  (if (fn? ?code) ?code (@dynaload/eval-string
+                         (str ?code) {:preset :termination-safe
+                                      :bindings {'m/properties properties
+                                                 'm/type type
+                                                 'm/children children
+                                                 'm/map-entries map-entries}})))
 ;;
 ;; Visitors
 ;;

--- a/src/malli/impl/clj/dynaload.clj
+++ b/src/malli/impl/clj/dynaload.clj
@@ -1,0 +1,33 @@
+(ns malli.impl.clj.dynaload
+  {:no-doc true})
+
+(defonce ^:private dynalock (Object.))
+
+(defmacro ^:private locking2
+  "Executes exprs in an implicit do, while holding the monitor of x.
+  Will release the monitor of x in all circumstances."
+  {:added "1.0"}
+  [x & body]
+  `(let [lockee# ~x]
+     (try
+       (let [locklocal# lockee#]
+         (monitor-enter locklocal#)
+         (try
+           ~@body
+           (finally
+             (monitor-exit locklocal#)))))))
+
+(defn dynaload
+  [s]
+  (delay
+    (let [ns (namespace s)]
+      (assert ns)
+      (locking2 dynalock
+                (require (symbol ns)))
+      (let [v (resolve s)]
+        (if v
+          @v
+          (throw (RuntimeException. (str "Var " s " is not on the classpath"))))))))
+
+(def eval-string
+  (dynaload 'sci.core/eval-string))

--- a/src/malli/impl/cljs/dynaload.cljc
+++ b/src/malli/impl/cljs/dynaload.cljc
@@ -1,0 +1,12 @@
+(ns malli.impl.cljs.dynaload)
+
+(defmacro dynaload [[_quote s]]
+  `(LazyVar.
+    (fn []
+      (if (cljs.core/exists? ~s)
+        ~(vary-meta s assoc :cljs.analyzer/no-resolve true)
+        (throw
+         (js/Error.
+          (str "Var " '~s " does not exist, "
+               (namespace '~s) " never required")))))
+    nil))

--- a/src/malli/impl/cljs/dynaload.cljs
+++ b/src/malli/impl/cljs/dynaload.cljs
@@ -1,0 +1,17 @@
+(ns malli.impl.cljs.dynaload
+  {:no-doc true}
+  (:require-macros
+   [malli.impl.cljs.dynaload :refer [dynaload]]))
+
+(deftype LazyVar [f ^:mutable cached]
+  IDeref
+  (-deref [this]
+    (if-not (nil? cached)
+      cached
+      (let [x (f)]
+        (when-not (nil? x)
+          (set! cached x))
+        x))))
+
+(def eval-string
+  (dynaload 'sci.core/eval-string))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3,7 +3,9 @@
             [malli.core :as m]
             [malli.edn :as me]
             [malli.transform :as mt]
-            [malli.util :as mu]))
+            [malli.util :as mu]
+            ;; TODO: separate tests for sci
+            [sci.core]))
 
 (defn with-schema-forms [result]
   (some-> result


### PR DESCRIPTION
This PR makes sci optional using the same mechanisms that clojure.spec uses to dynamically load test.check. Fixes #203.

- [ ] Maybe split the dynaload code out into a library so it can be used from other projects as well. With copyright notice for code borrowed from spec.
- [ ] Same mechanism can be used to make test.check optional for even smaller builds.
- [ ] The tests do pass but due to randomization in kaocha they sometimes fail. The reason is that `sci.core` has to be required first. There's probably a kaocha preloads plugin which can do this. But the tests have to be adapted to the optionality of sci anyway.

Note that sci users now have to bring in the sci dependency themselves. If they don't they will get an error message when using `malli.core/eval`.

``` clojure
$ plk -A:sci
ClojureScript 1.10.597
cljs.user=> (require '[malli.core :as m])
nil
cljs.user=> (require '[sci.core])
nil
cljs.user=> (m/validate int? "1")
false
cljs.user=>
undefined is not an object (evaluating 'malli.core.eval_string.call')
cljs.user=> (m/eval "(+ 1 2 3)")
6
```

vs.

``` clojure
$ plk
ClojureScript 1.10.597
cljs.user=> (require '[malli.core :as m])
nil
cljs.user=> (m/validate int? "1")
false
cljs.user=> (m/eval "(+ 1 2 3)")
Execution error (Error) at (<cljs repl>:1).
Var sci.core/eval-string does not exist, sci.core never required
```
