### PR TITLE
Replace Schema Visitor with Schema Walker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 ## UNRELEASED
 
 * ???
+  * **BREAKING:**: Visitor is implemented using a Walker.
+    * `m/accept` -> `m/walk`
+    * `m/schema-visitor` -> `m/schema-walker`
+    * `m/map-syntax-visitor` -> `m/map-syntax-walker`
+* 31.6.2020
   * **BREAKING:** new `-children` method in `Schema`, to return child schemas as instances (instead of just AST)
 * 17.6.2020
   * **BREAKING:** change all `malli.core/*-registy` defs into `malli.core/*-schemas` defns to enable DCE for clojurescript

--- a/README.md
+++ b/README.md
@@ -629,7 +629,7 @@ Schema unions (merged values of both schemas are valid for union schema):
 Adding generated example values to Schemas:
 
 ```clj
-(m/accept
+(m/walk
   [:map
    [:name string?]
    [:description string?]
@@ -637,7 +637,7 @@ Adding generated example values to Schemas:
     [:map
      [:street string?]
      [:country [:enum "finland" "poland"]]]]]
-  (m/schema-visitor
+  (m/schema-walker
     (fn [schema]
       (mu/update-properties schema assoc :examples (mg/sample schema {:size 2, :seed 20})))))
 ;[:map
@@ -903,14 +903,14 @@ Schemas can converted into map-syntax (with keys `:type` and optionally `:proper
 
 ## Schema Transformation
 
