### PR TITLE
Symmetric paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,26 +12,31 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 [breakver]: https://github.com/ptaoussanis/encore/blob/master/BREAK-VERSIONING.md
 
-## UNRELEASED
+## breaking changes in the pre-alpha era:
 
+* ???
+  * `:path` in explain is re-implemented: map keys by value, others by child index
+  * utilities for `LensSchema` in `malli.util` don't coerce data schemas into `Schema` instances
+  * `malli.util/path-schemas` return a vector of maps with `:path` and `:schema` keys
+  * `LensSchema` has a new `-key` method
 * 23.7.2020
-  * **BREAKING:**: `sci` is not a default dependency. Enabling sci-support:
+  * `sci` is not a default dependency. Enabling sci-support:
     * **Clojure**: add a dependency to `borkdude/sci`
     * **ClojureScript**: also require `sci.core` (directly or via `:preloads`)
 * 18.7.2020
-  * **BREAKING:**: big cleanup of `malli.transform` internals.
+  * big cleanup of `malli.transform` internals.
 * 12.7.2020
-  * **BREAKING:**: `malli.mermaid` is removed (in favor of `malli.dot`)  
+  * `malli.mermaid` is removed (in favor of `malli.dot`)  
 * 10.7.2020
   * `[metosin/malli "0.0.1-20200710.075225-19"]`
-  * **BREAKING:**: Visitor is implemented using a Walker.
+  * Visitor is implemented using a Walker.
     * `m/accept` -> `m/walk`
     * `m/schema-visitor` -> `m/schema-walker`
     * `m/map-syntax-visitor` -> `m/map-syntax-walker`
 * 31.6.2020
-  * **BREAKING:** new `-children` method in `Schema`, to return child schemas as instances (instead of just AST)
+  * new `-children` method in `Schema`, to return child schemas as instances (instead of just AST)
 * 17.6.2020
-  * **BREAKING:** change all `malli.core/*-registy` defs into `malli.core/*-schemas` defns to enable DCE for clojurescript
+  * change all `malli.core/*-registy` defs into `malli.core/*-schemas` defns to enable DCE for clojurescript
 * 9.6.2020 
-  * **BREAKING:** `malli.core/name` & `malli.core/-name` renamed to `malli.core/type` & `malli.core/-type`
-  * **BREAKING:** `malli.generator/-generator` is renamed to `malli.generator/-schema-generator`
+  * `malli.core/name` & `malli.core/-name` renamed to `malli.core/type` & `malli.core/-type`
+  * `malli.generator/-generator` is renamed to `malli.generator/-schema-generator`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
   * `:path` in explain is re-implemented: map keys by value, others by child index
   * `m/-walk` and `m/Walker` uses `:path`, not `:in`
   * `m/-outer` has new parameter order: `walker schema path children options`
-  * utilities for `LensSchema` in `malli.util` don't coerce data schemas into `Schema` instances
   * `malli.util/path-schemas` replaced with `malli.util/subschemas` & `malli.util/distict-by`
   * `LensSchema` has a new `-key` method
   * renamed some non-user apis in `malli.core` & `malli.util`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,11 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 * ???
   * `:path` in explain is re-implemented: map keys by value, others by child index
   * utilities for `LensSchema` in `malli.util` don't coerce data schemas into `Schema` instances
-  * `malli.util/path-schemas` return a vector of maps with `:path` and `:schema` keys
+  * `malli.util/path-schemas` replaced with `malli.util/subschemas` & `malli.util/distict-by`
   * `LensSchema` has a new `-key` method
+  * renamed some non-user apis in `malli.core` & `malli.util`
+  * moved map-syntax helpers from `malli.core` to `malli.util`
+  * dynaload `com.gfredericks/test.chuck`
 * 23.7.2020
   * `sci` is not a default dependency. Enabling sci-support:
     * **Clojure**: add a dependency to `borkdude/sci`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 * ???
   * `:path` in explain is re-implemented: map keys by value, others by child index
+  * `m/-walk` and `m/Walker` uses `:path`, not `:in`
+  * `m/-outer` has new parameter order: `walker schema path children options`
   * utilities for `LensSchema` in `malli.util` don't coerce data schemas into `Schema` instances
   * `malli.util/path-schemas` replaced with `malli.util/subschemas` & `malli.util/distict-by`
   * `LensSchema` has a new `-key` method

--- a/README.md
+++ b/README.md
@@ -678,7 +678,7 @@ Finding first value (prewalk):
 ; => "turvassa"
 ```
 
-Finding (sub)schemas for paths, retaining order:
+Finding (sub)schemas for all paths, retaining order:
 
 ```clj
 (mu/path-schemas
@@ -691,27 +691,28 @@ Finding (sub)schemas for paths, retaining order:
       [:street {:optional true} string?]
       [:lonlat {:optional true} [:tuple double? double?]]]
      [:fn '(fn [{:keys [street lonlat]}] (or street lonlat))]]]])
-;{[] [:map
-;     [:id string?]
-;     [:tags [:set keyword?]]
-;     [:address
-;      [:and
-;       [:map 
-;        [:street {:optional true} string?] 
-;        [:lonlat {:optional true} [:tuple double? double?]]]
-;       [:fn (fn [{:keys [street lonlat]}] (or street lonlat))]]]]
-; [:id] string?
-; [:tags] [:set keyword?]
-; [:tags :malli.core/in] keyword?
-; [:address] [:and
-;             [:map 
-;              [:street {:optional true} string?] 
-;              [:lonlat {:optional true} [:tuple double? double?]]]
-;             [:fn (fn [{:keys [street lonlat]}] (or street lonlat))]]
-; [:address :street] string?
-; [:address :lonlat] [:tuple double? double?]
-; [:address :lonlat 0] double?
-; [:address :lonlat 1] double?}
+;[{:path [], :schema [:map
+;                     [:id string?]
+;                     [:tags [:set keyword?]]
+;                     [:address
+;                      [:and
+;                       [:map
+;                        [:street {:optional true} string?]
+;                        [:lonlat {:optional true} [:tuple double? double?]]]
+;                       [:fn (fn [{:keys [street lonlat]}] (or street lonlat))]]]]}
+; {:path [:id], :schema string?}
+; {:path [:tags], :schema [:set keyword?]}
+; {:path [:tags :malli.core/in], :schema keyword?}
+; {:path [:address], :schema [:and
+;                             [:map
+;                              [:street {:optional true} string?]
+;                              [:lonlat {:optional true}
+;                               [:tuple double? double?]]]
+;                             [:fn (fn [{:keys [street lonlat]}] (or street lonlat))]]}
+; {:path [:address :street], :schema string?}
+; {:path [:address :lonlat], :schema [:tuple double? double?]}
+; {:path [:address :lonlat 0], :schema double?}
+; {:path [:address :lonlat 1], :schema double?}]
 ```
 
 ## Persisting Schemas 

--- a/README.md
+++ b/README.md
@@ -213,17 +213,22 @@ Detailed errors with `m/explain`:
 ;         :address {:street "Ahlmanintie 29"
 ;                   :zip 33100
 ;                   :lonlat [61.4858322 nil]}},
-; :errors (#Error{:path [2 1 1], :in [:tags 0], :schema keyword?, :value "coffee"}
-;          #Error{:path [3 1],
-;                 :in [:address],
+; :errors (#Error{:path [:tags 0]
+;                 :in [:tags 0]
+;                 :schema keyword?
+                  ::value "coffee"}
+;          #Error{:path [:address :city],
+;                 :in [:address :city],
 ;                 :schema [:map
 ;                          [:street string?]
 ;                          [:city string?]
 ;                          [:zip int?]
 ;                          [:lonlat [:tuple double? double?]]],
-;                 :type :malli.core/missing-key,
-;                 :malli.core/key :city}
-;          #Error{:path [3 1 4 1 2], :in [:address :lonlat 1], :schema double?, :value nil})}
+;                 :type :malli.core/missing-key}
+;          #Error{:path [:address :lonlat 1]
+;                 :in [:address :lonlat 1]
+;                 :schema double?
+;                 :value nil})}
 ```
 
 ## Custom Error Messages
@@ -241,9 +246,9 @@ Explain results can be humanized with `malli.error/humanize`:
                  :zip 33100
                  :lonlat [61.4858322, nil]}})
     (me/humanize))
-;{:tags #{["should be keyword"]}
+;{:tags #{["should be a keyword"]}
 ; :address {:city ["missing required key"]
-;           :lonlat [nil ["should be double"]]}}
+;           :lonlat [nil ["should be a double"]]}}
 ```
 
 Error messages can be customized with `:error/message` and `:error/fn` properties:

--- a/README.md
+++ b/README.md
@@ -730,34 +730,25 @@ Finding all subschmas with paths, retaining order:
 ; {:path [0 :address 1], :in [:address], :schema [:fn (fn [{:keys [street lonlat]}] (or street lonlat))]}]
 ```
 
-Collecting just unique value paths (`:in`):
+Collecting unique value paths and their schema paths:
 
 ```clj
 (->> Schema
      (mu/subschemas)
-     (mu/distinct-by :id))
-;[{:path [], :in [], :schema [:maybe
-;                             [:map
-;                              [:id string?]
-;                              [:tags [:set keyword?]]
-;                              [:address
-;                               [:and
-;                                [:map
-;                                 [:street {:optional true} string?]
-;                                 [:lonlat {:optional true} [:tuple double? double?]]]
-;                                [:fn (fn [{:keys [street lonlat]}] (or street lonlat))]]]]]}
-; {:path [0 :id], :in [:id], :schema string?}
-; {:path [0 :tags], :in [:tags], :schema [:set keyword?]}
-; {:path [0 :tags :malli.core/in], :in [:tags :malli.core/in], :schema keyword?}
-; {:path [0 :address], :in [:address], :schema [:and
-;                                               [:map
-;                                                [:street {:optional true} string?]
-;                                                [:lonlat {:optional true} [:tuple double? double?]]]
-;                                               [:fn (fn [{:keys [street lonlat]}] (or street lonlat))]]}
-; {:path [0 :address 0 :street], :in [:address :street], :schema string?}
-; {:path [0 :address 0 :lonlat], :in [:address :lonlat], :schema [:tuple double? double?]}
-; {:path [0 :address 0 :lonlat 0], :in [:address :lonlat 0], :schema double?}
-; {:path [0 :address 0 :lonlat 1], :in [:address :lonlat 1], :schema double?}
+     (mu/distinct-by :id)
+     (mapv (juxt :in :path)))
+;[[[] []]
+; [[] [0]]
+; [[:id] [0 :id]]
+; [[:tags] [0 :tags]]
+; [[:tags :malli.core/in] [0 :tags :malli.core/in]]
+; [[:address] [0 :address]]
+; [[:address] [0 :address 0]]
+; [[:address :street] [0 :address 0 :street]]
+; [[:address :lonlat] [0 :address 0 :lonlat]]
+; [[:address :lonlat 0] [0 :address 0 :lonlat 0]]
+; [[:address :lonlat 1] [0 :address 0 :lonlat 1]]
+; [[:address] [0 :address 1]]]
 ```
 
 Schema paths can be converted into value paths:
@@ -770,7 +761,7 @@ Schema paths can be converted into value paths:
 ; => [:address :lonlat]
 ```
 
-and back (returns all paths):
+and back, returning all paths:
 
 ```clj
 (mu/in->paths Schema [:address :lonlat])

--- a/README.md
+++ b/README.md
@@ -679,17 +679,20 @@ Finding first value (prewalk):
 Finding all subschmas with paths, retaining order:
 
 ```clj
-(mu/subschemas
-  [:maybe
-   [:map
-    [:id string?]
-    [:tags [:set keyword?]]
-    [:address
-     [:and
-      [:map
-       [:street {:optional true} string?]
-       [:lonlat {:optional true} [:tuple double? double?]]]
-      [:fn '(fn [{:keys [street lonlat]}] (or street lonlat))]]]]])
+(def Schema
+  (m/schema
+    [:maybe
+     [:map
+      [:id string?]
+      [:tags [:set keyword?]]
+      [:address
+       [:and
+        [:map
+         [:street {:optional true} string?]
+         [:lonlat {:optional true} [:tuple double? double?]]]
+        [:fn '(fn [{:keys [street lonlat]}] (or street lonlat))]]]]]))
+
+(mu/subschemas Schema)
 ;[{:path [], :in [], :schema [:maybe
 ;                             [:map
 ;                              [:id string?]
@@ -730,16 +733,7 @@ Finding all subschmas with paths, retaining order:
 Collecting just unique value paths (`:in`):
 
 ```clj
