### PR TITLE
feat: add `pos?` and `neg?` to `predicate-schemas`

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1118,7 +1118,7 @@
 ;;
 
 (defn predicate-schemas []
-  (->> [#'any? #'some? #'number? #'integer? #'int? #'pos-int? #'neg-int? #'nat-int? #'float? #'double?
+  (->> [#'any? #'some? #'number? #'integer? #'int? #'pos-int? #'neg-int? #'nat-int? #'pos? #'neg? #'float? #'double?
         #'boolean? #'string? #'ident? #'simple-ident? #'qualified-ident? #'keyword? #'simple-keyword?
         #'qualified-keyword? #'symbol? #'simple-symbol? #'qualified-symbol? #'uuid? #'uri? #?(:clj #'decimal?)
         #'inst? #'seqable? #'indexed? #'map? #'vector? #'list? #'seq? #'char? #'set? #'nil? #'false? #'true?

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -112,6 +112,8 @@
 (defmethod -schema-generator :<= [schema options] (-double-gen {:max (-> schema (m/children options) first)}))
 (defmethod -schema-generator := [schema options] (gen/return (first (m/children schema options))))
 (defmethod -schema-generator :not= [schema options] (gen/such-that (partial not= (-> schema (m/children options) first)) gen/any-printable 100))
+(defmethod -schema-generator 'pos? [_ _] (gen/one-of [(-double-gen {:min 0.00001}) gen/s-pos-int]))
+(defmethod -schema-generator 'neg? [_ _] (gen/one-of [(-double-gen {:max -0.0001}) gen/s-neg-int]))
 
 (defmethod -schema-generator :and [schema options] (gen/such-that (m/validator schema options) (-> schema (m/children options) first (generator options)) 100))
 (defmethod -schema-generator :or [schema options] (-or-gen schema options))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -27,6 +27,8 @@
 (defmethod accept 'nat-int? [_ _ _ _] {:type "integer", :format "int64" :minimum 0})
 (defmethod accept 'float? [_ _ _ _] {:type "number"})
 (defmethod accept 'double? [_ _ _ _] {:type "number"})
+(defmethod accept 'pos? [_ _ _ _] {:type "number" :exclusiveMininum 0})
+(defmethod accept 'neg? [_ _ _ _] {:type "number" :exclusiveMaximum 0})
 (defmethod accept 'boolean? [_ _ _ _] {:type "boolean"})
 (defmethod accept 'string? [_ _ _ _] {:type "string"})
 (defmethod accept 'ident? [_ _ _ _] {:type "string"})


### PR DESCRIPTION
Adds the core `pos?` and `neg?` functions to the predicate schemas. This
is useful for when you don't care about the type of numeric, (ie. int vs
double vs float) and only the sign of it.

Also useful for constructing `[:and pos? float?]` if you want positive floats.