-Schemas can be transformed using the [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern).
+Schemas can be transformed using post-walking, e.g. the [Visitor Pattern](https://en.wikipedia.org/wiki/visitor_pattern).
 
-The identity visitor:
+The identity walker:
 
 ```clj
-(m/accept 
+(m/walk 
   Address 
-  (m/schema-visitor identity))
+  (m/schema-walker identity))
 ;[:map
 ; [:id string?]
 ; [:tags [:set keyword?]]
@@ -925,9 +925,9 @@ The identity visitor:
 Adding `:title` property to schemas:
 
 ```clj
-(m/accept
+(m/walk
   Address
-  (m/schema-visitor #(mu/update-properties % assoc :title (name (m/type %)))))
+  (m/schema-walker #(mu/update-properties % assoc :title (name (m/type %)))))
 ;[:map {:title "map"}
 ; [:id [string? {:title "string?"}]]
 ; [:tags [:set {:title "set"} [keyword? {:title "keyword?"}]]]
@@ -942,7 +942,7 @@ Adding `:title` property to schemas:
 Adding `:path` property to schemas:
 
 ```clj
-(m/accept
+(m/walk
   Address
   (fn [schema children in options]
     (m/into-schema
@@ -966,7 +966,7 @@ Adding `:path` property to schemas:
 Transforming schemas into nested maps:
 
 ```clj
-(m/accept
+(m/walk
   Address
   (fn [schema children _ _]
     (-> (m/properties schema)

--- a/README.md
+++ b/README.md
@@ -537,6 +537,21 @@ Lifted `clojure.core` function to work with schemas: `select-keys`, `dissoc`, `g
 ; [:tags [:set keyword?]]]
 ```
 
+Finding first value (prewalk):
+
+```clj
+(mu/find-first
+  [:map
+   [:x int?]
+   [:y [:vector [:tuple
+                 [:or [:and {:salaisuus "turvassa"} boolean?] int?]
+                 [:schema {:salaisuus "vaarassa"} false?]]]]
+   [:z [:string {:salaisuus "piilossa"}]]]
+  (fn [schema _ _]
+    (-> schema m/properties :salaisuus)))
+; => "turvassa"
+```
+
 Making keys optional or required:
 
 ```clj

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -2,7 +2,7 @@
 
 ## Removing Schemas based on a property
 
-Schemas can be walked over recursively using `m/accept`:
+Schemas can be walked over recursively using `m/walk`:
 
 ```clj
 (require '[malli.core :as m])
@@ -15,7 +15,7 @@ Schemas can be walked over recursively using `m/accept`:
    [:nested [:map [:x [:tuple {:deleteMe true} string? string?]]]]
    [:token [string? {:deleteMe true}]]])
 
-(m/accept
+(m/walk
   Schema
   (fn [schema children _ options]
     ;; return nil if Schema has the property 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -547,9 +547,7 @@
                :leave (build :leave)}))
           (-walk [this walker in options]
             (if (-accept walker this in options)
-              (-outer walker this (mapv
-                                    (fn [[i s]] (-inner walker s (conj in i) options))
-                                    (map-indexed vector children)) in options)))
+              (-outer walker this (mapv (fn [[i s]] (-inner walker s (conj in i) options)) (map-indexed vector children)) in options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -800,9 +798,9 @@
               {:enter (-chain :enter [(:enter this-transformer) (fn [x] ((enter) x))])
                :leave (-chain :leave [(:leave this-transformer) (fn [x] ((leave) x))])}))
           (-walk [this walker in options]
-            (let [accept (fn [] (-inner walker (-ref) in (update options ::ref-accepted (fnil conj #{}) ref)))
+            (let [accept (fn [] (-inner walker (-ref) in (update options ::ref-walked (fnil conj #{}) ref)))
                   accept-ref ^{:type ::ref} (reify IDeref (#?(:cljs cljs.core/-deref, :clj deref) [_] (accept)))
-                  options (assoc options ::ref-accept accept-ref)]
+                  options (assoc options ::ref-walk accept-ref)]
               (if (-accept walker this in options)
                 (-outer walker this (vec children) in options))))
           (-properties [_] properties)
@@ -962,9 +960,9 @@
        (-outer [_ s c in options] (f s c in options)))
      [] options)))
 
-(defn search
+(defn ^:no-doc find-first
   ([?schema f]
-   (search ?schema f nil))
+   (find-first ?schema f nil))
   ([?schema f options]
    (let [result (atom nil)]
      (-walk
@@ -1142,11 +1140,3 @@
   (mr/registry (cond (identical? mr/type "default") (default-schemas)
                      (identical? mr/type "custom") (mr/custom-default-registry)
                      :else (fail! ::invalid-registry.type {:type mr/type}))))
-
-(comment
-  (search
-    [:vector [:tuple [:map [:x int?] [:y [:tuple [:and int?]]] [:z [:tuple int?]] [:u [:tuple int?]]]]]
-    (fn [s in options]
-      (println "search:" s)
-      (if (= :and (type s)) s)
-      )))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -960,20 +960,6 @@
        (-outer [_ s c in options] (f s c in options)))
      [] options)))
 
-(defn ^:no-doc find-first
-  ([?schema f]
-   (find-first ?schema f nil))
-  ([?schema f options]
-   (let [result (atom nil)]
-     (-walk
-       (schema ?schema options)
-       (reify Walker
-         (-accept [_ s in options] (not (or @result (reset! result (f s in options)))))
-         (-inner [this s in options] (if-not @result (-walk s this in options)))
-         (-outer [_ _ _ _ _]))
-       [] options)
-     @result)))
-
 (defn validator
   ([?schema]
    (validator ?schema nil))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -117,7 +117,7 @@
             (-value-transformer transformer this method options))
           (-walk [this walker in options]
             (if (-accept walker this in options)
-              (-outer walker this (-children this) in options)))
+              (-outer walker this children in options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -491,7 +491,7 @@
                :leave (build :leave)}))
           (-walk [this walker in options]
             (if (-accept walker this in options)
-              (-outer walker this (mapv #(-inner walker % (conj in ::in) options) children) in options)))
+              (-outer walker this [(-inner walker schema (conj in ::in) options)] in options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] [schema])

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -955,7 +955,7 @@
    (-walk
      (schema ?schema options)
      (reify Walker
-       (-accept [_ s _in _options] s)
+       (-accept [_ s _ _] s)
        (-inner [this s in options] (-walk s this in options))
        (-outer [_ s c in options] (f s c in options)))
      [] options)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -174,7 +174,7 @@
                :leave (build :leave)}))
           (-walk [this walker in options]
             (if (-accept walker this in options)
-              (-outer walker this (mapv #(-inner walker % in options) (-children this)) in options)))
+              (-outer walker this (mapv #(-inner walker % in options) children) in options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -446,7 +446,7 @@
     (-into-schema [_ {:keys [min max] :as properties} children options]
       (when-not (= 1 (count children))
         (fail! ::child-error {:type type, :properties properties, :children children, :min 1, :max 1}))
-      (let [[schema :as children] (mapv #(schema % options) children)
+      (let [schema (schema (first children) options)
             form (create-form type properties [(-form schema)])
             collection? #(or (sequential? %) (set? %))
             fwrap (fn [x] (if (collection? x) (fwrap x) x))
@@ -491,7 +491,7 @@
                :leave (build :leave)}))
           (-walk [this walker in options]
             (if (-accept walker this in options)
-              (-outer walker this (mapv #(-inner walker % (conj in ::in) options) (-children this)) in options)))
+              (-outer walker this (mapv #(-inner walker % (conj in ::in) options) children) in options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] [schema])

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -948,9 +948,9 @@
   ([?schema options]
    (-type (schema ?schema options))))
 
-(defn accept
+(defn walk
   ([?schema f]
-   (accept ?schema f nil))
+   (walk ?schema f nil))
   ([?schema f options]
    (-walk
      (schema ?schema options)
@@ -1063,14 +1063,14 @@
                                                                  'm/children children
                                                                  'm/map-entries map-entries}})))
 ;;
-;; Visitors
+;; Walkers
 ;;
 
-(defn schema-visitor [f]
+(defn schema-walker [f]
   (fn [schema children _ options]
     (f (into-schema (type schema) (properties schema) children options))))
 
-(defn ^:no-doc map-syntax-visitor [schema children _ _]
+(defn ^:no-doc map-syntax-walker [schema children _ _]
   (let [properties (properties schema)]
     (cond-> {:type (type schema)}
             (seq properties) (assoc :properties properties)
@@ -1082,7 +1082,7 @@
 
 (defn ^:no-doc to-map-syntax
   ([?schema] (to-map-syntax ?schema nil))
-  ([?schema options] (accept ?schema map-syntax-visitor options)))
+  ([?schema options] (walk ?schema map-syntax-walker options)))
 
 (defn ^:no-doc from-map-syntax
   ([m] (from-map-syntax m nil))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -968,7 +968,7 @@
      (-walk
        (schema ?schema options)
        (reify Walker
-         (-accept [_ s in options] (not (reset! result (f s in options))))
+         (-accept [_ s in options] (not (or @result (reset! result (f s in options)))))
          (-inner [this s in options] (if-not @result (-walk s this in options)))
          (-outer [_ _ _ _ _]))
        [] options)

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -93,7 +93,7 @@
 (defmethod accept :string [_ schema _ _]
   (merge {:type "string"} (-> schema m/properties (select-keys [:min :max]) (set/rename-keys {:min :minLength, :max :maxLenght}))))
 
-(defn- -json-schema-visitor [schema children _in options]
+(defn- -json-schema-walker [schema children _in options]
   (let [p (m/properties schema)]
     (or (unlift p :json-schema)
         (merge (select p)
@@ -110,4 +110,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/accept ?schema -json-schema-visitor options)))
+   (m/walk ?schema -json-schema-walker options)))

--- a/src/malli/mermaid.cljc
+++ b/src/malli/mermaid.cljc
@@ -6,7 +6,7 @@
 
 (defn collect [schema]
   (let [state (atom {})]
-    (m/accept
+    (m/walk
       schema
       (fn [schema _ _ _]
         (let [properties (m/properties schema)]
@@ -22,7 +22,7 @@
   (let [registry* (atom registry)]
     (doseq [[k v] registry]
       (swap! registry* assoc k
-             (m/accept v (fn [schema children in _]
+             (m/walk v (fn [schema children in _]
                            (let [options (update (m/options schema) :registry (partial mr/composite-registry @registry*))
                                  schema (m/into-schema (m/type schema) (m/properties schema) children options)]
                              (if (and (seq in) (= :map (m/type schema)))
@@ -35,7 +35,7 @@
 (defn get-links [registry]
   (let [links (atom {})]
     (doseq [[from schema] registry]
-      (m/accept
+      (m/walk
         schema
         (fn [schema _ _ _]
           (when-let [to (if (satisfies? m/RefSchema schema) (m/-ref schema))]

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -22,7 +22,7 @@
 
 (defmethod accept :tuple [_ _ children _] {:type "array" :items {} :x-items children})
 
-(defn- -swagger-visitor [schema children _in options]
+(defn- -swagger-walker [schema children _in options]
   (let [p (m/properties schema)]
     (or (json-schema/unlift p :swagger)
         (json-schema/unlift p :json-schema)
@@ -41,4 +41,4 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/accept ?schema -swagger-visitor options)))
+   (m/walk ?schema -swagger-walker options)))

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -103,9 +103,9 @@
   ([schema]
    (closed-schema schema nil))
   ([schema options]
-   (m/accept
+   (m/walk
      schema
-     (m/schema-visitor
+     (m/schema-walker
        (fn [schema]
          (if (-open-map? schema options)
            (update-properties schema c/assoc :closed true)
@@ -117,9 +117,9 @@
   ([schema]
    (open-schema schema nil))
   ([schema options]
-   (m/accept
+   (m/walk
      schema
-     (m/schema-visitor
+     (m/schema-walker
        (fn [schema]
          (if (-open-map? schema options)
            (update-properties schema c/dissoc :closed)

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -29,6 +29,22 @@
 ;; public api
 ;;
 
+(defn find-first
+  "Prewalks the Schema recursively with a 3-arity fn [schema in options], returns with
+  and as soon as the function returns non-null value."
+  ([?schema f]
+   (find-first ?schema f nil))
+  ([?schema f options]
+   (let [result (atom nil)]
+     (m/-walk
+       (m/schema ?schema options)
+       (reify m/Walker
+         (-accept [_ s in options] (not (or @result (reset! result (f s in options)))))
+         (-inner [this s in options] (if-not @result (m/-walk s this in options)))
+         (-outer [_ _ _ _ _]))
+       [] options)
+     @result)))
+
 (defn merge
   "Merges two schemas into one with the following rules:
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1159,29 +1159,3 @@
 
     (testing "from-map-syntax"
       (is (true? (mu/equals schema (-> schema (m/to-map-syntax) (m/from-map-syntax))))))))
-
-(deftest find-first-test
-  (let [schema [:map
-                [:x int?]
-                [:y [:vector [:tuple
-                              [:maybe int?]
-                              [:or [:and {:salaisuus "turvassa"} boolean?] int?]
-                              [:schema {:salaisuus "vaarassa"} false?]]]]
-                [:z [:string {:salaisuus "piilossa"}]]]]
-
-    (let [walked-properties (atom [])]
-      (is (= "turvassa" (m/find-first
-                          schema
-                          (fn [s _in _options]
-                            (some->> s m/properties (swap! walked-properties conj))
-                            (some-> s m/properties :salaisuus)))))
-      (is (= [{:salaisuus "turvassa"}] @walked-properties)))
-
-    (let [walked-properties (atom [])]
-      (is (= "vaarassa" (m/find-first
-                          schema
-                          (fn [s _in _options]
-                            (some->> s m/properties (swap! walked-properties conj))
-                            (some-> s m/properties :salaisuus #{"vaarassa"})))))
-      (is (= [{:salaisuus "turvassa"}
-              {:salaisuus "vaarassa"}] @walked-properties)))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1159,3 +1159,17 @@
 
     (testing "from-map-syntax"
       (is (true? (mu/equals schema (-> schema (m/to-map-syntax) (m/from-map-syntax))))))))
+
+(deftest search-test
+  (is (= "turvassa"
+         (m/find-first
+           [:map
+            [:x int?]
+            [:y [:vector [:tuple
+                          [:maybe int?]
+                          [:or [:and {:salaisuus "turvassa"} boolean?] int?]
+                          [:schema {:salaisuus "vaarassa"} false?]]]]
+            [:z [:string {:salaisuus "piilossa"}]]]
+           (fn [s _in _options]
+             (some-> s m/properties :salaisuus))))))
+

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1160,16 +1160,28 @@
     (testing "from-map-syntax"
       (is (true? (mu/equals schema (-> schema (m/to-map-syntax) (m/from-map-syntax))))))))
 
-(deftest search-test
-  (is (= "turvassa"
-         (m/find-first
-           [:map
-            [:x int?]
-            [:y [:vector [:tuple
-                          [:maybe int?]
-                          [:or [:and {:salaisuus "turvassa"} boolean?] int?]
-                          [:schema {:salaisuus "vaarassa"} false?]]]]
-            [:z [:string {:salaisuus "piilossa"}]]]
-           (fn [s _in _options]
-             (some-> s m/properties :salaisuus))))))
+(deftest find-first-test
+  (let [schema [:map
+                [:x int?]
+                [:y [:vector [:tuple
+                              [:maybe int?]
+                              [:or [:and {:salaisuus "turvassa"} boolean?] int?]
+                              [:schema {:salaisuus "vaarassa"} false?]]]]
+                [:z [:string {:salaisuus "piilossa"}]]]]
 
+    (let [walked-properties (atom [])]
+      (is (= "turvassa" (m/find-first
+                          schema
+                          (fn [s _in _options]
+                            (some->> s m/properties (swap! walked-properties conj))
+                            (some-> s m/properties :salaisuus)))))
+      (is (= [{:salaisuus "turvassa"}] @walked-properties)))
+
+    (let [walked-properties (atom [])]
+      (is (= "vaarassa" (m/find-first
+                          schema
+                          (fn [s _in _options]
+                            (some->> s m/properties (swap! walked-properties conj))
+                            (some-> s m/properties :salaisuus #{"vaarassa"})))))
+      (is (= [{:salaisuus "turvassa"}
+              {:salaisuus "vaarassa"}] @walked-properties)))))

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -62,7 +62,7 @@
       (-type [_])
       (-form [_])
       (-validator [_] int?)
-      (-accept [t v i o] (v t nil i o))
+      (-walk [t w i o] (m/-outer w t nil i o))
       json-schema/JsonSchema
       (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
 

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -70,7 +70,7 @@
    [(reify
       m/Schema
       (-properties [_])
-      (-accept [t v i o] (v t nil i o))
+      (-walk [t w i o] (m/-outer w t nil i o))
       swagger/SwaggerSchema
       (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
 


### PR DESCRIPTION
Re-implement Schema Visitor using Walker. Enables `find-first` to (almost) short-circuit when a match is found.

```clj
(m/find-first
  [:map
   [:x int?]
   [:y [:vector [:tuple
                 [:maybe int?]
                 [:or [:and {:salaisuus "turvassa"} boolean?] int?]
                 [:schema {:salaisuus "vaarassa"} false?]]]]
   [:z [:string {:salaisuus "piilossa"}]]]
  (fn [s _in _options]
    (some-> s m/properties :salaisuus)))
; => "turvassa"
```