-(->> [:maybe
-      [:map
-       [:id string?]
-       [:tags [:set keyword?]]
-       [:address
-        [:and
-         [:map
-          [:street {:optional true} string?]
-          [:lonlat {:optional true} [:tuple double? double?]]]
-         [:fn '(fn [{:keys [street lonlat]}] (or street lonlat))]]]]]
+(->> Schema
      (mu/subschemas)
      (mu/distinct-by :id))
 ;[{:path [], :in [], :schema [:maybe
@@ -764,6 +758,16 @@ Collecting just unique value paths (`:in`):
 ; {:path [0 :address 0 :lonlat], :in [:address :lonlat], :schema [:tuple double? double?]}
 ; {:path [0 :address 0 :lonlat 0], :in [:address :lonlat 0], :schema double?}
 ; {:path [0 :address 0 :lonlat 1], :in [:address :lonlat 1], :schema double?}
+```
+
+Schema paths can be converted into value paths:
+
+```clj
+(mu/get-in Schema [0 :address 0 :lonlat])
+; => [:tuple double? double?]
+
+(mu/path->in Schema [0 :address 0 :lonlat])
+; => [:address :lonlat]
 ```
 
 ## Persisting Schemas 

--- a/README.md
+++ b/README.md
@@ -770,6 +770,13 @@ Schema paths can be converted into value paths:
 ; => [:address :lonlat]
 ```
 
+and back (returns all paths):
+
+```clj
+(mu/in->paths Schema [:address :lonlat])
+; => [[0 :address 0 :lonlat]]
+```
+
 ## Persisting Schemas 
 
 Writing and Reading schemas as [EDN](https://github.com/edn-format/edn), no `eval` needed.

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :aliases {:test {:extra-paths ["test"]
-                  :extra-deps {lambdaisland/kaocha {:mvn/version "1.0.632"}
+                  :extra-deps {com.gfredericks/test.chuck {:mvn/version "0.2.10"}
+                               lambdaisland/kaocha {:mvn/version "1.0.632"}
                                lambdaisland/kaocha-cljs {:mvn/version "0.0-71"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
                                metosin/spec-tools {:mvn/version "0.10.3"}
@@ -40,8 +41,6 @@
                              "-Xmx4096m"
                              "-Dclojure.compiler.direct-linking=true"]}}
  :deps {org.clojure/clojure {:mvn/version "1.10.1"}
-        borkdude/dynaload {:git/url "https://github.com/borkdude/dynaload.git"
-                           :sha "52f71bc2cb7389a932835fe02f185e3801f7e063"}
-        borkdude/edamame {:mvn/version "0.0.11-alpha.12"}
-        org.clojure/test.check {:mvn/version "1.0.0"}
-        com.gfredericks/test.chuck {:mvn/version "0.2.10"}}}
+        borkdude/dynaload {:mvn/version "0.1.0"}
+        borkdude/edamame {:mvn/version "0.0.11-alpha.13"}
+        org.clojure/test.check {:mvn/version "1.1.0"}}}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -713,10 +713,9 @@
                 (if-let [validator (validators (dispatch x))]
                   (validator x)
                   false))))
-          ;; is path ok?
           (-explainer [this path]
             (let [explainers (reduce
-                               (fn [acc [key _properties schema]] ;; https://clojure.atlassian.net/browse/CLJS-1575
+                               (fn [acc [key _properties schema]] ;; https://clojure.atlassian.net/browse/CLJS-1575 ??
                                  (let [explainer (-explainer schema (conj path key))]
                                    (assoc acc key (fn [x in acc] (explainer x in acc)))))
                                {} entries)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -322,15 +322,15 @@
               (fn [m] (and (map? m) (validate m)))))
           (-explainer [this path]
             (let [explainers (cond-> (mapv
-                                       (fn [[i [key {:keys [optional]} schema]]]
-                                         (let [explainer (-explainer schema (conj path i))]
+                                       (fn [[key {:keys [optional]} schema]]
+                                         (let [explainer (-explainer schema (conj path key))]
                                            (fn [x in acc]
                                              (if-let [e (find x key)]
                                                (explainer (val e) (conj in key) acc)
                                                (if-not optional
-                                                 (conj acc (error (conj path i) (conj in key) this nil ::missing-key))
+                                                 (conj acc (error (conj path key) (conj in key) this nil ::missing-key))
                                                  acc)))))
-                                       (map-indexed vector entries))
+                                       entries)
                                      closed (into [(fn [x in acc]
                                                      (reduce
                                                        (fn [acc k]
@@ -716,10 +716,10 @@
           ;; is path ok?
           (-explainer [this path]
             (let [explainers (reduce
-                               (fn [acc [i [key _ schema]]]
-                                 (let [explainer (-explainer schema (conj path i))]
+                               (fn [acc [key _ schema]]
+                                 (let [explainer (-explainer schema (conj path key))]
                                    (assoc acc key (fn [x in acc] (explainer x in acc)))))
-                               {} (map-indexed vector entries))]
+                               {} entries)]
               (fn [x in acc]
                 (if-let [explainer (explainers (dispatch x))]
                   (explainer x in acc)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -27,7 +27,7 @@
   (-map-entries [this] "returns map entries"))
 
 (defprotocol LensSchema
-  (-key [this] "returns key of default child if Schema does not contribute to value path")
+  (-keep [this] "returns truthy if schema contributes to value path")
   (-get [this key default] "returns schema at key")
   (-set [this key value] "returns a copy with key having new value"))
 
@@ -138,7 +138,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-keep [_])
           (-get [_ _ default] default)
           (-set [this key _] (-fail! ::non-associative-schema {:schema this, :key key})))))))
 
@@ -192,7 +192,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_] 0)
+          (-keep [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :and properties (assoc children key value))))))))
 
@@ -270,7 +270,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_] ::or)
+          (-keep [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :or properties (assoc children key value))))))))
 
@@ -383,7 +383,7 @@
           MapSchema
           (-map-entries [_] entries)
           LensSchema
-          (-key [_])
+          (-keep [_] true)
           (-get [_ key default] (or (some (fn [[k _ s]] (if (= k key) s)) entries) default))
           (-set [_ key value]
             (let [found (atom nil)
@@ -451,7 +451,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_] 1)
+          (-keep [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :map-of properties (assoc children key value))))))))
 
@@ -508,7 +508,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-keep [_] true)
           (-get [_ _ _] schema)
           (-set [_ _ value] (into-schema type properties [value])))))))
 
@@ -562,7 +562,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-keep [_] true)
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :tuple properties (assoc children key value))))))))
 
@@ -594,7 +594,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-keep [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :enum properties (assoc children key value))))))))
 
@@ -630,7 +630,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-keep [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :re properties (assoc children key value))))))))
 
@@ -666,7 +666,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-keep [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :fn properties (assoc children key value))))))))
 
@@ -698,7 +698,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_] 0)
+          (-keep [_])
           (-get [_ key default] (if (= 0 key) schema default))
           (-set [this key value] (if (= 0 key)
                                    (into-schema :maybe properties [value])
@@ -758,7 +758,7 @@
           MapSchema
           (-map-entries [_] entries)
           LensSchema
-          (-key [_])
+          (-keep [_])
           (-get [_ key default] (or (some (fn [[k _ s]] (if (= k key) s)) entries) default))
           (-set [_ key value]
             (let [found (atom nil)
@@ -799,7 +799,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-keep [_])
           (-get [_ _ default] default)
           (-set [this key _] (-fail! ::non-associative-schema {:schema this, :key key})))))))
 
@@ -849,7 +849,7 @@
                                    (into-schema :ref properties [value])
                                    (-fail! ::index-out-of-bounds {:schema this, :key key})))
           RefSchema
-          (-key [_])
+          (-keep [_])
           (-ref [_] ref)
           (-deref [_] (-ref)))))))
 
@@ -880,7 +880,7 @@
             (-children [_] children)
             (-form [_] form)
             LensSchema
-            (-key [_])
+            (-keep [_])
             (-get [_ key default] (if (= key 0) child default))
             (-set [this key value] (if (= key 0)
                                      (into-schema type properties [value])

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -340,7 +340,7 @@
                                                        (fn [acc k]
                                                          (if (contains? keyset k)
                                                            acc
-                                                           (conj acc (error path (conj in k) this nil ::extra-key))))
+                                                           (conj acc (error (conj path k) (conj in k) this nil ::extra-key))))
                                                        acc (keys x)))]))]
               (fn [x in acc]
                 (if-not (map? x)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,5 +1,5 @@
 (ns malli.core
-  (:refer-clojure :exclude [eval type -deref -lookup])
+  (:refer-clojure :exclude [eval type -deref -lookup -key])
   (:require [malli.sci :as ms]
             [malli.registry :as mr])
   #?(:clj (:import (java.util.regex Pattern)
@@ -27,6 +27,7 @@
   (-map-entries [this] "returns map entries"))
 
 (defprotocol LensSchema
+  (-key [this] "returns key of default child if Schema does not contribute to value path")
   (-get [this key default] "returns schema at key")
   (-set [this key value] "returns a copy with key having new value"))
 
@@ -133,6 +134,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_])
           (-get [_ _ default] default)
           (-set [this key _] (fail! ::non-associative-schema {:schema this, :key key})))))))
 
@@ -186,6 +188,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_] 0)
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :and properties (assoc children key value))))))))
 
@@ -263,6 +266,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :or properties (assoc children key value))))))))
 
@@ -378,6 +382,7 @@
           MapSchema
           (-map-entries [_] entries)
           LensSchema
+          (-key [_])
           (-get [_ key default] (or (some (fn [[k _ s]] (if (= k key) s)) entries) default))
           (-set [_ key value]
             (let [found (atom nil)
@@ -445,6 +450,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_] 1)
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :map-of properties (assoc children key value))))))))
 
@@ -501,10 +507,9 @@
           (-children [_] [schema])
           (-form [_] form)
           LensSchema
-          (-get [_ key default] (if (= 0 key) schema default))
-          (-set [this key value] (if (= 0 key)
-                                   (into-schema type properties [value])
-                                   (fail! ::index-out-of-bounds {:schema this, :key key}))))))))
+          (-key [_])
+          (-get [_ _ _] schema)
+          (-set [_ _ value] (into-schema type properties [value])))))))
 
 (defn -tuple-schema []
   ^{:type ::into-schema}
@@ -556,6 +561,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :tuple properties (assoc children key value))))))))
 
@@ -587,6 +593,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :enum properties (assoc children key value))))))))
 
@@ -622,6 +629,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :re properties (assoc children key value))))))))
 
@@ -657,6 +665,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_])
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :fn properties (assoc children key value))))))))
 
@@ -688,6 +697,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_] 0)
           (-get [_ key default] (if (= 0 key) schema default))
           (-set [this key value] (if (= 0 key)
                                    (into-schema :maybe properties [value])
@@ -747,6 +757,7 @@
           MapSchema
           (-map-entries [_] entries)
           LensSchema
+          (-key [_])
           (-get [_ key default] (or (some (fn [[k _ s]] (if (= k key) s)) entries) default))
           (-set [_ key value]
             (let [found (atom nil)
@@ -787,6 +798,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
+          (-key [_])
           (-get [_ _ default] default)
           (-set [this key _] (fail! ::non-associative-schema {:schema this, :key key})))))))
 
@@ -836,6 +848,7 @@
                                    (into-schema :ref properties [value])
                                    (fail! ::index-out-of-bounds {:schema this, :key key})))
           RefSchema
+          (-key [_])
           (-ref [_] ref)
           (-deref [_] (-ref)))))))
 
@@ -866,6 +879,7 @@
             (-children [_] children)
             (-form [_] form)
             LensSchema
+            (-key [_])
             (-get [_ key default] (if (= key 0) child default))
             (-set [this key value] (if (= key 0)
                                      (into-schema type properties [value])

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -716,7 +716,7 @@
           ;; is path ok?
           (-explainer [this path]
             (let [explainers (reduce
-                               (fn [acc [key _ schema]]
+                               (fn [acc [key _properties schema]] ;; https://clojure.atlassian.net/browse/CLJS-1575
                                  (let [explainer (-explainer schema (conj path key))]
                                    (assoc acc key (fn [x in acc] (explainer x in acc)))))
                                {} entries)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -270,7 +270,7 @@
           (-children [_] children)
           (-form [_] form)
           LensSchema
-          (-key [_])
+          (-key [_] ::or)
           (-get [_ key default] (get children key default))
           (-set [_ key value] (into-schema :or properties (assoc children key value))))))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -38,7 +38,7 @@
 (defprotocol Walker
   (-accept [this schema path options])
   (-inner [this schema path options])
-  (-outer [this schema children path options]))
+  (-outer [this schema path children options]))
 
 (defprotocol Transformer
   (-transformer-chain [this] "returns transformer chain as a vector of maps with :name, :encoders, :decoders and :options")
@@ -132,7 +132,7 @@
             (-value-transformer transformer this method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this children path options)))
+              (-outer walker this path children options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -186,7 +186,7 @@
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (-inner-indexed walker path children options) path options)))
+              (-outer walker this path (-inner-indexed walker path children options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -264,7 +264,7 @@
                :leave (build :leave)}))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (-inner-indexed walker path children options) path options)))
+              (-outer walker this path (-inner-indexed walker path children options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -375,7 +375,7 @@
                :leave (build :leave)}))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (-inner-entries walker path entries options) path options)))
+              (-outer walker this path (-inner-entries walker path entries options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -445,7 +445,7 @@
                :leave (build :leave)}))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (-inner-indexed walker path children options) path options)))
+              (-outer walker this path (-inner-indexed walker path children options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -502,7 +502,7 @@
                :leave (build :leave)}))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this [(-inner walker schema (conj path ::in) options)] path options)))
+              (-outer walker this path [(-inner walker schema (conj path ::in) options)] options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -556,7 +556,7 @@
                :leave (build :leave)}))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (-inner-indexed walker path children options) path options)))
+              (-outer walker this path (-inner-indexed walker path children options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -588,7 +588,7 @@
             (-value-transformer transformer this method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this children path options)))
+              (-outer walker this path children options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -624,7 +624,7 @@
             (-value-transformer transformer this method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this children path options)))
+              (-outer walker this path children options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -660,7 +660,7 @@
             (-value-transformer transformer this method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this children path options)))
+              (-outer walker this path children options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -692,7 +692,7 @@
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (-inner-indexed walker path children options) path options)))
+              (-outer walker this path (-inner-indexed walker path children options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -750,7 +750,7 @@
                :leave (build :leave)}))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (-inner-entries walker path entries options) path options)))
