### PR TITLE
DRAFT: Default options

### DIFF
--- a/app/malli/app2.cljc
+++ b/app/malli/app2.cljc
@@ -3,24 +3,24 @@
 ;; - npx shadow-cljs release app2 --pseudo-names
 (ns malli.app2
   (:require [malli.core :as m]
-            [malli.registry :as mr]))
+            [malli.options :as mo]))
 
-;; - cljs: :closure-defines {malli.registry/type "custom"}
-;; -  clj: :jvm-opts ["-Dmalli.registry/type=custom"]
+;; - cljs: :closure-defines {malli.options/type "custom"}
+;; -  clj: :jvm-opts ["-Dmalli.options/type=custom"]
 
 ;; just what is needed (1.2kb gzipped)
-(def registry
-  {:string (m/-string-schema)
-   :maybe (m/-maybe-schema)
-   :map (m/-map-schema)})
+(def options
+  {:registry {:string (m/-string-schema)
+              :maybe (m/-maybe-schema)
+              :map (m/-map-schema)}})
 
 (m/validate
   [:map [:maybe [:maybe :string]]]
   {:maybe "sheep"}
-  {:registry registry})
+  options)
 ; => true
 
-(mr/set-default-registry! registry)
+(mo/reset-custom-default-options! options)
 
 (m/validate
   [:map [:maybe [:maybe :string]]]

--- a/app/malli/app3.cljc
+++ b/app/malli/app3.cljc
@@ -1,0 +1,15 @@
+;; this file is used to view the generated bundle sizes
+;; - npx shadow-cljs run shadow.cljs.build-report app3 /tmp/report.html
+;; - npx shadow-cljs release app3 --pseudo-names
+(ns malli.app3
+  (:require [malli.core :as m]))
+
+;; - cljs: :closure-defines {malli.options/type "empty"}
+;; -  clj: :jvm-opts ["-Dmalli.options/type=empty"]
+
+;; just what is needed (1.2kb gzipped)
+(m/validate
+  [:string {:min 1}]
+  "sheep"
+  {:registry {:string (m/-string-schema)}})
+; => true

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -1,13 +1,13 @@
 {:deps {:aliases [:shadow :sci]}
  :builds {:app {:target :browser
-                :closure-defines {malli.registry/type "default"}
+                :closure-defines {malli.options/type "default"}
                 :modules {:cljs {:entries [cljs.core]}
                           :malli {:entries [malli.core]
                                   :depends-on #{:cljs}}
                           :app {:entries [malli.app]
                                 :depends-on #{:malli}}}}
           :app-sci {:target :browser
-                    :closure-defines {malli.registry/type "default"}
+                    :closure-defines {malli.options/type "default"}
                     :devtools {:preloads [sci.core]}
                     :modules {:cljs {:entries [cljs.core]}
                               :sci {:entries [sci.core]
@@ -17,14 +17,14 @@
                               :app {:entries [malli.app]
                                     :depends-on #{:malli}}}}
           :app2 {:target :browser
-                 :closure-defines {malli.registry/type "custom"}
+                 :closure-defines {malli.options/type "custom"}
                  :modules {:cljs {:entries [cljs.core]}
                            :malli {:entries [malli.core]
                                    :depends-on #{:cljs}}
                            :app {:entries [malli.app2]
                                  :depends-on #{:malli}}}}
           :app2-sci {:target :browser
-                     :closure-defines {malli.registry/type "custom"}
+                     :closure-defines {malli.options/type "custom"}
                      :devtools {:preloads [sci.core]}
                      :modules {:cljs {:entries [cljs.core]}
                                :sci {:entries [sci.core]
@@ -32,4 +32,11 @@
                                :malli {:entries [malli.core]
                                        :depends-on #{:cljs :sci}}
                                :app {:entries [malli.app2]
-                                     :depends-on #{:malli}}}}}}
+                                     :depends-on #{:malli}}}}
+          :app3 {:target :browser
+                 :closure-defines {malli.options/type "empty"}
+                 :modules {:cljs {:entries [cljs.core]}
+                           :malli {:entries [malli.core]
+                                   :depends-on #{:cljs}}
+                           :app {:entries [malli.app3]
+                                 :depends-on #{:malli}}}}}}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -615,7 +615,7 @@
   (reify IntoSchema
     (-into-schema [_ properties children options]
       (-check-children! :fn properties children {:min 1, :max 1})
-      (let [f (eval (first children))
+      (let [f (eval (first children) options)
             form (create-form :fn properties children)]
         ^{:type ::schema}
         (reify Schema
@@ -676,7 +676,7 @@
     (-into-schema [_ properties children options]
       (let [{:keys [children entries forms]} (-parse-entry-syntax children options)
             form (create-form :multi properties forms)
-            dispatch (eval (:dispatch properties))
+            dispatch (eval (:dispatch properties) options)
             dispatch-map (->> (for [[d _ s] entries] [d s]) (into {}))]
         (when-not dispatch
           (fail! ::missing-property {:key :dispatch}))
@@ -1025,17 +1025,13 @@
      (if (satisfies? MapSchema schema)
        (-map-entries schema)))))
 
-;;
-;; eval
-;;
-
 (let [-eval (or (ms/evaluator {:preset :termination-safe
                                :bindings {'m/properties properties
                                           'm/type type
                                           'm/children children
                                           'm/map-entries map-entries}})
                 #(fail! :sci-not-available {:code %}))]
-  (defn eval [?code] (if (fn? ?code) ?code (-eval (str ?code)))))
+  (defn eval [?code _options] (if (fn? ?code) ?code (-eval (str ?code)))))
 
 ;;
 ;; Walkers

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -52,7 +52,7 @@
 ;;
 
 (defn transform
-  ([?schema] (transform ?schema nil))
+  ([?schema] (transform ?schema (m/default-options)))
   ([?schema options]
    (let [registry (-> ?schema (m/schema options) -lift -collect -normalize :registry)
          entity? #(->> % (get registry) m/properties ::entity)

--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -5,12 +5,12 @@
 
 (defn write-string
   ([?schema]
-   (write-string ?schema nil))
+   (write-string ?schema (m/default-options)))
   ([?schema options]
    (pr-str (m/form ?schema options))))
 
 (defn read-string
   ([form]
-   (read-string form nil))
+   (read-string form (m/default-options)))
   ([form options]
    (m/schema (edamame/parse-string form {:dispatch {\# {\" #(re-pattern %)}}}) options)))

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -79,7 +79,7 @@
   (if (map? x) (get x locale) x))
 
 (defn- -message [error x locale options]
-  (if x (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn) error options))
+  (if x (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn options) error options))
             (-maybe-localized (:error/message x) locale))))
 
 (defn- -ensure [x k]

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -162,13 +162,13 @@
 
 (defn error-path
   ([error]
-   (error-path error nil))
+   (error-path error (m/default-options)))
   ([error options]
    (into (:in error) (-path error options))))
 
 (defn error-message
   ([error]
-   (error-message error nil))
+   (error-message error (m/default-options)))
   ([{:keys [schema type] :as error}
     {:keys [errors locale default-locale]
      :or {errors default-errors
@@ -186,21 +186,21 @@
 
 (defn with-error-message
   ([error]
-   (with-error-message error nil))
+   (with-error-message error (m/default-options)))
   ([error options]
    (assoc error :message (error-message error options))))
 
 (defn with-error-messages
   ([explanation]
-   (with-error-messages explanation nil))
-  ([explanation {f :wrap :or {f identity} :as options}]
+   (with-error-messages explanation (m/default-options)))
+  ([explanation {f ::wrap :or {f identity} :as options}]
    (when explanation
      (update explanation :errors (partial map #(f (with-error-message % options)))))))
 
 (defn with-spell-checking
   ([explanation]
-   (with-spell-checking explanation nil))
-  ([explanation {:keys [keep-likely-misspelled-of]}]
+   (with-spell-checking explanation (m/default-options)))
+  ([explanation {::keys [keep-likely-misspelled-of]}]
    (when explanation
      (let [!likely-misspelling-of (atom #{})]
        (update
@@ -226,8 +226,8 @@
 
 (defn humanize
   ([explanation]
-   (humanize explanation nil))
-  ([{:keys [value errors]} {f :wrap :or {f :message} :as options}]
+   (humanize explanation (m/default-options)))
+  ([{:keys [value errors]} {f ::wrap :or {f :message} :as options}]
    (if errors
      (if (coll? value)
        (reduce

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -148,23 +148,22 @@
 ;;
 
 (defn generator
-  ([?schema]
-   (generator ?schema (m/default-options)))
-  ([?schema options]
-   (-create (m/schema ?schema options) options)))
+  ([?schema-or-generator]
+   (generator ?schema-or-generator (m/default-options)))
+  ([?schema-or-generator options]
+   (if (gen/generator? ?schema-or-generator) ?schema-or-generator (-create (m/schema ?schema-or-generator options) options))))
 
 (defn generate
-  ([?gen-or-schema]
-   (generate ?gen-or-schema (m/default-options)))
-  ([?gen-or-schema {:keys [seed size] :or {size 1} :as options}]
-   (let [gen (if (gen/generator? ?gen-or-schema) ?gen-or-schema (generator ?gen-or-schema options))]
-     (rose/root (gen/call-gen gen (-random seed) size)))))
+  ([?schema-or-generator]
+   (generate ?schema-or-generator (m/default-options)))
+  ([?schema-or-generator {:keys [seed size] :or {size 1} :as options}]
+   (rose/root (gen/call-gen (generator ?schema-or-generator options) (-random seed) size))))
 
 (defn sample
-  ([?gen-or-schema]
-   (sample ?gen-or-schema (m/default-options)))
-  ([?gen-or-schema {:keys [seed size] :or {size 10} :as options}]
-   (let [gen (if (gen/generator? ?gen-or-schema) ?gen-or-schema (generator ?gen-or-schema options))]
+  ([?schema-or-generator]
+   (sample ?schema-or-generator (m/default-options)))
+  ([?schema-or-generator {:keys [seed size] :or {size 10} :as options}]
+   (let [gen (generator ?schema-or-generator options)]
      (->> (gen/make-size-range-seq size)
           (map #(rose/root (gen/call-gen gen %1 %2))
                (gen/lazy-random-states (-random seed)))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -138,7 +138,7 @@
         gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema options) (-schema-generator schema options))))
         elements (when elements (gen/elements elements))]
     (cond
-      fmap (gen/fmap (m/eval fmap) (or elements gen (gen/return nil)))
+      fmap (gen/fmap (m/eval fmap options) (or elements gen (gen/return nil)))
       elements elements
       gen gen
       :else (m/fail! ::no-generator {:schema schema, :options options}))))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -149,20 +149,20 @@
 
 (defn generator
   ([?schema]
-   (generator ?schema nil))
+   (generator ?schema (m/default-options)))
   ([?schema options]
    (-create (m/schema ?schema options) options)))
 
 (defn generate
   ([?gen-or-schema]
-   (generate ?gen-or-schema nil))
+   (generate ?gen-or-schema (m/default-options)))
   ([?gen-or-schema {:keys [seed size] :or {size 1} :as options}]
    (let [gen (if (gen/generator? ?gen-or-schema) ?gen-or-schema (generator ?gen-or-schema options))]
      (rose/root (gen/call-gen gen (-random seed) size)))))
 
 (defn sample
   ([?gen-or-schema]
-   (sample ?gen-or-schema nil))
+   (sample ?gen-or-schema (m/default-options)))
   ([?gen-or-schema {:keys [seed size] :or {size 10} :as options}]
    (let [gen (if (gen/generator? ?gen-or-schema) ?gen-or-schema (generator ?gen-or-schema options))]
      (->> (gen/make-size-range-seq size)

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -108,6 +108,6 @@
 
 (defn transform
   ([?schema]
-   (transform ?schema nil))
+   (transform ?schema (m/default-options)))
   ([?schema options]
    (m/walk ?schema -json-schema-walker options)))

--- a/src/malli/options.cljc
+++ b/src/malli/options.cljc
@@ -1,0 +1,19 @@
+(ns malli.options
+  (:refer-clojure :exclude [type])
+  #?(:clj (:import (clojure.lang IDeref))))
+
+#?(:cljs (goog-define type "default")
+   :clj  (def type (as-> (or (System/getProperty "malli.options/type") "default") $ (.intern $))))
+
+(defn options [x] (reify IDeref (#?(:cljs cljs.core/-deref, :clj deref) [_] (if (map? x) x (deref x)))))
+
+(def ^:private options* (atom nil))
+
+(defn update-default-options! [& args]
+  (if-not (identical? type "default")
+    (apply swap! options* args)
+    (throw (ex-info (str "can't set default options with type " (pr-str type)) {:type type})))
+  (options options*))
+
+(defn reset-custom-default-options! [options]
+  (update-default-options! (constantly options)))

--- a/src/malli/provider.cljc
+++ b/src/malli/provider.cljc
@@ -61,13 +61,13 @@
 
 (defn stats
   ([xs]
-   (stats xs nil))
+   (stats xs (m/default-options)))
   ([xs options]
    (reduce (->infer options) options xs)))
 
 (defn schema
   ([stats]
-   (schema stats nil))
+   (schema stats (m/default-options)))
   ([{:keys [types] :as stats} options]
    (cond
      (= 1 (count (keys types)))
@@ -81,6 +81,6 @@
 
 (defn provide
   ([xs]
-   (provide xs nil))
+   (provide xs (m/default-options)))
   ([xs options]
    (-> xs (stats options) (schema options))))

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -1,8 +1,4 @@
-(ns malli.registry
-  (:refer-clojure :exclude [type]))
-
-#?(:cljs (goog-define type "default")
-   :clj  (def type (as-> (or (System/getProperty "malli.registry/type") "default") $ (.intern $))))
+(ns malli.registry)
 
 (defprotocol Registry
   (-schema [this type] "returns the schema from a registry")
@@ -17,23 +13,6 @@
 (defn registry [?registry]
   (cond (satisfies? Registry ?registry) ?registry
         (map? ?registry) (simple-registry ?registry)))
-
-;;
-;; custom
-;;
-
-(def ^:private registry* (atom (registry {})))
-
-(defn set-default-registry! [?registry]
-  (if (identical? type "custom")
-    (reset! registry* (registry ?registry))
-    (throw (ex-info "can't set default registry" {:type type}))))
-
-(defn ^:no-doc custom-default-registry []
-  (reify
-    Registry
-    (-schema [_ type] (-schema @registry* type))
-    (-schemas [_] (-schemas @registry*))))
 
 (defn composite-registry [& ?registries]
   (let [registries (mapv registry ?registries)]

--- a/src/malli/sci.cljc
+++ b/src/malli/sci.cljc
@@ -1,11 +1,6 @@
 (ns malli.sci
-  (:require #?(:clj  [borkdude.dynaload-clj :refer [dynaload]]
-               :cljs [borkdude.dynaload-cljs :refer-macros [dynaload]])))
+  (:require [sci.core :as sci]))
 
 (defn evaluator [options]
-  (let [eval-string* @(dynaload 'sci.core/eval-string* {:default nil})
-        init @(dynaload 'sci.core/init {:default nil})
-        fork @(dynaload 'sci.core/fork {:default nil})]
-    (if (and eval-string* init fork)
-      (let [ctx (init options)]
-        (fn eval [s] (eval-string* (fork ctx) s))))))
+   (let [ctx (sci/init options)]
+     (fn eval [s] (sci/eval-string* (sci/fork ctx) s))))

--- a/src/malli/sci_dynamic.cljc
+++ b/src/malli/sci_dynamic.cljc
@@ -1,0 +1,11 @@
+(ns malli.sci-dynamic
+  (:require #?(:clj  [borkdude.dynaload-clj :refer [dynaload]]
+               :cljs [borkdude.dynaload-cljs :refer-macros [dynaload]])))
+
+(defn evaluator [options]
+  (let [eval-string* @(dynaload 'sci.core/eval-string* {:default nil})
+        init @(dynaload 'sci.core/init {:default nil})
+        fork @(dynaload 'sci.core/fork {:default nil})]
+    (if (and eval-string* init fork)
+      (let [ctx (init options)]
+        (fn eval [s] (eval-string* (fork ctx) s))))))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -39,6 +39,6 @@
 
 (defn transform
   ([?schema]
-   (transform ?schema nil))
+   (transform ?schema (m/default-options)))
   ([?schema options]
    (m/walk ?schema -swagger-walker options)))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -298,7 +298,7 @@
   (let [->data (fn [ts default name key] {:transformers ts
                                           :default default
                                           :key (if name (keyword (str key "/" name)))})
-        ->eval (fn [x] (if (map? x) (reduce-kv (fn [x k v] (assoc x k (m/eval v))) x x) (m/eval x)))
+        ->eval (fn [x options] (if (map? x) (reduce-kv (fn [x k v] (assoc x k (m/eval v options))) x x) (m/eval x options)))
         ->chain (comp m/-transformer-chain m/into-transformer)
         chain (->> ?transformers (keep identity) (mapcat #(if (map? %) [%] (->chain %))) (vec))
         chain' (->> chain (mapv #(let [name (some-> % :name name)]
@@ -311,7 +311,7 @@
         (-value-transformer [_ schema method options]
           (reduce
             (fn [acc {{:keys [key default transformers]} method}]
-              (if-let [?interceptor (or (some-> (get (m/properties schema) key) ->eval)
+              (if-let [?interceptor (or (some-> (get (m/properties schema) key) (->eval options))
                                         (get transformers (m/type schema))
                                         default)]
                 (let [interceptor (-interceptor ?interceptor schema options)]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -5,7 +5,7 @@
 
 (defn ^:no-doc equals
   ([?schema1 ?schema2]
-   (equals ?schema1 ?schema2 nil))
+   (equals ?schema1 ?schema2 (m/default-options)))
   ([?schema1 ?schema2 options]
    (= (m/form ?schema1 options) (m/form ?schema2 options))))
 
@@ -33,7 +33,7 @@
   "Prewalks the Schema recursively with a 3-arity fn [schema in options], returns with
   and as soon as the function returns non-null value."
   ([?schema f]
-   (find-first ?schema f nil))
+   (find-first ?schema f (m/default-options)))
   ([?schema f options]
    (let [result (atom nil)]
      (m/-walk
@@ -58,7 +58,7 @@
   | `:merge-default`  | `schema1 schema2 options -> schema` fn to merge unknown entries
   | `:merge-required` | `boolean boolean -> boolean` fn to resolve how required keys are merged"
   ([?schema1 ?schema2]
-   (merge ?schema1 ?schema2 nil))
+   (merge ?schema1 ?schema2 (m/default-options)))
   ([?schema1 ?schema2 options]
    (let [[schema1 schema2 :as schemas] [(if ?schema1 (m/schema ?schema1 options))
                                         (if ?schema2 (m/schema ?schema2 options))]
@@ -94,7 +94,7 @@
 (defn union
   "Union of two schemas. See [[merge]] for more details."
   ([?schema1 ?schema2]
-   (union ?schema1 ?schema2 nil))
+   (union ?schema1 ?schema2 (m/default-options)))
   ([?schema1 ?schema2 options]
    (let [merge-default (fn [s1 s2 options] (if (equals s1 s2) s1 (m/schema [:or s1 s2] options)))
          merge-required (fn [r1 r2] (and r1 r2))]
@@ -117,7 +117,7 @@
   "Closes recursively all :map schemas by adding `{:closed true}`
   property, unless schema explicitely open with `{:closed false}`"
   ([schema]
-   (closed-schema schema nil))
+   (closed-schema schema (m/default-options)))
   ([schema options]
    (m/walk
      schema
@@ -131,7 +131,7 @@
   "Closes recursively all :map schemas by removing `:closed`
   property, unless schema explicitely open with `{:closed false}`"
   ([schema]
-   (open-schema schema nil))
+   (open-schema schema (m/default-options)))
   ([schema options]
    (m/walk
      schema
@@ -166,9 +166,9 @@
 (defn optional-keys
   "Makes map keys optional."
   ([?schema]
-   (optional-keys ?schema nil nil))
+   (optional-keys ?schema nil (m/default-options)))
   ([?schema ?keys]
-   (let [[keys options] (if (map? ?keys) [nil ?keys] [?keys nil])]
+   (let [[keys options] (if (map? ?keys) [nil ?keys] [?keys (m/default-options)])]
      (optional-keys ?schema keys options)))
   ([?schema keys options]
    (let [schema (m/schema ?schema options)
@@ -179,9 +179,9 @@
 (defn required-keys
   "Makes map keys required."
   ([?schema]
-   (required-keys ?schema nil nil))
+   (required-keys ?schema nil (m/default-options)))
   ([?schema ?keys]
-   (let [[keys options] (if (map? ?keys) [nil ?keys] [?keys nil])]
+   (let [[keys options] (if (map? ?keys) [nil ?keys] [?keys (m/default-options)])]
      (required-keys ?schema keys options)))
   ([?schema keys options]
    (let [schema (m/schema ?schema options)
@@ -193,7 +193,7 @@
 (defn select-keys
   "Like [[clojure.core/select-keys]], but for MapSchemas."
   ([?schema keys]
-   (select-keys ?schema keys nil))
+   (select-keys ?schema keys (m/default-options)))
   ([?schema keys options]
    (let [schema (m/schema ?schema options)
          key-set (set keys)]
@@ -202,7 +202,7 @@
 (defn dissoc
   "Like [[clojure.core/dissoc]], but for MapSchemas."
   ([?schema key]
-   (dissoc ?schema key nil))
+   (dissoc ?schema key (m/default-options)))
   ([?schema key options]
    (let [schema (m/schema ?schema options)]
      (transform-entries schema (partial remove (fn [[k]] (= key k))) options))))
@@ -214,7 +214,7 @@
 (defn get
   "Like [[clojure.core/get]], but for LensSchemas."
   ([?schema k]
-   (get ?schema k nil))
+   (get ?schema k (m/default-options)))
   ([?schema k options]
    (let [schema (m/schema (or ?schema :map) options)]
      (m/-get schema k nil))))
@@ -222,7 +222,7 @@
 (defn assoc
   "Like [[clojure.core/assoc]], but for LensSchemas."
   ([?schema key value]
-   (assoc ?schema key value nil))
+   (assoc ?schema key value (m/default-options)))
   ([?schema key value options]
    (let [schema (m/schema (or ?schema :map) options)]
      (m/-set schema key value))))
@@ -237,7 +237,7 @@
 (defn get-in
   "Like [[clojure.core/get-in]], but for LensSchemas."
   ([?schema ks]
-   (get-in ?schema ks nil))
+   (get-in ?schema ks (m/default-options)))
   ([?schema [k & ks] options]
    (let [schema (get (m/schema (or ?schema :map) options) k)]
      (if ks (get-in schema ks) schema))))
@@ -245,7 +245,7 @@
 (defn assoc-in
   "Like [[clojure.core/assoc-in]], but for LensSchemas."
   ([?schema ks value]
-   (assoc-in ?schema ks value nil))
+   (assoc-in ?schema ks value (m/default-options)))
   ([?schema [k & ks] value options]
    (let [schema (m/schema (or ?schema :map) options)]
      (assoc schema k (if ks (assoc-in (get schema k) ks value) value)))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -54,16 +54,16 @@
                   [:x boolean?]] nil))))
 
 (deftest eval-test
-  (is (= 2 ((m/eval inc) 1)))
-  (is (= 2 ((m/eval 'inc) 1)))
-  (is (= 2 ((m/eval '#(inc %)) 1)))
-  (is (= 2 ((m/eval '#(inc %1)) 1)))
-  (is (= 2 ((m/eval '(fn [x] (inc x))) 1)))
-  (is (= 2 ((m/eval "(fn [x] (inc x))") 1)))
-  (is (= {:district 9} (m/eval "(m/properties [int? {:district 9}])")))
-  (is (= :maybe (m/eval "(m/type [:maybe int?])")))
-  (is (= ['int? 'string?] (map m/form (m/eval "(m/children [:or {:some \"props\"} int? string?])"))))
-  (is (entries= [[:x nil 'int?] [:y nil 'string?]] (m/eval "(m/map-entries [:map [:x int?] [:y string?]])"))))
+  (is (= 2 ((m/eval inc nil) 1)))
+  (is (= 2 ((m/eval 'inc nil) 1)))
+  (is (= 2 ((m/eval '#(inc %) nil) 1)))
+  (is (= 2 ((m/eval '#(inc %1) nil) 1)))
+  (is (= 2 ((m/eval '(fn [x] (inc x)) nil) 1)))
+  (is (= 2 ((m/eval "(fn [x] (inc x))" nil) 1)))
+  (is (= {:district 9} (m/eval "(m/properties [int? {:district 9}])" nil)))
+  (is (= :maybe (m/eval "(m/type [:maybe int?])" nil)))
+  (is (= ['int? 'string?] (map m/form (m/eval "(m/children [:or {:some \"props\"} int? string?])" nil))))
+  (is (entries= [[:x nil 'int?] [:y nil 'string?]] (m/eval "(m/map-entries [:map [:x int?] [:y string?]])" nil))))
 
 (deftest into-schema-test
   (is (form= [:map {:closed true} [:x int?]]

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -86,7 +86,7 @@
                                [:street2 string?]]]]
                    (mu/closed-schema)
                    (m/explain {:address {:streetz "123"}})
-                   (me/with-spell-checking {:keep-likely-misspelled-of true})
+                   (me/with-spell-checking {::me/keep-likely-misspelled-of true})
                    (me/with-error-messages)
                    (get-errors))))))))
 


### PR DESCRIPTION
Instead of JVM/closure-defines overridable default registry, we can swap whole default options. This allows easy way to customize (sci) evalutor, in future default localizations etc.

Compiler/jvm bootstrap:
   * cljs: `:closure-defines {malli.options/type "custom"}`
   * clj: `:jvm-opts ["-Dmalli.options/type=custom"]`

Available types:
  * `default` -> the default registry + dynamic sci
  * `custom` -> empty registry + dynamic sci
  * `empty` -> empty registy + no sci
