### PR TITLE
fix a warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out
 .nrepl-port
 .dir-locals.el
 cljs-test-runner-out
+*.jar

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -854,7 +854,6 @@
                                    (into-schema :ref properties [value])
                                    (-fail! ::index-out-of-bounds {:schema this, :key key})))
           RefSchema
-          (-keep [_])
           (-ref [_] ref)
           (-deref [_] (-ref)))))))
 


### PR DESCRIPTION
When using latest master, shadow-cljs reports:

```
Resource: malli/core.cljc:819:9
Bad method signature in protocol implementation, RefSchema does
not declare method called -keep
```