+              (-outer walker this path (-inner-entries walker path entries options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -793,7 +793,7 @@
             (-value-transformer transformer this method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
-              (-outer walker this (vec children) path options)))
+              (-outer walker this path (vec children) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -838,7 +838,7 @@
                   accept-ref ^{:type ::ref} (reify IDeref (#?(:cljs cljs.core/-deref, :clj deref) [_] (accept)))
                   options (assoc options ::ref-walk accept-ref)]
               (if (-accept walker this path options)
-                (-outer walker this (vec children) path options))))
+                (-outer walker this path (vec children) options))))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
@@ -873,8 +873,8 @@
             (-walk [this walker path options]
               (if (-accept walker this path options)
                 (if id
-                  (-outer walker this [id] path options)
-                  (-outer walker this [(-inner walker child path options)] path options))))
+                  (-outer walker this path [id] options)
+                  (-outer walker this path [(-inner walker child path options)] options))))
             (-properties [_] properties)
             (-options [_] options)
             (-children [_] children)
@@ -996,8 +996,8 @@
      (schema ?schema options)
      (reify Walker
        (-accept [_ s _ _] s)
-       (-inner [this s path options] (-walk s this path options))
-       (-outer [_ s c path options] (f s c path options)))
+       (-inner [this s p options] (-walk s this p options))
+       (-outer [_ s p c options] (f s p c options)))
      [] options)))
 
 (defn validator
@@ -1099,7 +1099,7 @@
 ;;
 
 (defn schema-walker [f]
-  (fn [schema children _ _]
+  (fn [schema _ children _]
     (f (into-schema (-type schema) (-properties schema) children (-options schema)))))
 
 ;;

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -381,11 +381,11 @@
           (-get [_ key default] (or (some (fn [[k _ s]] (if (= k key) s)) entries) default))
           (-set [_ key value]
             (let [found (atom nil)
-                  [key kprop] (if (vector? key) key [key])
-                  entries (cond-> (mapv (fn [[k p s]] (if (= key k) (do (reset! found true) [k kprop value]) [k p s])) entries)
-                                  (not @found) (conj [key kprop value])
-                                  :always (->> (filter (fn [e] (-> e last some?)))))]
-              (into-schema :map properties entries))))))))
+                  [key :as new-child] (if (vector? key) (conj key value) [key value])
+                  children (cond-> (mapv (fn [[k :as child]] (if (= key k) (do (reset! found true) new-child) child)) children)
+                                   (not @found) (conj new-child)
+                                   :always (->> (filter (fn [e] (-> e last some?)))))]
+              (into-schema :map properties children))))))))
 
 (defn -map-of-schema []
   ^{:type ::into-schema}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -754,7 +754,7 @@
                   entries (cond-> (mapv (fn [[k p s]] (if (= key k) (do (reset! found true) [k kprop value]) [k p s])) entries)
                                   (not @found) (conj [key kprop value])
                                   :always (->> (filter (fn [e] (-> e last some?)))))]
