### PR TITLE
Fix default `false` value when applying transformations

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -323,7 +323,7 @@
                                  (let [entries (m/map-entries schema)
                                        defaults (->> entries
                                                      (keep (fn [[k _ v]]
-                                                             (if-let [default (get-default v)]
+                                                             (if-some [default (get-default v)]
                                                                [k default])))
                                                      (into {}))]
                                    (if (seq defaults)

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -521,16 +521,22 @@
                   [:d [:map
                        [:x [int? {:default 42}]]
                        [:y int?]]]
-                  [:e int?]]]
+                  [:e int?]
+                  [:f [boolean? {:default true}]]
+                  [:g [boolean? {:default false}]]]]
 
       (is (= {:a 1
               :b [1 2 3]
-              :c {:x 42}}
+              :c {:x 42}
+              :f true
+              :g false}
              (m/encode schema nil mt/default-value-transformer)))
 
       (is (= {:a "1"
               :b ["1" "2" "3"]
-              :c {:x "42"}}
+              :c {:x "42"}
+              :f true
+              :g false}
              (m/encode schema nil (mt/transformer
                                     mt/default-value-transformer
                                     mt/string-transformer)))))))


### PR DESCRIPTION
The default transformation was not applied when a `false` value was expected.