### PR TITLE
Optional SCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - run: npm ci
       - run: mkdir -p test-results
       - run: bin/kaocha --plugin kaocha.plugin/junit-xml --junit-xml-file  test-results/kaocha/results.xml
+      - run: bin/node
       - store_test_results:
           path: test-results
       - save_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 out
 .nrepl-port
 .dir-locals.el
+cljs-test-runner-out

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 ## UNRELEASED
 
-* ???
+* 23.7.2020
+  * **BREAKING:**: `sci` is not a default dependency. Enabling sci-support:
+    * **Clojure**: add a dependency to `borkdude/sci`
+    * **ClojureScript**: also require `sci.core` (directly or via `:preloads`)
+* 18.7.2020
   * **BREAKING:**: big cleanup of `malli.transform` internals.
 * 12.7.2020
   * **BREAKING:**: `malli.mermaid` is removed (in favor of `malli.dot`)  

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Plain data Schemas for Clojure/Script.
 - Schemas as plain data
 - [Validation](#examples) and [Value Transformation](#value-transformation)
 - First class [Error Messages](#error-messages) witg [Spell Checking](#spell-checking)
+- [Serializable function schemas](#serializable-functions)
 - [Generating values](#value-generation) from Schemas
 - [Inferring Schemas](#inferring-schemas) from sample values
 - Tools for [Programming with Schemas](#programming-with-schemas)
@@ -144,7 +145,12 @@ Using `:string` Schema:
 ; => false
 ```
 
-Serializable function schemas using [sci](https://github.com/borkdude/sci):
+## Serializable Functions
+
+Enabling serializable function schemas requires [sci](https://github.com/borkdude/sci) as external dependency. If
+it is not present, the malli function evaluater throws `:sci-not-available` exception.
+
+For ClojureScript, you also need to require `sci.core` manually, either directly or via [`:preloads`](https://clojurescript.org/reference/compiler-options#preloads).
 
 ```clj
 (def my-schema

--- a/bin/node
+++ b/bin/node
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo 'Running CLJS test in Node with optimizations :none'
+clojure -A:test:cljs-test-runner -c '{:optimizations :none, :preloads [sci.core]}' $@
+
+echo 'Running CLJS test in Node with optimizations :advanced'
+clojure -A:test:cljs-test-runner -c '{:optimizations :advanced, :preloads [sci.core]}' $@

--- a/bin/node
+++ b/bin/node
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 echo 'Running CLJS test in Node with optimizations :none'
-clojure -A:test:cljs-test-runner -c '{:optimizations :none, :preloads [sci.core]}' $@
+clojure -A:test:cljs-test-runner -c '{:optimizations :none, :preloads [sci.core]}' "$@"
 
 echo 'Running CLJS test in Node with optimizations :advanced'
-clojure -A:test:cljs-test-runner -c '{:optimizations :advanced, :preloads [sci.core]}' $@
+clojure -A:test:cljs-test-runner -c '{:optimizations :advanced, :preloads [sci.core]}' "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -5,10 +5,17 @@
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
                                metosin/spec-tools {:mvn/version "0.10.3"}
                                metosin/schema-tools {:mvn/version "0.12.2"}
+                               borkdude/sci {:git/url "https://github.com/borkdude/sci.git"
+                                             :sha "b310358cd41f761d7bbd50227a36d1160938ce71"}
                                prismatic/schema {:mvn/version "1.1.12"}
                                meta-merge {:mvn/version "1.0.0"}
                                org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
                                                         :sha "8498f9cb352135579b6d3a0a5d15c40e5c2647ce"}}}
+           :cljs-test-runner {:extra-deps {olical/cljs-test-runner {:mvn/version "3.7.0"}}
+                              :extra-paths ["test" "cljs-test-runner-out/gen"]
+                              :main-opts ["-m" "cljs-test-runner.main" "-d" "test"]}
+           :sci {:extra-deps {borkdude/sci {:git/url "https://github.com/borkdude/sci.git"
+                                            :sha "b310358cd41f761d7bbd50227a36d1160938ce71"}}}
            :shadow {:extra-paths ["app"]
                     :extra-deps {thheller/shadow-cljs {:mvn/version "2.10.10"}}}
            :slow {:extra-deps {io.dominic/slow-namespace-clj
@@ -33,7 +40,8 @@
                              "-Xmx4096m"
                              "-Dclojure.compiler.direct-linking=true"]}}
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        borkdude/sci {:mvn/version "0.1.0"}
+        borkdude/dynaload {:git/url "https://github.com/borkdude/dynaload.git"
+                           :sha "52f71bc2cb7389a932835fe02f185e3801f7e063"}
         borkdude/edamame {:mvn/version "0.0.11-alpha.12"}
         org.clojure/test.check {:mvn/version "1.0.0"}
         com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -19,8 +19,6 @@
           :app2 {:target :browser
                  :closure-defines {malli.registry/type "custom"}
                  :modules {:cljs {:entries [cljs.core]}
-                           #_#_:sci {:entries [sci.core]
-                                     :depends-on #{:cljs}}
                            :malli {:entries [malli.core]
                                    :depends-on #{:cljs}}
                            :app {:entries [malli.app2]

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,19 +1,37 @@
-{:deps {:aliases [:shadow]}
+{:deps {:aliases [:shadow :sci]}
  :builds {:app {:target :browser
                 :closure-defines {malli.registry/type "default"}
                 :modules {:cljs {:entries [cljs.core]}
-                          :sci {:entries [sci.core]
-                                :depends-on #{:cljs}}
                           :malli {:entries [malli.core]
-                                  :depends-on #{:cljs :sci}}
+                                  :depends-on #{:cljs}}
                           :app {:entries [malli.app]
                                 :depends-on #{:malli}}}}
+          :app-sci {:target :browser
+                    :closure-defines {malli.registry/type "default"}
+                    :devtools {:preloads [sci.core]}
+                    :modules {:cljs {:entries [cljs.core]}
+                              :sci {:entries [sci.core]
+                                    :depends-on #{:cljs}}
+                              :malli {:entries [malli.core]
+                                      :depends-on #{:cljs :sci}}
+                              :app {:entries [malli.app]
+                                    :depends-on #{:malli}}}}
           :app2 {:target :browser
                  :closure-defines {malli.registry/type "custom"}
                  :modules {:cljs {:entries [cljs.core]}
-                           :sci {:entries [sci.core]
-                                 :depends-on #{:cljs}}
+                           #_#_:sci {:entries [sci.core]
+                                     :depends-on #{:cljs}}
                            :malli {:entries [malli.core]
-                                   :depends-on #{:cljs :sci}}
+                                   :depends-on #{:cljs}}
                            :app {:entries [malli.app2]
-                                 :depends-on #{:malli}}}}}}
+                                 :depends-on #{:malli}}}}
+          :app2-sci {:target :browser
+                     :closure-defines {malli.registry/type "custom"}
+                     :devtools {:preloads [sci.core]}
+                     :modules {:cljs {:entries [cljs.core]}
+                               :sci {:entries [sci.core]
+                                     :depends-on #{:cljs}}
+                               :malli {:entries [malli.core]
+                                       :depends-on #{:cljs :sci}}
+                               :app {:entries [malli.app2]
+                                     :depends-on #{:malli}}}}}}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,6 +1,6 @@
 (ns malli.core
   (:refer-clojure :exclude [eval type -deref -lookup])
-  (:require [sci.core :as sci]
+  (:require [malli.sci :as ms]
             [malli.registry :as mr])
   #?(:clj (:import (java.util.regex Pattern)
                    (clojure.lang IDeref))))
@@ -1025,12 +1025,18 @@
      (if (satisfies? MapSchema schema)
        (-map-entries schema)))))
 
-(defn ^:no-doc eval [?code]
-  (if (fn? ?code) ?code (sci/eval-string (str ?code) {:preset :termination-safe
-                                                      :bindings {'m/properties properties
-                                                                 'm/type type
-                                                                 'm/children children
-                                                                 'm/map-entries map-entries}})))
+;;
+;; eval
+;;
+
+(let [-eval (or (ms/evaluator {:preset :termination-safe
+                               :bindings {'m/properties properties
+                                          'm/type type
+                                          'm/children children
+                                          'm/map-entries map-entries}})
+                #(fail! :sci-not-available {:code %}))]
+  (defn eval [?code] (if (fn? ?code) ?code (-eval (str ?code)))))
+
 ;;
 ;; Walkers
 ;;

--- a/src/malli/sci.cljc
+++ b/src/malli/sci.cljc
@@ -1,0 +1,11 @@
+(ns malli.sci
+  (:require #?(:clj  [borkdude.dynaload-clj :refer [dynaload]]
+               :cljs [borkdude.dynaload-cljs :refer-macros [dynaload]])))
+
+(defn evaluator [options]
+  (let [eval-string* @(dynaload 'sci.core/eval-string* {:default nil})
+        init @(dynaload 'sci.core/init {:default nil})
+        fork @(dynaload 'sci.core/fork {:default nil})]
+    (if (and eval-string* init fork)
+      (let [ctx (init options)]
+        (fn eval [s] (eval-string* (fork ctx) s))))))

--- a/tests.edn
+++ b/tests.edn
@@ -1,5 +1,8 @@
 #kaocha/v1
 {:tests [{:id   :unit
           :type :kaocha.type/clojure.test}
-         {:id   :unit-cljs
-          :type :kaocha.type/cljs}]}
+         ;; https://github.com/lambdaisland/kaocha/issues/152
+         #_{:id   :unit-cljs
+            :plugins [:preloads]
+            :kaocha.plugin.preloads/ns-names [sci.core]
+            :type :kaocha.type/cljs}]}


### PR DESCRIPTION
load `borkdude/sci` using `borkdude/dynaload` to enable:
* faster standalone usage for JVM (2.5sec -> 0.5sec to load `malli.core`)
* smaller js-bundles: 120kb -> 7kb

bit hacky, but works. in future sci should be enabled using explicit option, like:

```clj
(m/schema 
  [:fn '(fn [x] (> x 10))] 
  {:evaluator malli.sci/evaluator})
```

# example app

https://github.com/metosin/malli/blob/master/app/malli/app2.cljc

## with sci

<img width="911" alt="with-sci" src="https://user-images.githubusercontent.com/567532/88267107-04e04e80-ccd9-11ea-9ed1-63efe50ca7d9.png">


## without sci

<img width="910" alt="no-sci" src="https://user-images.githubusercontent.com/567532/88267114-09a50280-ccd9-11ea-8370-976873408ed2.png">