-              (into-schema :multiu properties entries))))))))
+              (into-schema :multi properties entries))))))))
 
 (defn -string-schema []
   ^{:type ::into-schema}
@@ -800,9 +800,7 @@
       (when-not (-ref-key? ref)
         (fail! ::invalid-ref {:ref ref}))
       (let [-memoize (fn [f] (let [value (atom nil)] (fn [] (or @value) (reset! value (f)))))
-            -ref (or (when-not (-ref-key? ref)
-                       (fail! ::invalid-ref {:type :ref, :ref ref}))
-                     (if-let [s (mr/-schema (registry options) ref)] (-memoize (fn [] (schema s options))))
+            -ref (or (if-let [s (mr/-schema (registry options) ref)] (-memoize (fn [] (schema s options))))
                      (when-not allow-invalid-refs
                        (fail! ::invalid-ref {:type :ref, :ref ref})))
             form (create-form :ref properties children)]

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -21,7 +21,7 @@
     @state))
 
 (defn -schema-name [base in]
-  (->> in (remove #{:malli.core/in}) (map (comp str/capitalize m/keyword->string)) (into [base]) (str/join "$")))
+  (->> in (remove #{:malli.core/in}) (map (comp str/capitalize m/-keyword->string)) (into [base]) (str/join "$")))
 
 (defn -normalize [{:keys [registry] :as ctx}]
   (let [registry* (atom registry)]

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -20,18 +20,18 @@
           (swap! state assoc :schema schema))))
     @state))
 
-(defn -schema-name [base in]
-  (->> in (remove #{:malli.core/in}) (map (comp str/capitalize m/-keyword->string)) (into [base]) (str/join "$")))
+(defn -schema-name [base path]
+  (->> path (remove #{:malli.core/in}) (map (comp str/capitalize m/-keyword->string)) (into [base]) (str/join "$")))
 
 (defn -normalize [{:keys [registry] :as ctx}]
   (let [registry* (atom registry)]
     (doseq [[k v] registry]
       (swap! registry* assoc k
-             (m/walk v (fn [schema children in _]
+             (m/walk v (fn [schema path children _]
                          (let [options (update (m/options schema) :registry (partial mr/composite-registry @registry*))
                                schema (m/into-schema (m/type schema) (m/properties schema) children options)]
-                           (if (and (seq in) (= :map (m/type schema)))
-                             (let [ref (-schema-name k in)]
+                           (if (and (seq path) (= :map (m/type schema)))
+                             (let [ref (-schema-name k path)]
                                (swap! registry* assoc ref (mu/update-properties schema assoc ::entity k))
                                ref)
                              schema))))))

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -209,19 +209,19 @@
          :errors
          (fn [errors]
            (as-> errors $
-                 (mapv (fn [{:keys [schema in type] :as error}]
+                 (mapv (fn [{:keys [schema path type] :as error}]
                          (if (= type ::m/extra-key)
                            (let [keys (->> schema (m/map-entries) (map first) (set))
-                                 value (get-in (:value explanation) (butlast in))
-                                 similar (-most-similar-to value (last in) keys)
-                                 likely-misspelling-of (mapv (partial conj (vec (butlast in))) (vec similar))]
+                                 value (get-in (:value explanation) (butlast path))
+                                 similar (-most-similar-to value (last path) keys)
+                                 likely-misspelling-of (mapv (partial conj (vec (butlast path))) (vec similar))]
                              (swap! !likely-misspelling-of into likely-misspelling-of)
                              (cond-> error similar (assoc :type ::misspelled-key
                                                           ::likely-misspelling-of likely-misspelling-of)))
                            error)) $)
                  (if-not keep-likely-misspelled-of
-                   (remove (fn [{:keys [in type]}]
-                             (and (@!likely-misspelling-of in)
+                   (remove (fn [{:keys [path type]}]
+                             (and (@!likely-misspelling-of path)
                                   (= type ::m/missing-key))) $)
                    $))))))))
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -26,9 +26,9 @@
 (defn -min-max [schema options]
   (let [{:keys [min max] gen-min :gen/min gen-max :gen/max} (m/properties schema options)]
     (when (and min gen-min (< gen-min min))
-      (m/fail! ::invalid-property {:key :gen/min, :value gen-min, :min min}))
+      (m/-fail! ::invalid-property {:key :gen/min, :value gen-min, :min min}))
     (when (and max gen-max (> gen-max max))
-      (m/fail! ::invalid-property {:key :gen/max, :value gen-min, :max min}))
+      (m/-fail! ::invalid-property {:key :gen/max, :value gen-min, :max min}))
     {:min (or gen-min min)
      :max (or gen-max max)}))
 
@@ -143,7 +143,7 @@
       fmap (gen/fmap (m/eval fmap) (or elements gen (gen/return nil)))
       elements elements
       gen gen
-      :else (m/fail! ::no-generator {:schema schema, :options options}))))
+      :else (m/-fail! ::no-generator {:schema schema, :options options}))))
 
 ;;
 ;; public api

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -1,6 +1,6 @@
 (ns malli.generator
   (:require [clojure.test.check.generators :as gen]
-            #?(:clj [com.gfredericks.test.chuck.generators :as gen2])
+            #?(:clj [borkdude.dynaload-clj :refer [dynaload]])
             [clojure.string :as str]
             [clojure.test.check.random :as random]
             [clojure.test.check.rose-tree :as rose]
@@ -92,9 +92,11 @@
     (gen/fmap (partial into {}) (gen/vector-distinct (gen/tuple k-gen v-gen)))))
 
 #?(:clj
-   (defn -re-gen [schema options]
-     (let [re (or (first (m/children schema options)) (m/form schema options))]
-       (gen2/string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1"))))))
+   ;; [com.gfredericks/test.chuck "0.2.10"+]
+   (when-let [string-from-regex @(dynaload 'com.gfredericks.test.chuck.generators/string-from-regex {:default nil})]
+     (defn -re-gen [schema options]
+       (let [re (or (first (m/children schema options)) (m/form schema options))]
+         (string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1")))))))
 
 ;;
 ;; generators

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -93,7 +93,7 @@
 (defmethod accept :string [_ schema _ _]
   (merge {:type "string"} (-> schema m/properties (select-keys [:min :max]) (set/rename-keys {:min :minLength, :max :maxLength}))))
 
-(defn- -json-schema-walker [schema children _in options]
+(defn- -json-schema-walker [schema _ children options]
   (let [p (m/properties schema)]
     (or (unlift p :json-schema)
         (merge (select p)

--- a/src/malli/provider.cljc
+++ b/src/malli/provider.cljc
@@ -10,7 +10,7 @@
 
 (defn- -safe? [f & args] (try (apply f args) (catch #?(:clj Exception, :cljs js/Error) _ false)))
 
-(defn- registry-schemas [options] (->> options (m/registry) (mr/-schemas) (vals) (keep (partial -safe? m/schema))))
+(defn- registry-schemas [options] (->> options (m/-registry) (mr/-schemas) (vals) (keep (partial -safe? m/schema))))
 
 (defn- ->infer-schemas [options]
   (fn [x] (-> options (registry-schemas) (->> (filter #(-safe? m/validate % x)) (map m/type)) (zipmap (repeat 1)))))

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -22,7 +22,7 @@
 
 (defmethod accept :tuple [_ _ children _] {:type "array" :items {} :x-items children})
 
-(defn- -swagger-walker [schema children _in options]
+(defn- -swagger-walker [schema _ children options]
   (let [p (m/properties schema)]
     (or (json-schema/unlift p :swagger)
         (json-schema/unlift p :json-schema)

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -24,7 +24,7 @@
     (let [compiled (::compiled options 0)
           options (assoc options ::compiled (inc ^long compiled))]
       (when (>= ^long compiled ^long *max-compile-depth*)
-        (m/fail! ::too-deep-compilation {:this ?interceptor, :schema schema, :options options}))
+        (m/-fail! ::too-deep-compilation {:this ?interceptor, :schema schema, :options options}))
       (if-let [interceptor (-interceptor ((:compile ?interceptor) schema options) schema options)]
         (merge
           (dissoc ?interceptor :compile)
@@ -48,7 +48,7 @@
 
     (nil? ?interceptor) nil
 
-    :else (m/fail! ::invalid-transformer {:value ?interceptor})))
+    :else (m/-fail! ::invalid-transformer {:value ?interceptor})))
 
 ;;
 ;; from strings
@@ -220,15 +220,15 @@
    'double? -number->double
    'inst? -string->date
 
-   :map-of (-transform-map-keys m/keyword->string)
+   :map-of (-transform-map-keys m/-keyword->string)
    :set -sequential->set
    :sequential -sequential->seq
    :list -sequential->seq})
 
 (defn -json-encoders []
-  {'keyword? m/keyword->string
-   'simple-keyword? m/keyword->string
-   'qualified-keyword? m/keyword->string
+  {'keyword? m/-keyword->string
+   'simple-keyword? m/-keyword->string
+   'qualified-keyword? m/-keyword->string
 
    'symbol? -any->string
    'simple-symbol? -any->string
@@ -299,7 +299,7 @@
                                           :default default
                                           :key (if name (keyword (str key "/" name)))})
         ->eval (fn [x] (if (map? x) (reduce-kv (fn [x k v] (assoc x k (m/eval v))) x x) (m/eval x)))
-        ->chain (comp m/-transformer-chain m/into-transformer)
+        ->chain (comp m/-transformer-chain m/-into-transformer)
         chain (->> ?transformers (keep identity) (mapcat #(if (map? %) [%] (->chain %))) (vec))
         chain' (->> chain (mapv #(let [name (some-> % :name name)]
                                    {:decode (->data (:decoders %) (:default-decoder %) name "decode")

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -259,3 +259,65 @@
             (assoc s k (if ks (up (get s k (m/schema :map (m/options schema))) ks f args)
                               (apply f (get s k) args))))]
     (up schema ks f args)))
+
+;;
+;; LensSchemas: path
+;;
+
+(defn -get* [schema]
+  (if schema
+    (if-let [k' (m/-key schema)]
+      (recur (m/-get schema k' nil))
+      schema)))
+
+(defn -update* [schema k f]
+  (if schema
+    (if-let [k' (m/-key schema)]
+      (m/-set schema k' (-update* (m/-get schema k' nil) k f))
+      (m/-set schema k (f (m/-get schema k nil))))))
+
+(defn get*
+  "Like [[clojure.core/get]], but for LensSchemas using :path syntax."
+  ([schema k]
+   (get* schema k nil))
+  ([schema k default]
+   (if-let [schema (-get* schema)]
+     (m/-get schema k default))))
+
+(defn assoc*
+  "Like [[clojure.core/assoc]], but for LensSchemas using :path syntax."
+  [schema key value]
+  (-update* schema key (constantly value)))
+
+(defn update
+  "Like [[clojure.core/update]], but for LensSchemas using :path syntax."
+  [schema key f & args]
+  (assoc* schema key (apply f (get* schema key (m/schema :map (m/options schema))) args)))
+
+(defn get-in*
+  "Like [[clojure.core/get-in]], but for LensSchemas using :path syntax."
+  ([schema ks]
+   (get-in* schema ks nil))
+  ([schema [k & ks] default]
+   (if-not k
+     schema
+     (let [sentinel #?(:clj (Object.), :cljs (js-obj))
+           schema (get* schema k sentinel)]
+       (cond
+         (identical? schema sentinel) default
+         ks (get-in* schema ks default)
+         :else schema)))))
+
+(defn assoc-in*
+  "Like [[clojure.core/assoc-in]], but for LensSchemas using :path syntax."
+  [schema [k & ks] value]
+  (prn k ks schema)
+  (assoc* schema k (if ks (assoc-in* (get* schema k (m/schema :map (m/options schema))) ks value) value)))
+
+(defn update-in*
+  "Like [[clojure.core/update-in]], but for LensSchemas using :path syntax."
+  [schema ks f & args]
+  (letfn [(up [s [k & ks] f args]
+            (assoc* s k (if ks (up (get* s k (m/schema :map (m/options schema))) ks f args)
+                              (apply f (get* s k) args))))]
+    (up schema ks f args)))

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -242,39 +242,50 @@
 
 (defn get
   "Like [[clojure.core/get]], but for LensSchemas."
-  ([schema k]
-   (get schema k nil))
-  ([schema k default]
-   (if schema (m/-get schema k default))))
+  ([?schema k]
+   (get ?schema k nil nil))
+  ([?schema k default]
+   (get ?schema k default nil))
+  ([?schema k default options]
+   (let [schema (m/schema ?schema options)]
+     (if schema (m/-get schema k default)))))
 
 (defn assoc
   "Like [[clojure.core/assoc]], but for LensSchemas."
-  [schema key value]
-  (m/-set schema key value))
+  ([?schema key value]
+   (assoc ?schema key value nil))
+  ([?schema key value options]
+   (m/-set (m/schema ?schema options) key value)))
 
 (defn update
-  "Like [[clojure.core/update]], but for LensSchemas."
+  "Like [[clojure.core/update]], but for LensSchema instances."
   [schema key f & args]
-  (assoc schema key (apply f (get schema key (m/schema :map (m/options schema))) args)))
+  (m/-set schema key (apply f (get schema key (m/schema :map (m/options schema))) args)))
 
 (defn get-in
   "Like [[clojure.core/get-in]], but for LensSchemas."
-  ([schema ks]
-   (get-in schema ks nil))
-  ([schema [k & ks] default]
-   (if-not k
-     schema
-     (let [sentinel #?(:clj (Object.), :cljs (js-obj))
-           schema (get schema k sentinel)]
-       (cond
-         (identical? schema sentinel) default
-         ks (get-in schema ks default)
-         :else schema)))))
+  ([?schema ks]
+   (get-in ?schema ks nil nil))
+  ([?schema ks default]
+   (get-in ?schema ks default nil))
+  ([?schema [k & ks] default options]
+   (let [schema (m/schema ?schema options)]
+     (if-not k
+       schema
+       (let [sentinel #?(:clj (Object.), :cljs (js-obj))
+             schema (get schema k sentinel)]
+         (cond
+           (identical? schema sentinel) default
+           ks (get-in schema ks default)
+           :else schema))))))
 
 (defn assoc-in
   "Like [[clojure.core/assoc-in]], but for LensSchemas."
-  [schema [k & ks] value]
-  (assoc schema k (if ks (assoc-in (get schema k (m/schema :map (m/options schema))) ks value) value)))
+  ([?schema ks value]
+   (assoc-in ?schema ks value nil))
+  ([?schema [k & ks] value options]
+   (let [schema (m/schema ?schema options)]
+     (assoc schema k (if ks (assoc-in (get schema k (m/schema :map (m/options schema))) ks value) value)))))
 
 (defn update-in
   "Like [[clojure.core/update-in]], but for LensSchemas."

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -275,7 +275,7 @@
 ;; map-syntax
 ;;
 
-(defn -map-syntax-walker [schema children _ _]
+(defn -map-syntax-walker [schema _ children _]
   (let [properties (m/properties schema)]
     (cond-> {:type (m/type schema)}
             (seq properties) (clojure.core/assoc :properties properties)

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -264,12 +264,12 @@
 ;; in->path->in
 ;;
 
-(defn in->path [schema in]
+(defn path->in [schema in]
   (loop [i 0, s schema, acc []]
     (or (and (>= i (count in)) acc)
         (recur (inc i) (get s (in i)) (if-not (m/-key s) (conj acc (in i)) acc)))))
 
-(defn path->in [schema path]
+(defn in->path [schema path]
   (loop [i 0, s schema, acc []]
     (or (and (>= i (count path)) acc)
         (let [[i k] (if-let [k (m/-key s)] [i k] [(inc i) (path i)])]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -239,8 +239,10 @@
   ([?schema ks]
    (get-in ?schema ks nil))
   ([?schema [k & ks] options]
-   (let [schema (get (m/schema (or ?schema :map) options) k)]
-     (if ks (get-in schema ks) schema))))
+   (if-not k
+     (m/schema ?schema options)
+     (let [schema (get (m/schema (or ?schema :map) options) k)]
+       (if ks (get-in schema ks) schema)))))
 
 (defn assoc-in
   "Like [[clojure.core/assoc-in]], but for LensSchemas."

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -164,7 +164,7 @@
 (defn path->in [schema path]
   (loop [i 0, s schema, acc []]
     (or (and (>= i (count path)) acc)
-        (recur (inc i) (m/-get s (path i) nil) (if-not (m/-key s) (conj acc (path i)) acc)))))
+        (recur (inc i) (m/-get s (path i) nil) (cond-> acc (m/-keep s) (conj (path i)))))))
 
 (defn in->paths [schema in]
   (let [state (atom [])

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -37,7 +37,7 @@
     (or (and (>= i (count in)) acc)
         (recur (inc i) (m/-get s (in i) nil) (if-not (m/-key s) (conj acc (in i)) acc)))))
 
-(defn in->path [schema path]
+(defn ^:no-doc in->path [schema path]
   (loop [i 0, s schema, acc []]
     (or (and (>= i (count path)) acc)
         (let [[i k] (if-let [k (m/-key s)] [i k] [(inc i) (path i)])]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -149,6 +149,7 @@
      options)))
 
 (defn subschemas
+  "Returns all subschemas for unique paths as a vector of maps with :schema, :path and :in keys"
   ([?schema]
    (subschemas ?schema nil))
   ([?schema options]
@@ -161,12 +162,16 @@
   (let [seen (atom #{})]
     (filterv (fn [m] (let [v (f m)] (if-not (@seen v) (swap! seen conj v)))) coll)))
 
-(defn path->in [schema path]
+(defn path->in
+  "Returns a value path for a given Schema and schema path"
+  [schema path]
   (loop [i 0, s schema, acc []]
     (or (and (>= i (count path)) acc)
         (recur (inc i) (m/-get s (path i) nil) (cond-> acc (m/-keep s) (conj (path i)))))))
 
-(defn in->paths [schema in]
+(defn in->paths
+  "Returns a vector of schema paths for a given Schema and value path"
+  [schema in]
   (let [state (atom [])
         in-equals (fn [[x & xs] [y & ys]] (cond (and x (= x y)) (recur xs ys), (= x y) true, (= ::m/in x) (recur xs ys)))
         parent-exists (fn [v1 v2] (let [i (min (count v1) (count v2))] (= (subvec v1 0 i) (subvec v2 0 i))))]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -170,9 +170,11 @@
   (let [state (atom [])
         in-equals (fn [[x & xs] [y & ys]] (cond (and x (= x y)) (recur xs ys), (= x y) true, (= ::m/in x) (recur xs ys)))
         parent-exists (fn [v1 v2] (let [i (min (count v1) (count v2))] (= (subvec v1 0 i) (subvec v2 0 i))))]
-    (find-first schema (fn [_ path _] (when (and (in-equals (path->in schema path) in)
-                                                 (not (some (partial parent-exists path) @state)))
-                                        (swap! state conj path) nil)))
+    (find-first
+      schema
+      (fn [_ path _]
+        (when (and (in-equals (path->in schema path) in) (not (some (partial parent-exists path) @state)))
+          (swap! state conj path) nil)))
     @state))
 
 ;;

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -116,43 +116,48 @@
 (defn closed-schema
   "Closes recursively all :map schemas by adding `{:closed true}`
   property, unless schema explicitely open with `{:closed false}`"
-  ([schema]
-   (closed-schema schema nil))
-  ([schema options]
+  ([?schema]
+   (closed-schema ?schema nil))
+  ([?schema options]
    (m/walk
-     schema
+     ?schema
      (m/schema-walker
        (fn [schema]
          (if (-open-map? schema options)
            (update-properties schema c/assoc :closed true)
-           schema))))))
+           schema)))
+     options)))
 
 (defn open-schema
   "Closes recursively all :map schemas by removing `:closed`
   property, unless schema explicitely open with `{:closed false}`"
-  ([schema]
-   (open-schema schema nil))
-  ([schema options]
+  ([?schema]
+   (open-schema ?schema nil))
+  ([?schema options]
    (m/walk
-     schema
+     ?schema
      (m/schema-walker
        (fn [schema]
          (if (-open-map? schema options)
            (update-properties schema c/dissoc :closed)
-           schema))))))
+           schema)))
+     options)))
 
 (defn path-schemas
   "Return a ordered map from value path -> schema"
-  [schema]
-  (let [state (atom {:m {}, :v []})]
-    (find-first
-      schema
-      (fn [s i _]
-        (swap! state #(cond-> % (not (c/get-in % [:m i]))
-                              (-> (c/update :m c/assoc i s)
-                                  (c/update :v into [i s]))))
-        nil))
-    (->> @state :v (apply array-map))))
+  ([?schema]
+   (path-schemas ?schema nil))
+  ([?schema options]
+   (let [state (atom {:m {}, :v []})]
+     (find-first
+       ?schema
+       (fn [s i _]
+         (swap! state #(cond-> % (not (c/get-in % [:m i]))
+                               (-> (c/update :m c/assoc i s)
+                                   (c/update :v into [i s]))))
+         nil)
+       options)
+     (->> @state :v (apply array-map)))))
 
 ;;
 ;; MapSchemas

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -154,10 +154,10 @@
        (fn [s i _]
          (swap! state #(cond-> % (not (c/get-in % [:m i]))
                                (-> (c/update :m c/assoc i s)
-                                   (c/update :v into [i s]))))
+                                   (c/update :v into [{:path i, :schema s}]))))
          nil)
        options)
-     (->> @state :v (apply array-map)))))
+     (:v @state))))
 
 ;;
 ;; MapSchemas
@@ -289,7 +289,7 @@
   [schema key value]
   (-update* schema key (constantly value)))
 
-(defn update
+(defn update*
   "Like [[clojure.core/update]], but for LensSchemas using :path syntax."
   [schema key f & args]
   (assoc* schema key (apply f (get* schema key (m/schema :map (m/options schema))) args)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1124,18 +1124,19 @@
     (is (= true (m/validate [sequential int?] value)))))
 
 (deftest walker-in-test
-  (is (form= [:map {:in []}
-              [:id [string? {:in [:id]}]]
-              [:tags [:set {:in [:tags]} [keyword? {:in [:tags :malli.core/in]}]]]
+  (is (form= [:map {:path []}
+              [:id [string? {:path [:id]}]]
+              [:tags [:set {:path [:tags]} [keyword? {:path [:tags ::m/in]}]]]
               [:address
-               [:maybe {:in [:address]}
-                [:vector {:in [:address]}
-                 [:map {:in [:address :malli.core/in]}
-                  [:street [string? {:in [:address :malli.core/in :street]}]]
+               [:maybe {:path [:address]}
+                [:vector {:path [:address 0]}
+                 [:map {:path [:address 0 :malli.core/in]}
+                  [:street [string? {:path [:address 0 ::m/in :street]}]]
                   [:lonlat
-                   [:tuple {:in [:address :malli.core/in :lonlat]}
-                    [double? {:in [:address :malli.core/in :lonlat 0]}]
-                    [double? {:in [:address :malli.core/in :lonlat 1]}]]]]]]]]
+                   [:tuple {:path [:address 0 ::m/in :lonlat]}
+                    [double? {:path [:address 0 ::m/in :lonlat 0]}]
+                    [double? {:path [:address 0 ::m/in :lonlat 1]}]]]]]]]]
+
              (m/walk
                [:map
                 [:id string?]
@@ -1146,9 +1147,9 @@
                    [:map
                     [:street string?]
                     [:lonlat [:tuple double? double?]]]]]]]
-               (fn [schema children in options]
+               (fn [schema children path options]
                  (m/into-schema
                    (m/type schema)
-                   (assoc (m/properties schema) :in in)
+                   (assoc (m/properties schema) :path path)
                    children
                    options))))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -320,6 +320,11 @@
 
   (testing "ref schemas"
 
+    (testing "invalid refs fail"
+      (is (thrown?
+            #?(:clj Exception, :cljs js/Error)
+            (m/schema [:ref int?]))))
+
     (testing "recursion"
       (let [ConsCell [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
                       ::cons]]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -326,8 +326,8 @@
             (m/schema [:ref int?]))))
 
     (testing "recursion"
-      (let [ConsCell [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
-                      ::cons]]
+      (let [ConsCell (m/schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
+                                ::cons])]
 
         (is (true? (m/validate ConsCell [1 nil])))
         (is (true? (m/validate ConsCell [1 [2 nil]])))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -558,14 +558,14 @@
       (is (results= {:schema schema
                      :value {:y "invalid" :z "kikka"}
                      :errors
-                     [{:path [0], :in [:x], :schema schema, :type ::m/missing-key}
-                      {:path [1], :in [:y], :schema int?, :value "invalid"}]}
+                     [{:path [:x], :in [:x], :schema schema, :type ::m/missing-key}
+                      {:path [:y], :in [:y], :schema int?, :value "invalid"}]}
                     (m/explain schema {:y "invalid" :z "kikka"})))
 
       (is (results= {:schema schema,
                      :value {:x "invalid"},
-                     :errors [{:path [0], :in [:x], :schema boolean?, :value "invalid"}
-                              {:path [2],
+                     :errors [{:path [:x], :in [:x], :schema boolean?, :value "invalid"}
+                              {:path [:z],
                                :in [:z],
                                :schema schema,
                                :type :malli.core/missing-key}]}
@@ -658,16 +658,16 @@
 
       (is (results= {:schema schema,
                      :value {:type :sized, :size "size"},
-                     :errors [{:path [0 1], :in [:size], :schema int?, :value "size"}]}
+                     :errors [{:path [:sized :size], :in [:size], :schema int?, :value "size"}]}
                     (m/explain schema invalid1)))
 
       (is (results= {:schema schema,
                      :value {:type :human, :namez "inkeri"},
-                     :errors [{:path [1 1]
+                     :errors [{:path [:human :name]
                                :in [:name]
                                :schema [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]
                                :type :malli.core/missing-key}
-                              {:path [1 2]
+                              {:path [:human :address]
                                :in [:address]
                                :schema [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]
                                :type :malli.core/missing-key}]}
@@ -1015,18 +1015,18 @@
                                         [schema {:x "non-x" :y "y"}
                                          {:schema schema
                                           :value {:x "non-x" :y "y"}
-                                          :errors [{:path [0 0], :in [:x], :schema [:enum "x"], :value "non-x"}]}]
+                                          :errors [{:path [:x 0], :in [:x], :schema [:enum "x"], :value "non-x"}]}]
 
                                         [schema {:x "x" :y "non-y"}
                                          {:schema schema
                                           :value {:x "x" :y "non-y"}
-                                          :errors [{:path [1 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]
+                                          :errors [{:path [:y 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]
 
                                         [schema {:x "non-x" :y "non-y"}
                                          {:schema schema
                                           :value {:x "non-x" :y "non-y"}
-                                          :errors [{:path [0 0], :in [:x], :schema [:enum "x"], :value "non-x"}
-                                                   {:path [1 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]])}
+                                          :errors [{:path [:x 0], :in [:x], :schema [:enum "x"], :value "non-x"}
+                                                   {:path [:y 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]])}
             expectations (assoc expectations "sequential" (concat (get expectations "list") (get expectations "vector")))]
 
         (doseq [[name data] expectations
@@ -1053,9 +1053,9 @@
     (is (= [0] (?path (m/explain [:tuple int?] ["2"]))))
     (is (= [0] (?path (m/explain [:tuple {:name "int?"} [int?]] ["2"]))))
 
-    (is (= [0] (?path (m/explain [:map [:x int?]] {:x "1"}))))
-    (is (= [0] (?path (m/explain [:map {:name int?} [:x int?]] {:x "1"}))))
-    (is (= [0] (?path (m/explain [:map {:name int?} [:x {:optional false} int?]] {:x "1"}))))))
+    (is (= [:x] (?path (m/explain [:map [:x int?]] {:x "1"}))))
+    (is (= [:x] (?path (m/explain [:map {:name int?} [:x int?]] {:x "1"}))))
+    (is (= [:x] (?path (m/explain [:map {:name int?} [:x {:optional false} int?]] {:x "1"}))))))
 
 (deftest properties-test
   (testing "properties can be set and retrieved"

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -338,7 +338,7 @@
                        :value [1 [2]]
                        :errors [{:in [1]
                                  :path [0 1 0 0]
-                                 :schema (mu/get ConsCell 0)
+                                 :schema (mu/get-in ConsCell [0 0 0])
                                  :type :malli.core/tuple-size
                                  :value [2]}]}
                       (m/explain ConsCell [1 [2]])))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -131,8 +131,8 @@
       (is (nil? (m/explain schema 1)))
       (is (results= {:schema schema,
                      :value 0,
-                     :errors [{:path [2 1], :in [], :schema pos-int?, :value 0}
-                              {:path [2 2], :in [], :schema neg-int?, :value 0}]}
+                     :errors [{:path [1 0], :in [], :schema pos-int?, :value 0}
+                              {:path [1 1], :in [], :schema neg-int?, :value 0}]}
                     (m/explain schema 0)))
 
       (is (= 1 (m/decode schema "1" mt/string-transformer)))
@@ -201,12 +201,12 @@
       (let [schema [:and pos-int? neg-int?]]
         (is (results= {:schema schema,
                        :value -1,
-                       :errors [{:path [1], :in [], :schema pos-int?, :value -1}]}
+                       :errors [{:path [0], :in [], :schema pos-int?, :value -1}]}
                       (m/explain schema -1))))
       (let [schema [:and pos-int? neg-int?]]
         (is (results= {:schema schema,
                        :value 1,
-                       :errors [{:path [2], :in [], :schema neg-int?, :value 1}]}
+                       :errors [{:path [1], :in [], :schema neg-int?, :value 1}]}
                       (m/explain schema 1))))))
 
   (testing "comparator schemas"
@@ -269,7 +269,7 @@
       (is (false? (m/validate schema "abba")))
 
       (is (nil? (m/explain schema 1)))
-      (is (results= {:schema [:maybe int?], :value "abba", :errors [{:path [1], :in [], :schema int?, :value "abba"}]}
+      (is (results= {:schema [:maybe int?], :value "abba", :errors [{:path [0], :in [], :schema int?, :value "abba"}]}
                     (m/explain [:maybe int?] "abba")))
 
       (is (= 1 (m/decode schema "1" mt/string-transformer)))
@@ -332,7 +332,7 @@
         (is (results= {:schema ConsCell
                        :value [1 [2]]
                        :errors [{:in [1]
-                                 :path [1 2 0 1]
+                                 :path [0 1 0 0]
                                  :schema (mu/get ConsCell 0)
                                  :type :malli.core/tuple-size
                                  :value [2]}]}
@@ -410,9 +410,9 @@
       (is (nil? (m/explain schema 1)))
       (is (results= {:schema schema
                      :value -1
-                     :errors [{:path [2 1] :in [] :schema pos-int?, :value -1}
-                              {:path [2 2], :in [], :schema pos-int?, :value -1}
-                              {:path [2 3], :in [], :schema pos-int?, :value -1}]}
+                     :errors [{:path [0 0] :in [] :schema pos-int?, :value -1}
+                              {:path [0 1], :in [], :schema pos-int?, :value -1}
+                              {:path [0 2], :in [], :schema pos-int?, :value -1}]}
 
                     (m/explain schema -1)))
 
@@ -553,14 +553,14 @@
       (is (results= {:schema schema
                      :value {:y "invalid" :z "kikka"}
                      :errors
-                     [{:path [1 0], :in [:x], :schema schema, :type ::m/missing-key}
-                      {:path [2 2], :in [:y], :schema int?, :value "invalid"}]}
+                     [{:path [0], :in [:x], :schema schema, :type ::m/missing-key}
+                      {:path [1], :in [:y], :schema int?, :value "invalid"}]}
                     (m/explain schema {:y "invalid" :z "kikka"})))
 
       (is (results= {:schema schema,
                      :value {:x "invalid"},
-                     :errors [{:path [1 1], :in [:x], :schema boolean?, :value "invalid"}
-                              {:path [3 0],
+                     :errors [{:path [0], :in [:x], :schema boolean?, :value "invalid"}
+                              {:path [2],
                                :in [:z],
                                :schema schema,
                                :type :malli.core/missing-key}]}
@@ -653,16 +653,16 @@
 
       (is (results= {:schema schema,
                      :value {:type :sized, :size "size"},
-                     :errors [{:path [2 1 2 1], :in [:size], :schema int?, :value "size"}]}
+                     :errors [{:path [0 1], :in [:size], :schema int?, :value "size"}]}
                     (m/explain schema invalid1)))
 
       (is (results= {:schema schema,
                      :value {:type :human, :namez "inkeri"},
-                     :errors [{:path [3 1 2 0]
+                     :errors [{:path [1 1]
                                :in [:name]
                                :schema [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]
                                :type :malli.core/missing-key}
-                              {:path [3 1 3 0]
+                              {:path [1 2]
                                :in [:address]
                                :schema [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]
                                :type :malli.core/missing-key}]}
@@ -728,18 +728,18 @@
     (is (some? (m/explain [:map-of string? int?] ::invalid)))
     (is (results= {:schema [:map-of string? int?],
                    :value {:age 18},
-                   :errors [{:path [1],
+                   :errors [{:path [0],
                              :in [:age],
                              :schema string?,
                              :value :age}]}
                   (m/explain [:map-of string? int?] {:age 18})))
     (is (results= {:schema [:map-of string? int?],
                    :value {:age "18"},
-                   :errors [{:path [1],
+                   :errors [{:path [0],
                              :in [:age],
                              :schema string?,
                              :value :age}
-                            {:path [2],
+                            {:path [1],
                              :in [:age],
                              :schema int?,
                              :value "18"}]}
@@ -928,7 +928,7 @@
                                       [schema [1 2 "3"]
                                        {:schema schema
                                         :value [1 2 "3"]
-                                        :errors [{:path [2], :in [2], :schema int?, :value "3"}]}]])
+                                        :errors [{:path [0], :in [2], :schema int?, :value "3"}]}]])
 
                           "list" (let [schema [:list {:min 2, :max 3} int?]]
 
@@ -953,7 +953,7 @@
                                     [schema '(1 2 "3")
                                      {:schema schema
                                       :value '(1 2 "3")
-                                      :errors [{:path [2], :in [2], :schema int?, :value "3"}]}]])
+                                      :errors [{:path [0], :in [2], :schema int?, :value "3"}]}]])
 
                           "set" (let [schema [:set {:min 2, :max 3} int?]]
 
@@ -978,7 +978,7 @@
                                    [schema #{1 2 "3"}
                                     {:schema schema
                                      :value #{1 2 "3"}
-                                     :errors [{:path [2], :in [0], :schema int?, :value "3"}]}]])
+                                     :errors [{:path [0], :in [0], :schema int?, :value "3"}]}]])
 
                           "tuple" (let [schema [:tuple int? string?]]
 
@@ -998,8 +998,10 @@
                                      [schema [1 2]
                                       {:schema schema
                                        :value [1 2]
-                                       :errors [{:path [2], :in [1], :schema string?, :value 2}]}]])
-                          "map+enum" (let [schema [:map [:x [:enum "x"]]
+                                       :errors [{:path [1], :in [1], :schema string?, :value 2}]}]])
+
+                          "map+enum" (let [schema [:map
+                                                   [:x [:enum "x"]]
                                                    [:y [:enum "y"]]]]
 
                                        [[schema {:x "x" :y "y"}
@@ -1008,18 +1010,18 @@
                                         [schema {:x "non-x" :y "y"}
                                          {:schema schema
                                           :value {:x "non-x" :y "y"}
-                                          :errors [{:path [1 1 0], :in [:x], :schema [:enum "x"], :value "non-x"}]}]
+                                          :errors [{:path [0 0], :in [:x], :schema [:enum "x"], :value "non-x"}]}]
 
                                         [schema {:x "x" :y "non-y"}
                                          {:schema schema
                                           :value {:x "x" :y "non-y"}
-                                          :errors [{:path [2 1 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]
+                                          :errors [{:path [1 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]
 
                                         [schema {:x "non-x" :y "non-y"}
                                          {:schema schema
                                           :value {:x "non-x" :y "non-y"}
-                                          :errors [{:path [1 1 0], :in [:x], :schema [:enum "x"], :value "non-x"}
-                                                   {:path [2 1 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]])}
+                                          :errors [{:path [0 0], :in [:x], :schema [:enum "x"], :value "non-x"}
+                                                   {:path [1 0], :in [:y], :schema [:enum "y"], :value "non-y"}]}]])}
             expectations (assoc expectations "sequential" (concat (get expectations "list") (get expectations "vector")))]
 
         (doseq [[name data] expectations
@@ -1037,18 +1039,18 @@
 (deftest path-with-properties-test
   (let [?path #(-> % :errors first :path)]
 
-    (is (= [1] (?path (m/explain [:and int?] "2"))))
-    (is (= [2] (?path (m/explain [:and {:name "int?"} int?] "2"))))
+    (is (= [0] (?path (m/explain [:and int?] "2"))))
+    (is (= [0] (?path (m/explain [:and {:name "int?"} int?] "2"))))
 
-    (is (= [1] (?path (m/explain [:vector int?] ["2"]))))
-    (is (= [2] (?path (m/explain [:vector {:name "int?"} [int?]] ["2"]))))
+    (is (= [0] (?path (m/explain [:vector int?] ["2"]))))
+    (is (= [0] (?path (m/explain [:vector {:name "int?"} [int?]] ["2"]))))
 
-    (is (= [1] (?path (m/explain [:tuple int?] ["2"]))))
-    (is (= [2] (?path (m/explain [:tuple {:name "int?"} [int?]] ["2"]))))
+    (is (= [0] (?path (m/explain [:tuple int?] ["2"]))))
+    (is (= [0] (?path (m/explain [:tuple {:name "int?"} [int?]] ["2"]))))
 
-    (is (= [1 1] (?path (m/explain [:map [:x int?]] {:x "1"}))))
-    (is (= [2 1] (?path (m/explain [:map {:name int?} [:x int?]] {:x "1"}))))
-    (is (= [2 2] (?path (m/explain [:map {:name int?} [:x {:optional false} int?]] {:x "1"}))))))
+    (is (= [0] (?path (m/explain [:map [:x int?]] {:x "1"}))))
+    (is (= [0] (?path (m/explain [:map {:name int?} [:x int?]] {:x "1"}))))
+    (is (= [0] (?path (m/explain [:map {:name int?} [:x {:optional false} int?]] {:x "1"}))))))
 
 (deftest properties-test
   (testing "properties can be set and retrieved"

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -578,7 +578,7 @@
 
       (is (results= {:schema closed-schema
                      :value valid-with-extras
-                     :errors [{:path [],
+                     :errors [{:path [:extra],
                                :in [:extra],
                                :schema closed-schema,
                                :value nil,

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1147,7 +1147,7 @@
                    [:map
                     [:street string?]
                     [:lonlat [:tuple double? double?]]]]]]]
-               (fn [schema children path options]
+               (fn [schema path children options]
                  (m/into-schema
                    (m/type schema)
                    (assoc (m/properties schema) :path path)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -69,7 +69,7 @@
   (is (form= [:map {:closed true} [:x int?]]
              (m/into-schema :map {:closed true} [[:x int?]]))))
 
-#_(deftest schema-walker-test
+(deftest schema-walker-test
   (is (form= [:map {:closed true} [:x int?]]
              (m/walk [:map {:closed true} [:x int?]] (m/schema-walker identity))))
   (is (form= [:map {:registry {::age [:and int? [:> 18]]}} [:age ::age]]

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -20,7 +20,7 @@
                 (-properties [_])
                 (-explainer [this path]
                   (fn [value in acc]
-                    (if-not (int? value) (conj acc (m/error path in this value)) acc)))
+                    (if-not (int? value) (conj acc (m/-error path in this value)) acc)))
                 me/SchemaError
                 (-error [_] {:error/message "from schema"})) "kikka" "from schema"]
              ;; via defaults

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -62,7 +62,7 @@
       (-type [_])
       (-form [_])
       (-validator [_] int?)
-      (-walk [t w i o] (m/-outer w t nil i o))
+      (-walk [t w p o] (m/-outer w t p nil o))
       json-schema/JsonSchema
       (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
 

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -70,7 +70,7 @@
    [(reify
       m/Schema
       (-properties [_])
-      (-walk [t w i o] (m/-outer w t nil i o))
+      (-walk [t w p o] (m/-outer w t p nil o))
       swagger/SwaggerSchema
       (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -157,46 +157,46 @@
                     [:b {:optional true} int?]]))))
 
 (deftest get-test
-  (is (form= (mu/get int? 0) nil))
+  (is (form= (mu/get (m/schema int?) 0) nil))
   (let [re #"kikka"]
-    (is (form= (mu/get [:re re] 0) re)))
+    (is (form= (mu/get (m/schema [:re re]) 0) re)))
   (let [f int?]
-    (is (form= (mu/get [:fn f] 0) f)))
-  (is (form= (mu/get [:string {:min 1}] 0) nil))
-  (is (form= (mu/get [:enum "A" "B"] 0) "A"))
-  (is (mu/equals (mu/get [:map [:x int?]] :x) int?))
-  (is (mu/equals (mu/get [:map [:x {:optional true} int?]] :x) int?))
-  (is (mu/equals (mu/get [:vector int?] 0) int?))
-  (is (mu/equals (mu/get [:list int?] 0) int?))
-  (is (mu/equals (mu/get [:set int?] 0) int?))
-  (is (mu/equals (mu/get [:sequential int?] 0) int?))
-  (is (mu/equals (mu/get [:or int? pos-int?] 1) pos-int?))
-  (is (mu/equals (mu/get [:and int? pos-int?] 1) pos-int?))
-  (is (mu/equals (mu/get [:tuple int? pos-int?] 1) pos-int?))
-  (is (form= (mu/get [:map [:x int?]] :y)
-             (mu/get [:vector int?] 1)
+    (is (form= (mu/get (m/schema [:fn f]) 0) f)))
+  (is (form= (mu/get (m/schema [:string {:min 1}]) 0) nil))
+  (is (form= (mu/get (m/schema [:enum "A" "B"]) 0) "A"))
+  (is (mu/equals (mu/get (m/schema [:map [:x int?]]) :x) int?))
+  (is (mu/equals (mu/get (m/schema [:map [:x {:optional true} int?]]) :x) int?))
+  (is (mu/equals (mu/get (m/schema [:vector int?]) 0) int?))
+  (is (mu/equals (mu/get (m/schema [:list int?]) 0) int?))
+  (is (mu/equals (mu/get (m/schema [:set int?]) 0) int?))
+  (is (mu/equals (mu/get (m/schema [:sequential int?]) 0) int?))
+  (is (mu/equals (mu/get (m/schema [:or int? pos-int?]) 1) pos-int?))
+  (is (mu/equals (mu/get (m/schema [:and int? pos-int?]) 1) pos-int?))
+  (is (mu/equals (mu/get (m/schema [:tuple int? pos-int?]) 1) pos-int?))
+  (is (form= (mu/get (m/schema [:map [:x int?]]) :y)
+             (mu/get (m/schema [:maybe int?]) 1)
              nil))
-  (is (mu/equals (mu/get [:map-of int? pos-int?] 0) int?))
-  (is (mu/equals (mu/get [:map-of int? pos-int?] 1) pos-int?))
-  (is (form= (mu/get [:ref {:registry {::a int?, ::b string?}} ::a] 0) ::a))
-  (is (mu/equals (mu/get [:schema int?] 0) int?)))
+  (is (mu/equals (mu/get (m/schema [:map-of int? pos-int?]) 0) int?))
+  (is (mu/equals (mu/get (m/schema [:map-of int? pos-int?]) 1) pos-int?))
+  (is (form= (mu/get (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) 0) ::a))
+  (is (mu/equals (mu/get (m/schema [:schema int?]) 0) int?)))
 
 (deftest get-in-test
   (is (mu/equals boolean?
                  (mu/get-in
-                   [:map
-                    [:x [:vector
-                         [:list
-                          [:set
-                           [:sequential
-                            [:tuple int? [:map [:y [:maybe boolean?]]]]]]]]]]
+                   (m/schema [:map
+                              [:x [:vector
+                                   [:list
+                                    [:set
+                                     [:sequential
+                                      [:tuple int? [:map [:y [:maybe boolean?]]]]]]]]]])
                    [:x 0 0 0 0 1 :y 0])))
   (is (mu/equals [:maybe [:tuple int? boolean?]]
-                 (mu/get-in [:maybe [:tuple int? boolean?]] [])))
-  (is (form= (mu/get-in [:ref {:registry {::a int?, ::b string?}} ::a] [0]) ::a))
-  (is (mu/equals (mu/get-in [:ref {:registry {::a int?, ::b string?}} ::a] [0 0]) int?))
-  (is (form= (mu/get-in [:schema {:registry {::a int?, ::b string?}} ::a] [0]) ::a))
-  (is (mu/equals (mu/get-in [:schema {:registry {::a int?, ::b string?}} ::a] [0 0]) int?)))
+                 (mu/get-in (m/schema [:maybe [:tuple int? boolean?]]) [])))
+  (is (form= (mu/get-in (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) [0]) ::a))
+  (is (mu/equals (mu/get-in (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) [0 0]) int?))
+  (is (form= (mu/get-in (m/schema [:schema {:registry {::a int?, ::b string?}} ::a]) [0]) ::a))
+  (is (mu/equals (mu/get-in (m/schema [:schema {:registry {::a int?, ::b string?}} ::a]) [0 0]) int?)))
 
 (deftest dissoc-test
   (let [schema [:map {:title "map"}
@@ -212,31 +212,29 @@
                     [:a int?]
                     [:c string?]]))))
 
-(let [re #"kikka"]
-  (mu/assoc [:re #"kukka"] 0 re))
-
 (deftest assoc-test
   (let [re #"kikka"]
-    (is (mu/equals (mu/assoc [:re #"kukka"] 0 re) [:re re])))
+    (is (mu/equals (mu/assoc (m/schema [:re #"kukka"]) 0 re) [:re re])))
   (let [f 'int?]
-    (is (mu/equals (mu/assoc [:fn 'string?] 0 f) [:fn f])))
-  (is (mu/equals (mu/assoc [:enum "A" "B"] 1 "C") [:enum "A" "C"]))
-  (is (mu/equals (mu/assoc [:enum "A" "B"] 2 "C") [:enum "A" "B" "C"]))
-  (is (mu/equals (mu/assoc [:vector int?] 0 string?) [:vector string?]))
-  (is (mu/equals (mu/assoc [:tuple int? int?] 1 string?) [:tuple int? string?]))
-  (is (mu/equals (mu/assoc [:tuple int? int?] 2 string?) [:tuple int? int? string?]))
-  (is (mu/equals (mu/assoc [:and int? int?] 1 string?) [:and int? string?]))
-  (is (mu/equals (mu/assoc [:maybe int?] 0 string?) [:maybe string?]))
-  (is (mu/equals (mu/assoc [:map [:x int?] [:y int?]] :x nil) [:map [:y int?]]))
-  (is (mu/equals (mu/assoc [:map-of int? int?] 0 string?) [:map-of string? int?]))
-  (is (mu/equals (mu/assoc [:map-of int? int?] 1 string?) [:map-of int? string?]))
-  (is (mu/equals (mu/assoc [:ref {:registry {::a int?, ::b string?}} ::a] 0 ::b) [:ref {:registry {::a int?, ::b string?}} ::b]))
-  (is (mu/equals (mu/assoc [:schema int?] 0 string?) [:schema string?]))
+    (is (mu/equals (mu/assoc (m/schema [:fn 'string?]) 0 f) [:fn f])))
+  (is (mu/equals (mu/assoc (m/schema [:enum "A" "B"]) 1 "C") [:enum "A" "C"]))
+  (is (mu/equals (mu/assoc (m/schema [:enum "A" "B"]) 2 "C") [:enum "A" "B" "C"]))
+  (is (mu/equals (mu/assoc (m/schema [:vector int?]) 0 string?) [:vector string?]))
+  (is (mu/equals (mu/assoc (m/schema [:tuple int? int?]) 1 string?) [:tuple int? string?]))
+  (is (mu/equals (mu/assoc (m/schema [:tuple int? int?]) 2 string?) [:tuple int? int? string?]))
+  (is (mu/equals (mu/assoc (m/schema [:and int? int?]) 1 string?) [:and int? string?]))
+  (is (mu/equals (mu/assoc (m/schema [:maybe int?]) 0 string?) [:maybe string?]))
+  (is (mu/equals (mu/assoc (m/schema [:map [:x int?] [:y int?]]) :x nil) [:map [:y int?]]))
+  (is (mu/equals (mu/assoc (m/schema [:map-of int? int?]) 0 string?) [:map-of string? int?]))
+  (is (mu/equals (mu/assoc (m/schema [:map-of int? int?]) 1 string?) [:map-of int? string?]))
+  (is (mu/equals (mu/assoc (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) 0 ::b) [:ref {:registry {::a int?, ::b string?}} ::b]))
+  (is (mu/equals (mu/assoc (m/schema [:schema int?]) 0 string?) [:schema string?]))
 
   (testing "invalid assoc throws"
     (are [schema i]
       (is (thrown? #?(:clj Exception, :cljs js/Error) (mu/assoc schema i string?)))
 
+      nil :x
       int? 0
       [:string {:min 1}] 0
       [:vector int?] 1
@@ -248,10 +246,11 @@
       [:ref {:registry {::a int?}} ::a] 1
       [:schema int?] 1))
 
-  (let [schema [:map {:title "map"}
-                [:a int?]
-                [:b {:optional true} int?]
-                [:c string?]]]
+  (let [schema (m/schema
+                 [:map {:title "map"}
+                  [:a int?]
+                  [:b {:optional true} int?]
+                  [:c string?]])]
     (is (mu/equals (mu/assoc schema :a string?)
                    [:map {:title "map"}
                     [:a string?]
@@ -269,22 +268,23 @@
                     [:c string?]]))))
 
 (deftest update-test
-  (is (mu/equals (mu/update [:vector int?] 0 (constantly string?)) [:vector string?]))
-  (is (mu/equals (mu/update [:tuple int? int?] 1 (constantly string?)) [:tuple int? string?]))
-  (is (mu/equals (mu/update [:tuple int? int?] 2 (constantly string?)) [:tuple int? int? string?]))
-  (is (mu/equals (mu/update [:or int? int?] 1 (constantly string?)) [:or int? string?]))
-  (is (mu/equals (mu/update [:or int? int?] 2 (constantly string?)) [:or int? int? string?]))
-  (is (mu/equals (mu/update [:and int? int?] 1 (constantly string?)) [:and int? string?]))
-  (is (mu/equals (mu/update [:and int? int?] 2 (constantly string?)) [:and int? int? string?]))
-  (is (mu/equals (mu/update [:maybe int?] 0 (constantly string?)) [:maybe string?]))
-  (is (mu/equals (mu/update [:map [:x int?] [:y int?]] :x (constantly nil)) [:map [:y int?]]))
-  (is (mu/equals (mu/update [:ref {:registry {::a int?, ::b string?}} ::a] 0 (constantly ::b)) [:ref {:registry {::a int?, ::b string?}} ::b]))
-  (is (mu/equals (mu/update [:schema int?] 0 (constantly string?)) [:schema string?]))
+  (is (mu/equals (mu/update (m/schema [:vector int?]) 0 (constantly string?)) [:vector string?]))
+  (is (mu/equals (mu/update (m/schema [:tuple int? int?]) 1 (constantly string?)) [:tuple int? string?]))
+  (is (mu/equals (mu/update (m/schema [:tuple int? int?]) 2 (constantly string?)) [:tuple int? int? string?]))
+  (is (mu/equals (mu/update (m/schema [:or int? int?]) 1 (constantly string?)) [:or int? string?]))
+  (is (mu/equals (mu/update (m/schema [:or int? int?]) 2 (constantly string?)) [:or int? int? string?]))
+  (is (mu/equals (mu/update (m/schema [:and int? int?]) 1 (constantly string?)) [:and int? string?]))
+  (is (mu/equals (mu/update (m/schema [:and int? int?]) 2 (constantly string?)) [:and int? int? string?]))
+  (is (mu/equals (mu/update (m/schema [:maybe int?]) 0 (constantly string?)) [:maybe string?]))
+  (is (mu/equals (mu/update (m/schema [:map [:x int?] [:y int?]]) :x (constantly nil)) [:map [:y int?]]))
+  (is (mu/equals (mu/update (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) 0 (constantly ::b)) [:ref {:registry {::a int?, ::b string?}} ::b]))
+  (is (mu/equals (mu/update (m/schema [:schema int?]) 0 (constantly string?)) [:schema string?]))
 
-  (let [schema [:map {:title "map"}
-                [:a int?]
-                [:b {:optional true} int?]
-                [:c string?]]]
+  (let [schema (m/schema
+                 [:map {:title "map"}
+                  [:a int?]
+                  [:b {:optional true} int?]
+                  [:c string?]])]
     (is (mu/equals (mu/update schema :a mu/update-properties assoc :title "a")
                    [:map {:title "map"}
                     [:a [int? {:title "a"}]]
@@ -307,36 +307,32 @@
                     [:c string?]]))))
 
 (deftest assoc-in-test
-  (is (mu/equals (mu/assoc-in [:vector int?] [0] string?) [:vector string?]))
-  (is (mu/equals (mu/assoc-in [:tuple int? int?] [1] string?) [:tuple int? string?]))
-  (is (mu/equals (mu/assoc-in [:tuple int? int?] [2] string?) [:tuple int? int? string?]))
-  (is (mu/equals (mu/assoc-in [:or int? int?] [1] string?) [:or int? string?]))
-  (is (mu/equals (mu/assoc-in [:or int? int?] [2] string?) [:or int? int? string?]))
-  (is (mu/equals (mu/assoc-in [:and int? int?] [1] string?) [:and int? string?]))
-  (is (mu/equals (mu/assoc-in [:and int? int?] [2] string?) [:and int? int? string?]))
-  (is (mu/equals (mu/assoc-in [:maybe int?] [0] string?) [:maybe string?]))
-  (is (mu/equals (mu/assoc-in nil [:a [:b {:optional true}] :c :d] int?)
-                 [:map [:a [:map [:b {:optional true} [:map [:c [:map [:d int?]]]]]]]]))
-  (is (mu/equals (mu/assoc-in [:map] [:a :b :c :d] int?)
+  (is (mu/equals (mu/assoc-in (m/schema [:vector int?]) [0] string?) [:vector string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:tuple int? int?]) [1] string?) [:tuple int? string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:tuple int? int?]) [2] string?) [:tuple int? int? string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:or int? int?]) [1] string?) [:or int? string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:or int? int?]) [2] string?) [:or int? int? string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:and int? int?]) [1] string?) [:and int? string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:and int? int?]) [2] string?) [:and int? int? string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:maybe int?]) [0] string?) [:maybe string?]))
+  (is (mu/equals (mu/assoc-in (m/schema [:map]) [:a :b :c :d] int?)
                  [:map [:a [:map [:b [:map [:c [:map [:d int?]]]]]]]]))
-  (is (mu/equals (mu/assoc-in [:ref {:registry {::a int?, ::b string?}} ::a] [0] ::b) [:ref {:registry {::a int?, ::b string?}} ::b]))
-  (is (mu/equals (mu/assoc-in [:schema int?] [0] string?) [:schema string?])))
+  (is (mu/equals (mu/assoc-in (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) [0] ::b) [:ref {:registry {::a int?, ::b string?}} ::b]))
+  (is (mu/equals (mu/assoc-in (m/schema [:schema int?]) [0] string?) [:schema string?])))
 
 (deftest update-in-test
-  (is (mu/equals (mu/update-in [:vector int?] [0] (constantly string?)) [:vector string?]))
-  (is (mu/equals (mu/update-in [:tuple int? int?] [1] (constantly string?)) [:tuple int? string?]))
-  (is (mu/equals (mu/update-in [:tuple int? int?] [2] (constantly string?)) [:tuple int? int? string?]))
-  (is (mu/equals (mu/update-in [:or int? int?] [1] (constantly string?)) [:or int? string?]))
-  (is (mu/equals (mu/update-in [:or int? int?] [2] (constantly string?)) [:or int? int? string?]))
-  (is (mu/equals (mu/update-in [:and int? int?] [1] (constantly string?)) [:and int? string?]))
-  (is (mu/equals (mu/update-in [:and int? int?] [2] (constantly string?)) [:and int? int? string?]))
-  (is (mu/equals (mu/update-in [:maybe int?] [0] (constantly string?)) [:maybe string?]))
-  (is (mu/equals (mu/update-in nil [:a [:b {:optional true}] :c :d] (constantly int?))
-                 [:map [:a [:map [:b {:optional true} [:map [:c [:map [:d int?]]]]]]]]))
-  (is (mu/equals (mu/update-in [:map] [:a :b :c :d] (constantly int?))
+  (is (mu/equals (mu/update-in (m/schema [:vector int?]) [0] (constantly string?)) [:vector string?]))
+  (is (mu/equals (mu/update-in (m/schema [:tuple int? int?]) [1] (constantly string?)) [:tuple int? string?]))
+  (is (mu/equals (mu/update-in (m/schema [:tuple int? int?]) [2] (constantly string?)) [:tuple int? int? string?]))
+  (is (mu/equals (mu/update-in (m/schema [:or int? int?]) [1] (constantly string?)) [:or int? string?]))
+  (is (mu/equals (mu/update-in (m/schema [:or int? int?]) [2] (constantly string?)) [:or int? int? string?]))
+  (is (mu/equals (mu/update-in (m/schema [:and int? int?]) [1] (constantly string?)) [:and int? string?]))
+  (is (mu/equals (mu/update-in (m/schema [:and int? int?]) [2] (constantly string?)) [:and int? int? string?]))
+  (is (mu/equals (mu/update-in (m/schema [:maybe int?]) [0] (constantly string?)) [:maybe string?]))
+  (is (mu/equals (mu/update-in (m/schema [:map]) [:a :b :c :d] (constantly int?))
                  [:map [:a [:map [:b [:map [:c [:map [:d int?]]]]]]]]))
-  (is (mu/equals (mu/update-in [:ref {:registry {::a int?, ::b string?}} ::a] [0] (constantly ::b)) [:ref {:registry {::a int?, ::b string?}} ::b]))
-  (is (mu/equals (mu/update-in [:schema int?] [0] (constantly string?)) [:schema string?])))
+  (is (mu/equals (mu/update-in (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) [0] (constantly ::b)) [:ref {:registry {::a int?, ::b string?}} ::b]))
+  (is (mu/equals (mu/update-in (m/schema [:schema int?]) [0] (constantly string?)) [:schema string?])))
 
 (deftest optional-keys-test
   (let [schema [:map [:x int?] [:y int?]]]

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -375,51 +375,49 @@
               {:salaisuus "vaarassa"}] @walked-properties)))))
 
 (deftest path-schema-test
-  (let [schema [:and
-                [:map
-                 [:a int?]
-                 [:b [:set boolean?]]
-                 [:c [:vector
-                      [:and
-                       [:fn '(constantly true)]
-                       [:map
-                        [:d string?]]]]]]
-                [:fn '(constantly true)]]]
+  (let [with-forms (partial map #(update % :schema m/form))]
 
     (testing "retains original order"
-      (= [[]
-          [:a]
-          [:b]
-          [:b :malli.core/in]
-          [:c]
-          [:c :malli.core/in]
-          [:c :malli.core/in :d]]
-         (keys (mu/path-schemas schema))))
-
-    (testing "path-schemas are correct"
-      (is (= (->> {[] [:and
-                       [:map
-                        [:a int?]
-                        [:b [:set boolean?]]
-                        [:c [:vector
-                             [:and
-                              [:fn '(constantly true)]
-                              [:map
-                               [:d string?]]]]]]
-                       [:fn '(constantly true)]]
-                   [:a] int?
-                   [:b] [:set boolean?]
-                   [:b :malli.core/in] boolean?
-                   [:c] [:vector
-                         [:and
+      (is (= (with-forms
+               [{:path [],
+                 :schema [:and
+                          [:map
+                           [:a int?]
+                           [:b [:set boolean?]]
+                           [:c [:vector
+                                [:and
+                                 [:fn '(constantly true)]
+                                 [:map
+                                  [:d string?]]]]]]
+                          [:fn '(constantly true)]]}
+                {:path [:a]
+                 :schema int?}
+                {:path [:b]
+                 :schema [:set boolean?]}
+                {:path [:b :malli.core/in]
+                 :schema boolean?}
+                {:path [:c]
+                 :schema [:vector
+                          [:and
+                           [:fn '(constantly true)]
+                           [:map
+                            [:d string?]]]]}
+                {:path [:c :malli.core/in]
+                 :schema [:and
                           [:fn '(constantly true)]
                           [:map
-                           [:d string?]]]]
-                   [:c :malli.core/in] [:and
-                                        [:fn '(constantly true)]
-                                        [:map
-                                         [:d string?]]]
-                   [:c :malli.core/in :d] string?}
-                  (map (fn [[k v]] [k (m/form v)])))
-             (->> (mu/path-schemas schema)
-                  (map (fn [[k v]] [k (m/form v)]))))))))
+                           [:d string?]]]}
+                {:path [:c :malli.core/in :d]
+                 :schema string?}])
+             (with-forms
+               (mu/path-schemas
+                 [:and
+                  [:map
+                   [:a int?]
+                   [:b [:set boolean?]]
+                   [:c [:vector
+                        [:and
+                         [:fn '(constantly true)]
+                         [:map
+                          [:d string?]]]]]]
+                  [:fn '(constantly true)]])))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -167,15 +167,17 @@
          (mu/get [:vector int?] 1))))
 
 (deftest get-in-test
-  (is (mu/equals (mu/get-in
+  (is (mu/equals boolean?
+                 (mu/get-in
                    [:map
                     [:x [:vector
                          [:list
                           [:set
                            [:sequential
                             [:tuple int? [:map [:y [:maybe boolean?]]]]]]]]]]
-                   [:x 0 0 0 0 1 :y 0])
-                 boolean?)))
+                   [:x 0 0 0 0 1 :y 0])))
+  (is (mu/equals [:maybe [:tuple int? boolean?]]
+                 (mu/get-in [:maybe [:tuple int? boolean?]] []))))
 
 (deftest dissoc-test
   (let [schema [:map {:title "map"}

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -158,6 +158,12 @@
 
 (deftest get-test
   (is (form= (mu/get int? 0) nil))
+  (let [re #"kikka"]
+    (is (form= (mu/get [:re re] 0) re)))
+  (let [f int?]
+    (is (form= (mu/get [:fn f] 0) f)))
+  (is (form= (mu/get [:string {:min 1}] 0) nil))
+  (is (form= (mu/get [:enum "A" "B"] 0) "A"))
   (is (mu/equals (mu/get [:map [:x int?]] :x) int?))
   (is (mu/equals (mu/get [:map [:x {:optional true} int?]] :x) int?))
   (is (mu/equals (mu/get [:vector int?] 0) int?))
@@ -206,7 +212,16 @@
                     [:a int?]
                     [:c string?]]))))
 
+(let [re #"kikka"]
+  (mu/assoc [:re #"kukka"] 0 re))
+
 (deftest assoc-test
+  (let [re #"kikka"]
+    (is (mu/equals (mu/assoc [:re #"kukka"] 0 re) [:re re])))
+  (let [f 'int?]
+    (is (mu/equals (mu/assoc [:fn 'string?] 0 f) [:fn f])))
+  (is (mu/equals (mu/assoc [:enum "A" "B"] 1 "C") [:enum "A" "C"]))
+  (is (mu/equals (mu/assoc [:enum "A" "B"] 2 "C") [:enum "A" "B" "C"]))
   (is (mu/equals (mu/assoc [:vector int?] 0 string?) [:vector string?]))
   (is (mu/equals (mu/assoc [:tuple int? int?] 1 string?) [:tuple int? string?]))
   (is (mu/equals (mu/assoc [:tuple int? int?] 2 string?) [:tuple int? int? string?]))
@@ -222,15 +237,16 @@
     (are [schema i]
       (is (thrown? #?(:clj Exception, :cljs js/Error) (mu/assoc schema i string?)))
 
-      int? 1
+      int? 0
+      [:string {:min 1}] 0
       [:vector int?] 1
       [:tuple int? int?] 3
       [:or int? int?] 3
       [:and int? int?] 3
-      [:maybe int?] 2
+      [:maybe int?] 1
       [:map-of int? int?] 2
-      [:ref {:registry {::a int?}} ::a] 2
-      [:schema int?] 2))
+      [:ref {:registry {::a int?}} ::a] 1
+      [:schema int?] 1))
 
   (let [schema [:map {:title "map"}
                 [:a int?]

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -489,3 +489,33 @@
     (is (= subschema
            (mu/get-in schema path)
            (mu/get-in schema (mu/in->path schema in))))))
+
+(deftest to-from-maps-test
+  (let [schema [:map {:registry {::size [:enum "S" "M" "L"]}}
+                [:id string?]
+                [:tags [:set keyword?]]
+                [:size ::size]
+                [:address
+                 [:vector
+                  [:map
+                   [:street string?]
+                   [:lonlat [:tuple double? double?]]]]]]]
+
+    (testing "to-map-syntax"
+      (is (= {:type :map,
+              :properties {:registry {::size [:enum "S" "M" "L"]}}
+              :children [[:id nil {:type 'string?}]
+                         [:tags nil {:type :set
+                                     :children [{:type 'keyword?}]}]
+                         [:size nil {:type ::m/schema
+                                     :children [::size]}]
+                         [:address nil {:type :vector,
+                                        :children [{:type :map,
+                                                    :children [[:street nil {:type 'string?}]
+                                                               [:lonlat nil {:type :tuple
+                                                                             :children [{:type 'double?} {:type 'double?}]}]]}]}]]}
+             (mu/to-map-syntax schema))))
+
+    (testing "from-map-syntax"
+      (is (true? (mu/equals schema (-> schema (mu/to-map-syntax) (mu/from-map-syntax))))))))
+

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -13,7 +13,7 @@
 
 (deftest simplify-map-entry-test
   (are [entry expected]
-    (is (= expected (mu/simplify-map-entry entry)))
+    (is (= expected (mu/-simplify-map-entry entry)))
 
     [:x 'int?] [:x 'int?]
     [:x nil 'int?] [:x 'int?]

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -478,3 +478,14 @@
                          [:map
                           [:d string?]]]]]]
                   [:fn '(constantly true)]])))))))
+
+(deftest in-path-conversions
+  (let [subschema (m/schema [:maybe int?])
+        schema (m/schema [:maybe [:and [:map [:x [:maybe [:map [:y subschema]]]]]]])
+        path [:x :y]
+        in [0 0 :x 0 :y]]
+    (is (= in (mu/path->in schema path)))
+    (is (= path (mu/in->path schema in)))
+    (is (= subschema
+           (mu/get-in schema in)
+           (mu/get-in schema (mu/path->in schema path))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -224,9 +224,27 @@
   (is (mu/equals (mu/update [:vector int?] 0 (constantly string?)) [:vector string?]))
   (is (mu/equals (mu/update [:tuple int? int?] 1 (constantly string?)) [:tuple int? string?]))
   (is (mu/equals (mu/update [:tuple int? int?] 2 (constantly string?)) [:tuple int? int? string?]))
+  (is (mu/equals (mu/update [:or int? int?] 1 (constantly string?)) [:or int? string?]))
+  (is (mu/equals (mu/update [:or int? int?] 2 (constantly string?)) [:or int? int? string?]))
   (is (mu/equals (mu/update [:and int? int?] 1 (constantly string?)) [:and int? string?]))
+  (is (mu/equals (mu/update [:and int? int?] 2 (constantly string?)) [:and int? int? string?]))
   (is (mu/equals (mu/update [:maybe int?] 0 (constantly string?)) [:maybe string?]))
   (is (mu/equals (mu/update [:map [:x int?] [:y int?]] :x (constantly nil)) [:map [:y int?]]))
+  (is (mu/equals (mu/update [:ref {:registry {::a int?, ::b string?}} ::a] 0 (constantly ::b)) [:ref {:registry {::a int?, ::b string?}} ::b]))
+  (is (mu/equals (mu/update [:schema int?] 0 (constantly string?)) [:schema string?]))
+
+  (testing "index-out-of-bounds"
+    (are [schema i]
+      (is (thrown? #?(:clj Exception, :cljs js/Error) (mu/update schema i (constantly string?))))
+
+      [:vector int?] 1
+      [:tuple int? int?] 3
+      [:or int? int?] 3
+      [:and int? int?] 3
+      [:maybe int?] 2
+      [:ref {:registry {::a int?}} ::a] 2
+      [:schema int?] 2))
+
   (let [schema [:map {:title "map"}
                 [:a int?]
                 [:b {:optional true} int?]
@@ -256,23 +274,33 @@
   (is (mu/equals (mu/assoc-in [:vector int?] [0] string?) [:vector string?]))
   (is (mu/equals (mu/assoc-in [:tuple int? int?] [1] string?) [:tuple int? string?]))
   (is (mu/equals (mu/assoc-in [:tuple int? int?] [2] string?) [:tuple int? int? string?]))
+  (is (mu/equals (mu/assoc-in [:or int? int?] [1] string?) [:or int? string?]))
+  (is (mu/equals (mu/assoc-in [:or int? int?] [2] string?) [:or int? int? string?]))
   (is (mu/equals (mu/assoc-in [:and int? int?] [1] string?) [:and int? string?]))
+  (is (mu/equals (mu/assoc-in [:and int? int?] [2] string?) [:and int? int? string?]))
   (is (mu/equals (mu/assoc-in [:maybe int?] [0] string?) [:maybe string?]))
   (is (mu/equals (mu/assoc-in nil [:a [:b {:optional true}] :c :d] int?)
                  [:map [:a [:map [:b {:optional true} [:map [:c [:map [:d int?]]]]]]]]))
   (is (mu/equals (mu/assoc-in [:map] [:a :b :c :d] int?)
-                 [:map [:a [:map [:b [:map [:c [:map [:d int?]]]]]]]])))
+                 [:map [:a [:map [:b [:map [:c [:map [:d int?]]]]]]]]))
+  (is (mu/equals (mu/assoc-in [:ref {:registry {::a int?, ::b string?}} ::a] [0] ::b) [:ref {:registry {::a int?, ::b string?}} ::b]))
+  (is (mu/equals (mu/assoc-in [:schema int?] [0] string?) [:schema string?])))
 
 (deftest update-in-test
   (is (mu/equals (mu/update-in [:vector int?] [0] (constantly string?)) [:vector string?]))
   (is (mu/equals (mu/update-in [:tuple int? int?] [1] (constantly string?)) [:tuple int? string?]))
   (is (mu/equals (mu/update-in [:tuple int? int?] [2] (constantly string?)) [:tuple int? int? string?]))
+  (is (mu/equals (mu/update-in [:or int? int?] [1] (constantly string?)) [:or int? string?]))
+  (is (mu/equals (mu/update-in [:or int? int?] [2] (constantly string?)) [:or int? int? string?]))
   (is (mu/equals (mu/update-in [:and int? int?] [1] (constantly string?)) [:and int? string?]))
+  (is (mu/equals (mu/update-in [:and int? int?] [2] (constantly string?)) [:and int? int? string?]))
   (is (mu/equals (mu/update-in [:maybe int?] [0] (constantly string?)) [:maybe string?]))
   (is (mu/equals (mu/update-in nil [:a [:b {:optional true}] :c :d] (constantly int?))
                  [:map [:a [:map [:b {:optional true} [:map [:c [:map [:d int?]]]]]]]]))
   (is (mu/equals (mu/update-in [:map] [:a :b :c :d] (constantly int?))
-                 [:map [:a [:map [:b [:map [:c [:map [:d int?]]]]]]]])))
+                 [:map [:a [:map [:b [:map [:c [:map [:d int?]]]]]]]]))
+  (is (mu/equals (mu/update-in [:ref {:registry {::a int?, ::b string?}} ::a] [0] (constantly ::b)) [:ref {:registry {::a int?, ::b string?}} ::b]))
+  (is (mu/equals (mu/update-in [:schema int?] [0] (constantly string?)) [:schema string?])))
 
 (deftest optional-keys-test
   (let [schema [:map [:x int?] [:y int?]]]

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -482,10 +482,10 @@
 (deftest in-path-conversions
   (let [subschema (m/schema [:maybe int?])
         schema (m/schema [:maybe [:and [:map [:x [:maybe [:map [:y subschema]]]]]]])
-        path [:x :y]
-        in [0 0 :x 0 :y]]
-    (is (= in (mu/path->in schema path)))
+        path [0 0 :x 0 :y]
+        in [:x :y]]
     (is (= path (mu/in->path schema in)))
+    (is (= in (mu/path->in schema path)))
     (is (= subschema
-           (mu/get-in schema in)
-           (mu/get-in schema (mu/path->in schema path))))))
+           (mu/get-in schema path)
+           (mu/get-in schema (mu/in->path schema in))))))


### PR DESCRIPTION
**BREAKING** Changes to get symmetric path access, fixes #220.

  * `:path` in explain is re-implemented: map keys by value, others by child index
  * `m/-walk` and `m/Walker` uses `:path`, not `:in`
  * `m/-outer` has new parameter order: `walker schema path children options`
  * `malli.util/path-schemas` replaced with `malli.util/subschemas` & `malli.util/distict-by`
  * `LensSchema` has a new `-key` method
  * renamed some non-user apis in `malli.core` & `malli.util`
  * moved map-syntax helpers from `malli.core` to `malli.util`
  * dynaload `com.gfredericks/test.chuck`


```clj
(def Schema
  [:maybe
   [:multi {:dispatch :type}
    [:sized [:map
             [:type [:= :sized]]
             [:size [:maybe int?]]]]
    [:human [:map
             [:type [:= :human]]
             [:name string?]
             [:age int?]
             [:address [:maybe [:map [:country keyword?]]]]]]]])

(m/explain
  Schema
  {:type :human
   :name "inkeri"
   :age "100"
   :address {:country "sweden"}})
;{:schema [:maybe
;          [:multi
;           {:dispatch :type}
;           [:sized [:map [:type [:= :sized]] [:size [:maybe int?]]]]
;           [:human
;            [:map [:type [:= :human]] [:name string?] [:age int?] [:address [:maybe [:map [:country keyword?]]]]]]]],
; :value {:type :human, :name "inkeri", :age "100", :address {:country "sweden"}},
; :errors (#Error{:path [0 :human :age], :in [:age], :schema int?, :value "100"}
;           #Error{:path [0 :human :address 0 :country], :in [:address :country], :schema keyword?, :value "sweden"})}
```

To find all subschemas:

```clj
(mu/subschemas Schema)
;[{:path [],
;  :in [],
;  :schema [:maybe
;           [:multi
;            {:dispatch :type}
;            [:sized [:map [:type [:= :sized]] [:size [:maybe int?]]]]
;            [:human
;             [:map [:type [:= :human]] [:name string?] [:age int?] [:address [:maybe [:map [:country keyword?]]]]]]]]}
; {:path [0],
;  :in [],
;  :schema [:multi
;           {:dispatch :type}
;           [:sized [:map [:type [:= :sized]] [:size [:maybe int?]]]]
;           [:human
;            [:map [:type [:= :human]] [:name string?] [:age int?] [:address [:maybe [:map [:country keyword?]]]]]]]}
; {:path [0 :sized], :in [:sized], :schema [:map [:type [:= :sized]] [:size [:maybe int?]]]}
; {:path [0 :sized :type], :in [:sized :type], :schema [:= :sized]}
; {:path [0 :sized :size], :in [:sized :size], :schema [:maybe int?]}
; {:path [0 :sized :size 0], :in [:sized :size], :schema int?}
; {:path [0 :human],
;  :in [:human],
;  :schema [:map [:type [:= :human]] [:name string?] [:age int?] [:address [:maybe [:map [:country keyword?]]]]]}
; {:path [0 :human :type], :in [:human :type], :schema [:= :human]}
; {:path [0 :human :name], :in [:human :name], :schema string?}
; {:path [0 :human :age], :in [:human :age], :schema int?}
; {:path [0 :human :address], :in [:human :address], :schema [:maybe [:map [:country keyword?]]]}
; {:path [0 :human :address 0], :in [:human :address], :schema [:map [:country keyword?]]}
; {:path [0 :human :address 0 :country], :in [:human :address :country], :schema keyword?}]
```

distinct value paths:

```clj
(->> Schema (mu/subschemas) (mu/distinct-by :in) (map :in))
;([]
; [:sized]
; [:sized :type]
; [:sized :size]
; [:human]
; [:human :type]
; [:human :name]
; [:human :age]
; [:human :address]
; [:human :address :country])
```

```diff
 src/malli/core.cljc        | 476 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--------------------------------------------------------------
 src/malli/dot.cljc         |  10 +--
 src/malli/error.cljc       |  12 ++--
 src/malli/generator.cljc   |  16 +++--
 src/malli/json_schema.cljc |   2 +-
 src/malli/provider.cljc    |   2 +-
 src/malli/swagger.cljc     |   2 +-
 src/malli/transform.cljc   |  14 ++--
 src/malli/util.cljc        | 149 +++++++++++++++++++++++++++---------------
 9 files changed, 380 insertions(+), 303 deletions(-)
```