### PR TITLE
Collection transforming type transformation pushed to transformers + malli.transform cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 ## UNRELEASED
 
 * ???
-  * **BREAKING:**: decoders & encoders in `malli.transform` are renamed and moved from def to defns
+  * **BREAKING:**: big cleanup of `malli.transform` internals.
 * 12.7.2020
   * **BREAKING:**: `malli.mermaid` is removed (in favor of `malli.dot`)  
 * 10.7.2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 ## UNRELEASED
 
+* ???
+  * **BREAKING:**: decoders & encoders in `malli.transform` are renamed and moved from def to defns
 * 12.7.2020
   * **BREAKING:**: `malli.mermaid` is removed (in favor of `malli.dot`)  
 * 10.7.2020

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -443,15 +443,13 @@
           (-children [_] children)
           (-form [_] form))))))
 
-(defn -collection-schema [type fpred fwrap fempty]
+(defn -collection-schema [type fpred fempty]
   ^{:type ::into-schema}
   (reify IntoSchema
     (-into-schema [_ {:keys [min max] :as properties} children options]
       (-check-children! type properties children {:min 1 :max 1})
       (let [schema (schema (first children) options)
             form (create-form type properties [(-form schema)])
-            collection? #(or (sequential? %) (set? %))
-            fwrap (fn [x] (if (collection? x) (fwrap x) x))
             validate-limits (cond
                               (not (or min max)) (constantly true)
                               (and min max) (fn [x] (let [size (count x)] (<= min size max)))
@@ -479,11 +477,10 @@
                               acc)))))))
           (-transformer [this transformer method options]
             (let [collection? #(or (sequential? %) (set? %))
-                  fwrap (fn [x] (if (collection? x) (fwrap x) x))
                   this-transformer (-value-transformer transformer this method options)
                   child-transformer (-transformer schema transformer method options)
                   build (fn [phase]
-                          (let [->this (or (phase this-transformer) fwrap)
+                          (let [->this (phase this-transformer)
                                 ->child (if-let [ct (phase child-transformer)]
                                           (if fempty
                                             #(into (if % fempty) (map ct) %)
@@ -1090,10 +1087,10 @@
    :or (-or-schema)
    :map (-map-schema)
    :map-of (-map-of-schema)
-   :vector (-collection-schema :vector vector? vec [])
-   :list (-collection-schema :list list? seq nil)
-   :sequential (-collection-schema :sequential sequential? seq nil)
-   :set (-collection-schema :set set? set #{})
+   :vector (-collection-schema :vector vector? [])
+   :list (-collection-schema :list list? nil)
+   :sequential (-collection-schema :sequential sequential? nil)
+   :set (-collection-schema :set set? #{})
    :enum (-enum-schema)
    :maybe (-maybe-schema)
    :tuple (-tuple-schema)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -801,9 +801,9 @@
   ^{:type ::into-schema}
   (let [type (if (or id raw) ::schema :schema)]
     (reify IntoSchema
-      (-into-schema [_ properties [child :as children] options]
+      (-into-schema [_ properties children options]
         (-check-children! type properties children {:min 1, :max 1})
-        (let [child (schema child options)
+        (let [[child :as children] (map #(schema % options) children)
               form (or (and (empty? properties) (or id (and raw (-form child))))
                        (create-form type properties [(-form child)]))]
           ^{:type ::schema}

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -192,7 +192,7 @@
 ;; decoders
 ;;
 
-(def +json-decoders+
+(defn json-decoders []
   {'ident? string->keyword
    'simple-ident? string->keyword
    'qualified-ident? string->keyword
@@ -211,7 +211,7 @@
 
    :map-of (coerce-map-keys m/keyword->string)})
 
-(def +json-encoders+
+(defn json-encoders []
   {'keyword? m/keyword->string
    'simple-keyword? m/keyword->string
    'qualified-keyword? m/keyword->string
@@ -228,9 +228,9 @@
    'inst? date->string
    #?@(:clj ['ratio? number->double])})
 
-(def +string-decoders+
+(defn string-decoders []
   (merge
-    +json-decoders+
+    (json-decoders)
     {'integer? string->long
      'int? string->long
      'pos-int? string->long
@@ -255,9 +255,9 @@
      'false? string->boolean
      'true? string->boolean}))
 
-(def +string-encoders+
+(defn string-encoders []
   (merge
-    +json-encoders+
+    (json-encoders)
     {'integer? any->string
      'int? any->string
      'pos-int? any->string
@@ -281,14 +281,14 @@
 (defn json-transformer []
   (transformer
     {:name :json
-     :decoders +json-decoders+
-     :encoders +string-encoders+}))
+     :decoders (json-decoders)
+     :encoders (string-encoders)}))
 
 (defn string-transformer []
   (transformer
     {:name :string
-     :decoders +string-decoders+
-     :encoders +string-encoders+}))
+     :decoders (string-decoders)
+     :encoders (string-encoders)}))
 
 (defn strip-extra-keys-transformer
   ([]

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -181,10 +181,7 @@
 (defn coerce-map-keys [transform]
   (fn [x]
     (if (map? x)
-      (into {}
-            (map
-              (fn [[k v]] [(transform k) v]))
-            x)
+      (into {} (map (fn [[k v]] [(transform k) v])) x)
       x)))
 
 

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -321,10 +321,10 @@
 (defn json-transformer
   ([]
    (json-transformer nil))
-  ([{::keys [json-arrays]}]
+  ([{::keys [json-vectors]}]
    (transformer
      {:name :json
-      :decoders (cond-> (-json-decoders) (not json-arrays) (assoc :vector -sequential->vector))
+      :decoders (cond-> (-json-decoders) json-vectors (assoc :vector -sequential->vector))
       :encoders (-json-encoders)})))
 
 (defn string-transformer []
@@ -385,13 +385,11 @@
       {:decoders {:map add-defaults}
        :encoders {:map add-defaults}})))
 
-;; TODO: test me
 (defn collection-transformer []
   (let [coders {:vector -sequential-or-set->vector
                 :list -sequential-or-set->seq
                 :sequential -sequential-or-set->seq
-                :set -sequential->seq}]
+                :set -sequential->set}]
     (transformer
-      {:name :collection
-       :decoders coders
+      {:decoders coders
        :encoders coders})))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -385,11 +385,12 @@
       {:decoders {:map add-defaults}
        :encoders {:map add-defaults}})))
 
+;; TODO: test me
 (defn collection-transformer []
-  (let [coders {:vector -sequential->vector
-                :list -sequential->seq
-                :sequential -sequential->seq
-                :set -sequential->set}]
+  (let [coders {:vector -sequential-or-set->vector
+                :list -sequential-or-set->seq
+                :sequential -sequential-or-set->seq
+                :set -sequential->seq}]
     (transformer
       {:name :collection
        :decoders coders

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1112,7 +1112,7 @@
       (is (= "foo" encoded))
       (is (= :foo decoded)))))
 
-(def sequential (#'m/-collection-schema `sequential sequential? seq nil))
+(def sequential (m/-collection-schema `sequential sequential? nil))
 
 (deftest custom-into-schema-test
   (doseq [value [[1 2 3] '(1 2 3)]]

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -6,7 +6,7 @@
 
 (deftest ->interceptor-test
   (are [?interceptor expected]
-    (= expected (is (#'mt/->interceptor ?interceptor {} {})))
+    (= expected (is (#'mt/-interceptor ?interceptor {} {})))
 
     inc {:enter inc}
     {:enter inc} {:enter inc}
@@ -18,80 +18,80 @@
   (let [?interceptor {:compile (constantly {:compile (constantly inc)})}]
     (testing "shallow compilation succeeds"
       (binding [mt/*max-compile-depth* 2]
-        (is (= {:enter inc} (#'mt/->interceptor ?interceptor {} {})))))
+        (is (= {:enter inc} (#'mt/-interceptor ?interceptor {} {})))))
     (testing "too deep compilation fails"
       (binding [mt/*max-compile-depth* 1]
-        (is (thrown? #?(:clj Exception, :cljs js/Error) (#'mt/->interceptor ?interceptor {} {})))))))
+        (is (thrown? #?(:clj Exception, :cljs js/Error) (#'mt/-interceptor ?interceptor {} {})))))))
 
 (deftest string->long
-  (is (= 1 (mt/string->long "1")))
-  (is (= 1 (mt/string->long 1)))
-  (is (= "abba" (mt/string->long "abba"))))
+  (is (= 1 (mt/-string->long "1")))
+  (is (= 1 (mt/-string->long 1)))
+  (is (= "abba" (mt/-string->long "abba"))))
 
 (deftest string->double
-  (is (= 1.0 (mt/string->double "1")))
-  (is (= 1.0 (mt/string->double 1.0)))
-  (is (= 1 (mt/string->double 1)))
-  (is (= "abba" (mt/string->double "abba"))))
+  (is (= 1.0 (mt/-string->double "1")))
+  (is (= 1.0 (mt/-string->double 1.0)))
+  (is (= 1 (mt/-string->double 1)))
+  (is (= "abba" (mt/-string->double "abba"))))
 
 (deftest string->keyword
-  (is (= :abba (mt/string->keyword "abba")))
-  (is (= :abba (mt/string->keyword :abba))))
+  (is (= :abba (mt/-string->keyword "abba")))
+  (is (= :abba (mt/-string->keyword :abba))))
 
 (deftest string->boolean
-  (is (= true (mt/string->boolean "true")))
-  (is (= false (mt/string->boolean "false")))
-  (is (= "abba" (mt/string->boolean "abba"))))
+  (is (= true (mt/-string->boolean "true")))
+  (is (= false (mt/-string->boolean "false")))
+  (is (= "abba" (mt/-string->boolean "abba"))))
 
 (deftest string->uuid
-  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/string->uuid "5f60751d-9bf7-4344-97ee-48643c9949ce")))
-  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/string->uuid #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce")))
-  (is (= "abba" (mt/string->uuid "abba"))))
+  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/-string->uuid "5f60751d-9bf7-4344-97ee-48643c9949ce")))
+  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/-string->uuid #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce")))
+  (is (= "abba" (mt/-string->uuid "abba"))))
 
 (deftest string->date
-  (is (= #inst "2018-04-27T18:25:37Z" (mt/string->date "2018-04-27T18:25:37Z")))
-  (is (= #inst "2018-04-27T00:00:00Z" (mt/string->date "2018-04-27")))
-  (is (= #inst "2018-04-27T05:00:00Z" (mt/string->date "2018-04-27T08:00:00+03:00")))
-  (is (= #inst "2018-04-27T18:25:37Z" (mt/string->date "2018-04-27T18:25:37.000Z")))
-  (is (= #inst "2018-04-27T18:25:37Z" (mt/string->date "2018-04-27T18:25:37.000+0000")))
-  (is (= #inst "2014-02-18T18:25:37Z" (mt/string->date #inst "2014-02-18T18:25:37Z")))
-  (is (= #inst "2018-04-27T00:00:00Z" (mt/string->date #inst "2018-04-27")))
-  (is (= #inst "2018-04-27T05:00:00Z" (mt/string->date #inst "2018-04-27T08:00:00+03:00")))
-  (is (= "abba" (mt/string->date "abba"))))
+  (is (= #inst "2018-04-27T18:25:37Z" (mt/-string->date "2018-04-27T18:25:37Z")))
+  (is (= #inst "2018-04-27T00:00:00Z" (mt/-string->date "2018-04-27")))
+  (is (= #inst "2018-04-27T05:00:00Z" (mt/-string->date "2018-04-27T08:00:00+03:00")))
+  (is (= #inst "2018-04-27T18:25:37Z" (mt/-string->date "2018-04-27T18:25:37.000Z")))
+  (is (= #inst "2018-04-27T18:25:37Z" (mt/-string->date "2018-04-27T18:25:37.000+0000")))
+  (is (= #inst "2014-02-18T18:25:37Z" (mt/-string->date #inst "2014-02-18T18:25:37Z")))
+  (is (= #inst "2018-04-27T00:00:00Z" (mt/-string->date #inst "2018-04-27")))
+  (is (= #inst "2018-04-27T05:00:00Z" (mt/-string->date #inst "2018-04-27T08:00:00+03:00")))
+  (is (= "abba" (mt/-string->date "abba"))))
 
 #?(:clj
    (deftest string->decimal
-     (is (= 42M (mt/string->decimal "42")))
-     (is (= 42.24M (mt/string->decimal "42.24")))
-     (is (= nil (mt/string->decimal nil)))
-     (is (= "42.42M" (mt/string->decimal "42.42M")))))
+     (is (= 42M (mt/-string->decimal "42")))
+     (is (= 42.24M (mt/-string->decimal "42.24")))
+     (is (= nil (mt/-string->decimal nil)))
+     (is (= "42.42M" (mt/-string->decimal "42.42M")))))
 
 (deftest date->string
-  (is (= "2014-02-18T18:25:37.000Z" (mt/date->string #inst "2014-02-18T18:25:37Z")))
-  (is (= "abba" (mt/date->string "abba"))))
+  (is (= "2014-02-18T18:25:37.000Z" (mt/-date->string #inst "2014-02-18T18:25:37Z")))
+  (is (= "abba" (mt/-date->string "abba"))))
 
 (deftest string->symbol
-  (is (= 'inc (mt/string->symbol "inc")))
-  (is (= 'inc (mt/string->symbol 'inc))))
+  (is (= 'inc (mt/-string->symbol "inc")))
+  (is (= 'inc (mt/-string->symbol 'inc))))
 
 (deftest string->nil
-  (is (= nil (mt/string->nil "")))
-  (is (= nil (mt/string->nil nil))))
+  (is (= nil (mt/-string->nil "")))
+  (is (= nil (mt/-string->nil nil))))
 
 (deftest number->double
-  #?(:clj (is (= 0.5 (mt/number->double 1/2))))
-  (is (= 1.0 (mt/number->double 1)))
-  (is (= "kikka" (mt/number->double "kikka"))))
+  #?(:clj (is (= 0.5 (mt/-number->double 1/2))))
+  (is (= 1.0 (mt/-number->double 1)))
+  (is (= "kikka" (mt/-number->double "kikka"))))
 
 (deftest any->string
-  #?(:clj (is (= "1/2" (mt/any->string 1/2))))
-  (is (= "0.5" (mt/any->string 0.5)))
-  (is (= nil (mt/any->string nil))))
+  #?(:clj (is (= "1/2" (mt/-any->string 1/2))))
+  (is (= "0.5" (mt/-any->string 0.5)))
+  (is (= nil (mt/-any->string nil))))
 
 (deftest any->any
-  #?(:clj (is (= 1/2 (mt/any->any 1/2))))
-  (is (= 0.5 (mt/any->any 0.5)))
-  (is (= nil (mt/any->any nil))))
+  #?(:clj (is (= 1/2 (mt/-any->any 1/2))))
+  (is (= 0.5 (mt/-any->any 0.5)))
+  (is (= nil (mt/-any->any nil))))
 
 (deftest transform-test
 
@@ -517,7 +517,7 @@
                                                :leave #(cond (and (int? %) (>= % 100)) (* 10 %)
                                                              (keyword? %) (keyword "decoded" (name %))
                                                              :else %)}}
-                          [pos-int? {:decode/string {:enter mt/string->long
+                          [pos-int? {:decode/string {:enter mt/-string->long
                                                      :leave #(if (int? %) (inc %) %)}}]
                           keyword?]
                          x mt/string-transformer)))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -192,14 +192,15 @@
     (testing "json transformer"
       (testing "json vectors"
         (testing "by default"
-          (testing "sequences are decoded as vectors"
-            (is (vector? (m/decode [:vector string?] '("1") (mt/json-transformer)))))
+          (testing "sequences are not decoded as vectors"
+            (is (list? (m/decode [:vector string?] '("1") (mt/json-transformer)))))
           (testing "sets are not"
             (is (set? (m/decode [:vector string?] #{"1"} (mt/json-transformer))))))
         (testing "using option"
-          (testing "decoding can be turned off"
-            (is (list? (m/decode [:vector string?] '("1") (mt/json-transformer {::mt/json-arrays true}))))
-            (is (set? (m/decode [:vector string?] #{"1"} (mt/json-transformer {::mt/json-arrays true})))))))))
+          (testing "sequences are decoded as vectors"
+            (is (vector? (m/decode [:vector string?] '("1") (mt/json-transformer {::mt/json-vectors true})))))
+          (testing "sets are not"
+            (is (set? (m/decode [:vector string?] #{"1"} (mt/json-transformer {::mt/json-vectors true})))))))))
 
   (testing "map"
     (testing "decode"
@@ -243,7 +244,6 @@
       (is (= nil (m/encode [:tuple keyword? int?] nil mt/string-transformer)))
       (is (= ["kikka" "1" "2"] (m/encode [:tuple keyword? int?] [:kikka 1 "2"] mt/string-transformer))))))
 
-;; TODO: this is wrong!
 (deftest collection-transform-test
   (testing "decode"
     (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] mt/collection-transformer)))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -247,6 +247,8 @@
 (deftest collection-transform-test
   (testing "decode"
     (is (= #{1 2 3} (m/decode [:set int?] [1 2 3] mt/collection-transformer)))
+    ;; sets to sequences / vectors, lose order, is this a good transformation?
+    (is (= [1 3 2] (m/decode [:vector int?] #{1 2 3} mt/collection-transformer)))
     (is (= #{1 2 3} (m/decode [:set {:decode/string #(map str %)} int?]
                               "123" mt/string-transformer))))
   (testing "encode"


### PR DESCRIPTION
Some **BREAKING** changes before release:

* collection transformers don't coerce their type if children don't need transformation
* `mt/string-transformer` transforms set, vectors and sequences
* `mt/json-transformer` trnansforms sets and sequences
* `mt/collection-transformer` transforms all
* move defs to defns to allow DCE with CLJS advanced
* rename all internals