### PR TITLE
Schema Applications can use MapEntry properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 ## breaking changes in the pre-alpha era:
 
+* ????
+  * `m/children` returns 3-tuple (key, properties, schma) for `MapSchema`s
+  * `m/map-entries` is removed, `m/entries` returns 2-tuple (key, entry-schema)  
 * 4.8.2020
   * `:path` in explain is re-implemented: map keys by value, others by child index
   * `m/-walk` and `m/Walker` uses `:path`, not `:in`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 * ????
   * `m/children` returns 3-tuple (key, properties, schma) for `MapSchema`s
-  * `m/map-entries` is removed, `m/entries` returns 2-tuple (key, entry-schema)  
+  * `m/map-entries` is removed, `m/entries` returns a `MapEntry` of key & `m/-val-schema`  
 * 4.8.2020
   * `:path` in explain is re-implemented: map keys by value, others by child index
   * `m/-walk` and `m/Walker` uses `:path`, not `:in`

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -20,8 +20,8 @@ Schemas can be walked over recursively using `m/walk`:
   (fn [schema _ children options]
     ;; return nil if Schema has the property 
     (when-not (:deleteMe (m/properties schema))
-      ;; there are two syntaxes: normal and the map-entry, handle separatly
-      (let [children (if (m/map-entries schema) (filterv last children) children)]
+      ;; there are two syntaxes: normal and the entry, handle separatly
+      (let [children (if (m/entries schema) (filterv last children) children)]
         ;; create a new Schema with the updated children, or return nil
         (try (m/into-schema (m/type schema) (m/properties schema) children options)
              (catch #?(:clj Exception, :cljs js/Error) _))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -289,7 +289,8 @@
    (reify IntoSchema
      (-into-schema [_ properties children options]
        (-check-children! ::entry properties children {:min 1, :max 1})
-       (let [[schema :as children] (map #(schema % options) children)]
+       (let [[schema :as children] (map #(schema % options) children)
+             form (-create-form ::entry properties (map -form children))]
          ^{:type ::schema}
          (reify Schema
            (-type [_] ::entry)
@@ -305,7 +306,7 @@
            (-properties [_] properties)
            (-options [_] (-options schema))
            (-children [_] children)
-           (-form [_] (-form schema))
+           (-form [_] form)
            LensSchema
            (-keep [_])
            (-get [_ key default] (if (= 0 key) schema default))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -24,7 +24,7 @@
   (-form [this] "returns original form of the schema"))
 
 (defprotocol MapSchema
-  (-entries [this] "returns sequence of key-EntrySchema tuples"))
+  (-entries [this] "returns sequence of `key -val-schema` MapEntries"))
 
 (defprotocol LensSchema
   (-keep [this] "returns truthy if schema contributes to value path")

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -61,7 +61,7 @@
          sorted #(sort-by (comp str first) %)
          wrap #(str "\"" % "\"")
          label (fn [k v] (str "\"{" k "|"
-                              (or (some->> (m/map-entries v) (map (fn [[k _ s]] (str k " " (esc (m/form s))))) (str/join "\\l"))
+                              (or (some->> (m/entries v) (map (fn [[k s]] (str k " " (esc (m/form s))))) (str/join "\\l"))
                                   (esc (m/form v)))
                               "\\l}\""))
          > #(apply println %&)

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -61,7 +61,7 @@
          sorted #(sort-by (comp str first) %)
          wrap #(str "\"" % "\"")
          label (fn [k v] (str "\"{" k "|"
-                              (or (some->> (m/entries v) (map (fn [[k s]] (str k " " (esc (m/form s))))) (str/join "\\l"))
+                              (or (some->> (m/entries v) (map (fn [[k s]] (str k " " (esc (m/form (m/-deref s)))))) (str/join "\\l"))
                                   (esc (m/form v)))
                               "\\l}\""))
          > #(apply println %&)

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -221,7 +221,7 @@
            (as-> errors $
                  (mapv (fn [{:keys [schema path type] :as error}]
                          (if (= type ::m/extra-key)
-                           (let [keys (->> schema (m/map-entries) (map first) (set))
+                           (let [keys (->> schema (m/entries) (map first) (set))
                                  value (get-in (:value explanation) (butlast path))
                                  similar (-most-similar-to value (last path) keys)
                                  likely-misspelling-of (mapv (partial conj (vec (butlast path))) (vec similar))]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -76,7 +76,7 @@
 (defn -map-gen [schema options]
   (let [entries (m/map-entries schema)
         [continue options] (-recur schema options)
-        value-gen (fn [k p s] (gen/fmap (fn [v] [k v]) (generator (m/-entry-schema s p) options)))
+        value-gen (fn [k _ s] (gen/fmap (fn [v] [k v]) (generator s options)))
         gen-req (->> entries
                      (remove #(-> % second :optional))
                      (map (fn [[k p s]] (value-gen k p s)))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -71,19 +71,19 @@
   (gen/one-of (keep #(some->> (-maybe-recur % options) (generator %)) (m/children schema options))))
 
 (defn -multi-gen [schema options]
-  (gen/one-of (keep #(some->> (-maybe-recur (last %) options) (generator (last %))) (m/map-entries schema options))))
+  (gen/one-of (keep #(some->> (-maybe-recur (last %) options) (generator (last %))) (m/entries schema options))))
 
 (defn -map-gen [schema options]
-  (let [entries (m/map-entries schema)
+  (let [entries (m/entries schema)
         [continue options] (-recur schema options)
-        value-gen (fn [k _ s] (gen/fmap (fn [v] [k v]) (generator s options)))
+        value-gen (fn [k s] (gen/fmap (fn [v] [k v]) (generator s options)))
         gen-req (->> entries
-                     (remove #(-> % second :optional))
-                     (map (fn [[k p s]] (value-gen k p s)))
+                     (remove #(-> % last m/properties :optional))
+                     (map (fn [[k s]] (value-gen k s)))
                      (apply gen/tuple))
         gen-opt (->> entries
-                     (filter #(-> % second :optional))
-                     (map (fn [[k p s]] (gen/one-of (into [(gen/return nil)] (if continue [(value-gen k p s)])))))
+                     (filter #(-> % last m/properties :optional))
+                     (map (fn [[k s]] (gen/one-of (into [(gen/return nil)] (if continue [(value-gen k s)])))))
                      (apply gen/tuple))]
     (gen/fmap (fn [[req opt]] (into {} (concat req opt))) (gen/tuple gen-req gen-opt))))
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -117,7 +117,7 @@
 
 (defmethod -schema-generator :and [schema options] (gen/such-that (m/validator schema options) (-> schema (m/children options) first (generator options)) 100))
 (defmethod -schema-generator :or [schema options] (-or-gen schema options))
-(defmethod -schema-generator ::m/entry [schema options] (generator (first (m/children schema)) options))
+(defmethod -schema-generator ::m/val [schema options] (generator (first (m/children schema)) options))
 (defmethod -schema-generator :map [schema options] (-map-gen schema options))
 (defmethod -schema-generator :map-of [schema options] (-map-of-gen schema options))
 (defmethod -schema-generator :multi [schema options] (-multi-gen schema options))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -74,7 +74,7 @@
 (defmethod accept :and [_ _ children _] {:allOf children})
 (defmethod accept :or [_ _ children _] {:anyOf children})
 
-(defmethod accept ::m/entry [_ _ children _] (first children))
+(defmethod accept ::m/val [_ _ children _] (first children))
 (defmethod accept :map [_ _ children _]
   (let [required (->> children (filter (comp not :optional second)) (mapv first))]
     {:type "object"
@@ -126,4 +126,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/walk ?schema -json-schema-walker (assoc options ::m/walk-entries true))))
+   (m/walk ?schema -json-schema-walker (assoc options ::m/walk-entry-vals true))))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -74,6 +74,7 @@
 (defmethod accept :and [_ _ children _] {:allOf children})
 (defmethod accept :or [_ _ children _] {:anyOf children})
 
+(defmethod accept ::m/entry [_ _ children _] (first children))
 (defmethod accept :map [_ _ children _]
   (let [required (->> children (filter (comp not :optional second)) (mapv first))]
     {:type "object"
@@ -125,4 +126,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/walk ?schema -json-schema-walker options)))
+   (m/walk ?schema -json-schema-walker (assoc options ::m/walk-map-entries true))))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -126,4 +126,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/walk ?schema -json-schema-walker (assoc options ::m/walk-map-entries true))))
+   (m/walk ?schema -json-schema-walker (assoc options ::m/walk-entries true))))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -41,4 +41,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/walk ?schema -swagger-walker options)))
+   (m/walk ?schema -swagger-walker (assoc options ::m/walk-map-entries true))))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -41,4 +41,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/walk ?schema -swagger-walker (assoc options ::m/walk-map-entries true))))
+   (m/walk ?schema -swagger-walker (assoc options ::m/walk-entries true))))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -41,4 +41,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/walk ?schema -swagger-walker (assoc options ::m/walk-entries true))))
+   (m/walk ?schema -swagger-walker (assoc options ::m/walk-entry-vals true))))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -362,7 +362,7 @@
   ([{:keys [accept] :or {accept (comp (some-fn nil? true?) :closed m/properties)}}]
    (let [transform {:compile (fn [schema _]
                                (if (accept schema)
-                                 (if-let [ks (some->> schema m/map-entries (map first) seq set)]
+                                 (if-let [ks (some->> schema m/entries (map first) seq set)]
                                    (fn [x] (reduce (fn [acc k] (if-not (ks k) (dissoc acc k) acc)) x (keys x))))))}]
      (transformer
        {:decoders {:map transform}

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -382,8 +382,8 @@
         add-defaults {:compile (fn [schema _]
                                  (let [entries (m/map-entries schema)
                                        defaults (->> entries
-                                                     (keep (fn [[k _ v]]
-                                                             (if-some [default (get-default v)]
+                                                     (keep (fn [[k {:keys [default]} v]]
+                                                             (if-some [default (if (some? default) default (get-default v))]
                                                                [k default])))
                                                      (into {}))]
                                    (if (seq defaults)

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -380,8 +380,7 @@
                                 (if-some [default (get-default schema)]
                                   (fn [x] (if (nil? x) default x))))}
         add-defaults {:compile (fn [schema _]
-                                 (let [entries (m/map-entries schema)
-                                       defaults (->> entries
+                                 (let [defaults (->> (m/children schema)
                                                      (keep (fn [[k {:keys [default]} v]]
                                                              (if-some [default (if (some? default) default (get-default v))]
                                                                [k default])))

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -93,7 +93,7 @@
                                      (c/update :form conj e2)
                                      (c/update :keys conj k2))))
                              {:keys #{}, :form []}
-                             (mapcat m/map-entries schemas))))
+                             (mapcat m/children schemas))))
                    (m/schema options)))))))
 
 (defn union

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -188,9 +188,9 @@
 ;;
 
 (defn transform-entries
-  "Transforms map-entries with f."
+  "Transforms entries with f."
   [schema f options]
-  (m/into-schema (m/type schema) (m/properties schema) (f (m/map-entries schema options))))
+  (m/into-schema (m/type schema) (m/properties schema) (f (m/children schema options))))
 
 (defn optional-keys
   "Makes map keys optional."

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -34,23 +34,18 @@
   (is (= "abba" (m/-keyword->string "abba"))))
 
 (deftest parse-entry-syntax-test
-  (let [{:keys [children raw-entries entries forms]} (m/-parse-entry-syntax
-                                                       [[:x int?]
-                                                        ::x
-                                                        [::y {:optional true}]
-                                                        [:y {:optional true, :title "boolean"} boolean?]]
-                                                       true {:registry (merge (m/default-schemas) {::x int?, ::y int?})})]
+  (let [{:keys [children entries forms]} (m/-parse-entry-syntax
+                                           [[:x int?]
+                                            ::x
+                                            [::y {:optional true}]
+                                            [:y {:optional true, :title "boolean"} boolean?]]
+                                           true {:registry (merge (m/default-schemas) {::x int?, ::y int?})})]
     (testing "forms"
       (is (= [[:x 'int?]
               ::x
               [::y {:optional true}]
               [:y {:optional true, :title "boolean"} 'boolean?]]
              forms)))
-    (testing "raw-entries"
-      (is (entries= [[:x nil int?]
-                     [:y {:optional true, :title "int"} int?]]
-                    raw-entries))
-      (is (every? #{'int?} (->> raw-entries (map last) (map m/type)))))
     (testing "entries"
       (is (= [[:x nil 'int?]
               [::x nil ::x]
@@ -58,8 +53,11 @@
               [:y {:optional true, :title "boolean"} 'boolean?]]
              (map #(update % 2 m/form) entries))))
     (testing "children"
-      (is (= [2 2 3 3]
-             (map count children)))))
+      (is (= [[:x nil 'int?]
+              [::x nil ::x]
+              [::y {:optional true} ::y]
+              [:y {:optional true, :title "boolean"} 'boolean?]]
+             (map #(update % 2 m/form) children)))))
   (testing "duplicate keys"
     (is (thrown? #?(:clj Exception, :cljs js/Error)
                  (m/-parse-entry-syntax

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -34,18 +34,23 @@
   (is (= "abba" (m/-keyword->string "abba"))))
 
 (deftest parse-entry-syntax-test
-  (let [{:keys [children entries forms]} (m/-parse-entry-syntax
-                                           [[:x int?]
-                                            ::x
-                                            [::y {:optional true}]
-                                            [:y {:optional true, :title "boolean"} boolean?]]
-                                           true {:registry (merge (m/default-schemas) {::x int?, ::y int?})})]
+  (let [{:keys [children raw-entries entries forms]} (m/-parse-entry-syntax
+                                                       [[:x int?]
+                                                        ::x
+                                                        [::y {:optional true}]
+                                                        [:y {:optional true, :title "boolean"} boolean?]]
+                                                       true {:registry (merge (m/default-schemas) {::x int?, ::y int?})})]
     (testing "forms"
       (is (= [[:x 'int?]
               ::x
               [::y {:optional true}]
               [:y {:optional true, :title "boolean"} 'boolean?]]
              forms)))
+    (testing "raw-entries"
+      (is (entries= [[:x nil int?]
+                     [:y {:optional true, :title "int"} int?]]
+                    raw-entries))
+      (is (every? #{'int?} (->> raw-entries (map last) (map m/type)))))
     (testing "entries"
       (is (= [[:x nil 'int?]
               [::x nil ::x]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -20,7 +20,7 @@
   (apply = (map with-schema-forms results)))
 
 (defn entries= [& entries]
-  (apply = (map (partial map #(update % 2 m/form)) entries)))
+  (apply = (map (partial map #(update % (dec (count %)) m/form)) entries)))
 
 (defn form= [& entries]
   (apply = (map m/form entries)))
@@ -47,11 +47,11 @@
               [:y {:optional true, :title "boolean"} 'boolean?]]
              forms)))
     (testing "entries"
-      (is (= [[:x nil 'int?]
-              [::x nil ::x]
-              [::y {:optional true} ::y]
-              [:y {:optional true, :title "boolean"} 'boolean?]]
-             (map #(update % 2 m/form) entries))))
+      (is (= [[:x 'int?]
+              [::x ::x]
+              [::y ::y]
+              [:y 'boolean?]]
+             (map #(update % 1 m/form) entries))))
     (testing "children"
       (is (= [[:x nil 'int?]
               [::x nil ::x]
@@ -78,7 +78,8 @@
   (is (= {:district 9} (m/eval "(m/properties [int? {:district 9}])")))
   (is (= :maybe (m/eval "(m/type [:maybe int?])")))
   (is (= ['int? 'string?] (map m/form (m/eval "(m/children [:or {:some \"props\"} int? string?])"))))
-  (is (entries= [[:x nil 'int?] [:y nil 'string?]] (m/eval "(m/map-entries [:map [:x int?] [:y string?]])"))))
+  (is (entries= [[:x 'int?] [:y 'string?]] (m/eval "(m/entries [:map [:x int?] [:y string?]])")))
+  (is (entries= [[:x nil 'int?] [:y nil 'string?]] (m/eval "(m/children [:map [:x int?] [:y string?]])")))) ;
 
 (deftest into-schema-test
   (is (form= [:map {:closed true} [:x int?]]
@@ -536,7 +537,7 @@
             [[:x nil boolean?]
              [:y {:optional true} int?]
              [:z {:optional false} string?]]
-            (m/map-entries schema)))
+            (m/children schema)))
 
       (is (results= {:schema schema
                      :value {:y "invalid" :z "kikka"}
@@ -696,7 +697,7 @@
 
       (is (entries= [[:sized nil [:map [:type keyword?] [:size int?]]]
                      [:human nil [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]]]
-                    (m/map-entries schema)))
+                    (m/children schema)))
 
       (is (= [:multi
               {:dispatch :type, :decode/string '(fn [x] (update x :type keyword))}

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -574,12 +574,13 @@
                                                (mt/key-transformer
                                                  {:decode #(-> % name (str "_key") keyword)}))))
 
-      (is (= {:x 24}
+      (is (= {:x 32}
              (m/decode
-               [:map
-                {:decode/string '{:enter #(update % :x inc), :leave #(update % :x (partial * 2))}}
-                [:x [int? {:decode/string '{:enter (partial + 2), :leave (partial * 3)}}]]]
-               {:x 1} mt/string-transformer)))
+               [:map {:decode/string '{:enter #(update % :x inc), :leave #(update % :x (partial * 2))}}
+                [:x {:decode/string '{:enter inc, :leave inc}}
+                 [int? {:decode/string '{:enter (partial + 2), :leave (partial * 3)}}]]]
+               {:x 1}
+               mt/string-transformer)))
 
       (is (true? (m/validate (over-the-wire schema) valid)))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1359,9 +1359,3 @@
 
         (testing "map-syntax"
           (is (= map-syntax (mu/to-map-syntax schema))))))))
-
-(m/entries
-  [:map
-   [:x boolean?]
-   [:y {:optional true} int?]
-   [:z {:optional false} string?]])

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -35,6 +35,14 @@
                     :qualified-symbol]]
       (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
 
+  (testing "map entries"
+    (is (= {:korppu "koira"
+            :piilomaan "pikku aasi"
+            :muuli "mukkelis"}
+           (mg/generate [:map {:gen/fmap '#(assoc % :korppu "koira")}
+                         [:piilomaan {:gen/fmap '(partial str "pikku ")} [:string {:gen/elements ["aasi"]}]]
+                         [:muuli {:gen/elements ["mukkelis"]} [:string {:gen/elements ["???"]}]]]))))
+
   (testing "ref"
     (testing "recursion"
       (let [schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -76,10 +76,28 @@
 (deftest json-schema-test
   (doseq [[schema json-schema] expectations]
     (is (= json-schema (json-schema/transform schema))))
+
   (testing "full override"
     (is (= {:type "file"}
            (json-schema/transform
              [:map {:json-schema {:type "file"}} [:file any?]]))))
+
+  (testing "map-entry overrides"
+    (is (= {:type "object",
+            :properties {:x1 {:title "x", :type "string"},
+                         :x2 {:title "x"},
+                         :x3 {:title "x", :type "string", :default "x"},
+                         :x4 {:title "x-string", :default "x2"},
+                         :x5 {:type "x-string"}},
+            :required [:x1 :x2 :x3 :x4 :x5]}
+           (json-schema/transform
+             [:map
+              [:x1 {:json-schema/title "x"} :string]
+              [:x2 {:json-schema {:title "x"}} [:string {:json-schema/default "x"}]]
+              [:x3 {:json-schema/title "x"} [:string {:json-schema/default "x"}]]
+              [:x4 {:json-schema/title "x-string"} [:string {:json-schema {:default "x2"}}]]
+              [:x5 {:json-schema {:type "x-string"}} [:string {:json-schema {:default "x"}}]]]))))
+
   (testing "with properties"
     (is (= {:allOf [{:type "integer", :format "int64"}]
             :title "age"

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -77,6 +77,7 @@
 (deftest swagger-test
   (doseq [[schema swagger-schema] expectations]
     (is (= swagger-schema (swagger/transform schema))))
+
   (testing "full override"
     (is (= {:type "file"}
            (swagger/transform
@@ -88,6 +89,23 @@
            (swagger/transform
              [:map {:swagger {:type "file"}
                     :json-schema {:type "file2"}} [:file any?]]))))
+
+  (testing "map-entry overrides"
+    (is (= {:type "object",
+            :properties {:x1 {:title "x", :type "string"},
+                         :x2 {:title "x"},
+                         :x3 {:title "x", :type "string", :default "x"},
+                         :x4 {:title "x-string", :default "x2"},
+                         :x5 {:type "x-string"}},
+            :required [:x1 :x2 :x3 :x4 :x5]}
+           (swagger/transform
+             [:map
+              [:x1 {:swagger/title "x"} :string]
+              [:x2 {:swagger {:title "x"}} [:string {:swagger/default "x"}]]
+              [:x3 {:swagger/title "x"} [:string {:swagger/default "x"}]]
+              [:x4 {:swagger/title "x-string"} [:string {:swagger {:default "x2"}}]]
+              [:x5 {:swagger {:type "x-string"}} [:string {:swagger {:default "x"}}]]]))))
+
   (testing "with properties"
     (is (= {:title "age"
             :type "integer"

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -595,7 +595,7 @@
 
   (testing "nested"
     (let [schema [:map {:default {}}
-                  [:a [int? {:default 1}]]
+                  [:a {:default 1} int?]
                   [:b [:vector {:default [1 2 3]} int?]]
                   [:c [:map {:default {}}
                        [:x [int? {:default 42}]]
@@ -625,4 +625,5 @@
 
   (testing "default false"
     (is (= {:user/verified false} (m/decode [:map [:user/verified [:and {:default false} boolean?]]] {} mt/default-value-transformer)))
+    (is (= {:user/verified false} (m/decode [:map [:user/verified {:default false} boolean?]] {} mt/default-value-transformer)))
     (is (= false (m/decode [:and {:default false} boolean?] nil mt/default-value-transformer)))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -454,12 +454,12 @@
       (reset! state nil)
       (m/decode schema {:x 1, :y "2"} transformer)
       (is (= [[:decode :enter :map {:x 1, :y "2"}]
-              [:decode :enter :malli.core/entry 1]
-              [:decode :enter :malli.core/entry "2"]
+              [:decode :enter ::m/entry 1]
+              [:decode :enter ::m/entry "2"]
               [:decode :enter 'string? "2"]
-              [:decode :leave :malli.core/entry 1]
+              [:decode :leave ::m/entry 1]
               [:decode :leave 'string? "2"]
-              [:decode :leave :malli.core/entry "2"]
+              [:decode :leave ::m/entry "2"]
               [:decode :leave :map {:x 1, :y "2"}]]
              @state)))
 
@@ -467,12 +467,12 @@
       (reset! state nil)
       (m/encode schema {:x 1, :y "2"} transformer)
       (is (= [[:encode :enter :map {:x 1, :y "2"}]
-              [:encode :enter :malli.core/entry 1]
-              [:encode :enter :malli.core/entry "2"]
+              [:encode :enter ::m/entry 1]
+              [:encode :enter ::m/entry "2"]
               [:encode :enter 'string? "2"]
-              [:encode :leave :malli.core/entry 1]
+              [:encode :leave ::m/entry 1]
               [:encode :leave 'string? "2"]
-              [:encode :leave :malli.core/entry "2"]
+              [:encode :leave ::m/entry "2"]
               [:encode :leave :map {:x 1, :y "2"}]]
              @state)))))
 

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -454,12 +454,12 @@
       (reset! state nil)
       (m/decode schema {:x 1, :y "2"} transformer)
       (is (= [[:decode :enter :map {:x 1, :y "2"}]
-              [:decode :enter ::m/entry 1]
-              [:decode :enter ::m/entry "2"]
+              [:decode :enter ::m/val 1]
+              [:decode :enter ::m/val "2"]
               [:decode :enter 'string? "2"]
-              [:decode :leave ::m/entry 1]
+              [:decode :leave ::m/val 1]
               [:decode :leave 'string? "2"]
-              [:decode :leave ::m/entry "2"]
+              [:decode :leave ::m/val "2"]
               [:decode :leave :map {:x 1, :y "2"}]]
              @state)))
 
@@ -467,12 +467,12 @@
       (reset! state nil)
       (m/encode schema {:x 1, :y "2"} transformer)
       (is (= [[:encode :enter :map {:x 1, :y "2"}]
-              [:encode :enter ::m/entry 1]
-              [:encode :enter ::m/entry "2"]
+              [:encode :enter ::m/val 1]
+              [:encode :enter ::m/val "2"]
               [:encode :enter 'string? "2"]
-              [:encode :leave ::m/entry 1]
+              [:encode :leave ::m/val 1]
               [:encode :leave 'string? "2"]
-              [:encode :leave ::m/entry "2"]
+              [:encode :leave ::m/val "2"]
               [:encode :leave :map {:x 1, :y "2"}]]
              @state)))))
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -224,7 +224,7 @@
 
         [:schema int?] 0 int?
         [:schema int?] 1 nil)
-      
+
       (is (mu/equals (mu/get [:tuple int? pos-int?] 9 boolean?) boolean?))
       (is (mu/equals (mu/get [:map [:x int?]] :y boolean?) boolean?)))
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -591,4 +591,4 @@
                                                                                          :children [{:type :tuple
                                                                                                      :children [{:type 'double?}
                                                                                                                 {:type 'double?}]}]}]]}]}]}]]}
-             (mu/to-map-syntax schema {::m/walk-map-entries true}))))))
+             (mu/to-map-syntax schema {::m/walk-entries true}))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -564,8 +564,31 @@
                                         :children [{:type :map,
                                                     :children [[:street nil {:type 'string?}]
                                                                [:lonlat nil {:type :tuple
-                                                                             :children [{:type 'double?} {:type 'double?}]}]]}]}]]}
+                                                                             :children [{:type 'double?}
+                                                                                        {:type 'double?}]}]]}]}]]}
              (mu/to-map-syntax schema))))
 
     (testing "from-map-syntax"
-      (is (true? (mu/equals schema (-> schema (mu/to-map-syntax) (mu/from-map-syntax))))))))
+      (is (true? (mu/equals schema (-> schema (mu/to-map-syntax) (mu/from-map-syntax))))))
+
+    (testing "walking entries"
+      (is (= {:type :map,
+              :properties {:registry {::size [:enum "S" "M" "L"]}}
+              :children [[:id nil {:type ::m/entry
+                                   :children [{:type 'string?}]}]
+                         [:tags nil {:type ::m/entry
+                                     :children [{:type :set
+                                                 :children [{:type 'keyword?}]}]}]
+                         [:size nil {:type ::m/entry
+                                     :children [{:type ::m/schema
+                                                 :children [::size]}]}]
+                         [:address nil {:type ::m/entry
+                                        :children [{:type :vector,
+                                                    :children [{:type :map,
+                                                                :children [[:street nil {:type ::m/entry
+                                                                                         :children [{:type 'string?}]}]
+                                                                           [:lonlat nil {:type ::m/entry
+                                                                                         :children [{:type :tuple
+                                                                                                     :children [{:type 'double?}
+                                                                                                                {:type 'double?}]}]}]]}]}]}]]}
+             (mu/to-map-syntax schema {::m/walk-map-entries true}))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -574,22 +574,22 @@
     (testing "walking entries"
       (is (= {:type :map,
               :properties {:registry {::size [:enum "S" "M" "L"]}}
-              :children [[:id nil {:type ::m/entry
+              :children [[:id nil {:type ::m/val
                                    :children [{:type 'string?}]}]
-                         [:tags {:title "tag"} {:type ::m/entry
+                         [:tags {:title "tag"} {:type ::m/val
                                                 :properties {:title "tag"}
                                                 :children [{:type :set
                                                             :children [{:type 'keyword?}]}]}]
-                         [:size nil {:type ::m/entry
+                         [:size nil {:type ::m/val
                                      :children [{:type ::m/schema
                                                  :children [::size]}]}]
-                         [:address nil {:type ::m/entry
+                         [:address nil {:type ::m/val
                                         :children [{:type :vector,
                                                     :children [{:type :map,
-                                                                :children [[:street nil {:type ::m/entry
+                                                                :children [[:street nil {:type ::m/val
                                                                                          :children [{:type 'string?}]}]
-                                                                           [:lonlat nil {:type ::m/entry
+                                                                           [:lonlat nil {:type ::m/val
                                                                                          :children [{:type :tuple
                                                                                                      :children [{:type 'double?}
                                                                                                                 {:type 'double?}]}]}]]}]}]}]]}
-             (mu/to-map-syntax schema {::m/walk-entries true}))))))
+             (mu/to-map-syntax schema {::m/walk-entry-vals true}))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -544,7 +544,7 @@
 (deftest to-from-maps-test
   (let [schema [:map {:registry {::size [:enum "S" "M" "L"]}}
                 [:id string?]
-                [:tags [:set keyword?]]
+                [:tags {:title "tag"} [:set keyword?]]
                 [:size ::size]
                 [:address
                  [:vector
@@ -556,8 +556,8 @@
       (is (= {:type :map,
               :properties {:registry {::size [:enum "S" "M" "L"]}}
               :children [[:id nil {:type 'string?}]
-                         [:tags nil {:type :set
-                                     :children [{:type 'keyword?}]}]
+                         [:tags {:title "tag"} {:type :set
+                                                :children [{:type 'keyword?}]}]
                          [:size nil {:type ::m/schema
                                      :children [::size]}]
                          [:address nil {:type :vector,
@@ -576,9 +576,10 @@
               :properties {:registry {::size [:enum "S" "M" "L"]}}
               :children [[:id nil {:type ::m/entry
                                    :children [{:type 'string?}]}]
-                         [:tags nil {:type ::m/entry
-                                     :children [{:type :set
-                                                 :children [{:type 'keyword?}]}]}]
+                         [:tags {:title "tag"} {:type ::m/entry
+                                                :properties {:title "tag"}
+                                                :children [{:type :set
+                                                            :children [{:type 'keyword?}]}]}]
                          [:size nil {:type ::m/entry
                                      :children [{:type ::m/schema
                                                  :children [::size]}]}]


### PR DESCRIPTION
Spike on whether and how `MapEntry` properties should used in schema applications:

* [x] forms
* [x] transformation
* [x] default transformer
* [x] ~error messages~ (postponed)
* [x] value generation
* [x] json schema transformation
* [x] swagger2 transformation

Related issues: #80, #86, #116,  #120, #182
Related PRs: #119, #197

### forms

* should not change (e.g. not merging data to children)

```clj
(m/form [:map [:x {:encode/math inc} int?]])
; => [:map [:x {:encode/math inc} int?]]
```

### transformation 

* should allow extra property-based transformations
* should have a target key for `:encoders` & `:decoders`?

```clj
(m/decode 
  [:map [:x {:encode/math inc} [int? {:encode/math inc}]]]
  {:x 1}
  (mt/transformer {:name :math}))
; => {:x 3}
```

### error messages

* ~should use the parent props if defined~
* despite the orginal cause (#86), not resolving this with this PR. Handling errors is a special case, will resolve that later

```clj
(-> [:map [:x {:error/message "over 18"} [:and int? [:> 18]]]
    (m/explain {:x 12})
    (me/humanize))
; {:x ["over 18"]}
```

* also for composite schemas

```clj
(-> [:and {:error/message "over 18"} int? [:> 18]]
    (m/explain 12)
    (me/humanize))
; ["over 18"]
```

### value generation

* should use the parent props if defined

```clj
(mg/generate [:map [:foo {:gen/elements [1 2]} int?]])
; => {:foo 1}
```

### json-schema

* should use merged properties (parent wins)

```clj
(json-schema/transform [:map [:x {:json-schema {:type "numberz"}} int?]])
;{:type "object",
; :properties {:x {:type "numberz"},
; :required [:x]}
```

```clj
(json-schema/transform [:map [:x {:json-schema/type "numberz"} [:schema {:json-schema/format "int32"} [int? {:json-schema/example 1}]]]])
;{:type "object",
; :properties {:x {:type "numberz", :format "int32", :example 1},
; :required [:x]}
```

### swagger

* like with json-schema