### PR TITLE
Add support for lazy refs

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -819,6 +819,7 @@
    (reify IntoSchema
      (-into-schema [_ properties children options]
        (let [type (or (:type opts) :multi)
+             opts (merge opts (select-keys properties [:lazy-refs]))
              {:keys [children entries forms]} (-parse-entries children opts options)
              form (-create-form type properties forms)
              dispatch (eval (:dispatch properties))

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -14,6 +14,7 @@
    ::m/missing-key {:error/message {:en "missing required key"}}
    ::m/invalid-type {:error/message {:en "invalid type"}}
    ::m/extra-key {:error/message {:en "disallowed key"}}
+   :malli.core/invalid-dispatch-value {:error/message {:en "invalid dispatch value"}}
    ::misspelled-key {:error/fn {:en (fn [{::keys [likely-misspelling-of]} _]
                                       (str "should be spelled " (str/join " or " (map last likely-misspelling-of))))}}
    ::misspelled-value {:error/fn {:en (fn [{::keys [likely-misspelling-of]} _]

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -219,7 +219,6 @@
                                       (let [value (dispatch value)]
                                         [::misspelled-value value #{value}]))))
            types {::m/extra-key (fn [_ path value] [::misspelled-key (last path) (-> value keys set (or #{}))])
-                  ::m/invalid-value handle-invalid-value
                   ::m/invalid-dispatch-value handle-invalid-value}]
        (update
          explanation

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -153,10 +153,7 @@
 
 (defn- -likely-misspelled [keys known-keys key]
   (when-not (known-keys key)
-    (->> known-keys
-         (filter #(-similar-key % key))
-         (remove keys)
-         not-empty)))
+    (->> known-keys (filter #(-similar-key % key)) (remove keys) (not-empty))))
 
 (defn- -most-similar-to [keys key known-keys]
   (->> (-likely-misspelled keys known-keys key)
@@ -164,7 +161,7 @@
        (filter first)
        (sort-by first)
        (map second)
-       not-empty))
+       (not-empty)))
 
 ;;
 ;; public api

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -151,8 +151,6 @@
         dist (-levenshtein (str ky) (str ky2))]
     (when (<= dist (-length->threshold min-len)) dist)))
 
-;; a tricky part is is that a keyword is not considered misspelled
-;; if its substitute is already present in the original map
 (defn- -likely-misspelled [keys known-keys key]
   (when-not (known-keys key)
     (->> known-keys

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -16,6 +16,8 @@
    ::m/extra-key {:error/message {:en "disallowed key"}}
    ::misspelled-key {:error/fn {:en (fn [{::keys [likely-misspelling-of]} _]
                                       (str "should be spelled " (str/join " or " (map last likely-misspelling-of))))}}
+   ::misspelled-value {:error/fn {:en (fn [{::keys [likely-misspelling-of]} _]
+                                        (str "did you mean " (str/join " or " (map last likely-misspelling-of))))}}
    'any? {:error/message {:en "should be any"}}
    'some? {:error/message {:en "shoud be some"}}
    'number? {:error/message {:en "should be a number"}}
@@ -151,16 +153,16 @@
 
 ;; a tricky part is is that a keyword is not considered misspelled
 ;; if its substitute is already present in the original map
-(defn- -likely-misspelled [value known-keys]
+(defn- -likely-misspelled [keys known-keys]
   (fn [key]
     (when-not (known-keys key)
       (->> known-keys
            (filter #(-similar-key % key))
-           (remove (set (keys value)))
+           (remove keys)
            not-empty))))
 
-(defn- -most-similar-to [value key known-keys]
-  (->> ((-likely-misspelled value known-keys) key)
+(defn- -most-similar-to [keys key known-keys]
+  (->> ((-likely-misspelled keys known-keys) key)
        (map (juxt #(-levenshtein (str %) (str key)) identity))
        (filter first)
        (sort-by first)
@@ -215,20 +217,27 @@
    (with-spell-checking explanation nil))
   ([explanation {:keys [keep-likely-misspelled-of]}]
    (when explanation
-     (let [!likely-misspelling-of (atom #{})]
+     (let [!likely-misspelling-of (atom #{})
+           types {::m/extra-key (fn [_ path value] [::misspelled-key (last path) (-> value keys set (or #{}))])
+                  ::m/invalid-dispatch-value (fn [schema _ value]
+                                               (let [dispatch (:dispatch (m/properties schema))]
+                                                 (if (keyword? dispatch)
+                                                   (let [value (dispatch value)]
+                                                     [::misspelled-value value #{value}]))))}]
        (update
          explanation
          :errors
          (fn [errors]
            (as-> errors $
                  (mapv (fn [{:keys [schema path type] :as error}]
-                         (if (= type ::m/extra-key)
-                           (let [keys (->> schema (m/entries) (map first) (set))
+                         (if-let [get-keys (types type)]
+                           (let [known-keys (->> schema (m/entries) (map first) (set))
                                  value (get-in (:value explanation) (butlast path))
-                                 similar (-most-similar-to value (last path) keys)
+                                 [error-type key keys] (get-keys schema path value)
+                                 similar (-most-similar-to keys key known-keys)
                                  likely-misspelling-of (mapv (partial conj (vec (butlast path))) (vec similar))]
                              (swap! !likely-misspelling-of into likely-misspelling-of)
-                             (cond-> error similar (assoc :type ::misspelled-key
+                             (cond-> error similar (assoc :type error-type
                                                           ::likely-misspelling-of likely-misspelling-of)))
                            error)) $)
                  (if-not keep-likely-misspelled-of

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -72,5 +72,12 @@
                   schema)))
           (-schemas [_] @cache*))))))
 
-(defn schema [registry type] (-schema registry type))
-(defn schemas [registry] (-schemas registry))
+(defn schema
+  "finds a schema from a registry"
+  [registry type]
+  (-schema registry type))
+
+(defn schemas
+  "finds all schemas from a registry"
+  [registry]
+  (-schemas registry))

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -11,7 +11,7 @@
 (defn simple-registry [schemas]
   (reify
     Registry
-    (-schema [_ name] (get schemas name))
+    (-schema [_ type] (get schemas type))
     (-schemas [_] schemas)))
 
 (defn registry [?registry]
@@ -55,3 +55,22 @@
     Registry
     (-schema [_ type] (get *registry* type))
     (-schemas [_] *registry*)))
+
+(defn lazy-registry [default-registry provider]
+  (let [cache* (atom {})
+        registry* (atom default-registry)]
+    (reset!
+      registry*
+      (composite-registry
+        default-registry
+        (reify
+          Registry
+          (-schema [_ name]
+            (or (@cache* name)
+                (when-let [schema (provider name @registry*)]
+                  (swap! cache* assoc name schema)
+                  schema)))
+          (-schemas [_] @cache*))))))
+
+(defn schema [registry type] (-schema registry type))
+(defn schemas [registry] (-schemas registry))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -39,24 +39,29 @@
   (let [{:keys [children entries forms]} (m/-parse-entries
                                            [[:x int?]
                                             ::x
+                                            "x"
                                             [::y {:optional true}]
                                             [:y {:optional true, :title "boolean"} boolean?]]
-                                           true {:registry (merge (m/default-schemas) {::x int?, ::y int?})})]
+                                           {:naked-keys true}
+                                           {:registry (merge (m/default-schemas) {::x int?, "x" int?, ::y int?})})]
     (testing "forms"
       (is (= [[:x 'int?]
               ::x
+              "x"
               [::y {:optional true}]
               [:y {:optional true, :title "boolean"} 'boolean?]]
              forms)))
     (testing "entries"
       (is (schema= [[:x [::m/val 'int?]]
                     [::x [::m/val ::x]]
+                    ["x" [::m/val "x"]]
                     [::y [::m/val {:optional true} ::y]]
                     [:y [::m/val {:optional true :title "boolean"} 'boolean?]]]
                    entries)))
     (testing "children"
       (is (= [[:x nil 'int?]
               [::x nil ::x]
+              ["x" nil "x"]
               [::y {:optional true} ::y]
               [:y {:optional true, :title "boolean"} 'boolean?]]
              (map #(update % 2 m/form) children)))))
@@ -64,11 +69,11 @@
     (is (thrown? #?(:clj Exception, :cljs js/Error)
                  (m/-parse-entries
                    [[:x int?]
-                    [:x boolean?]] true nil))))
+                    [:x boolean?]] {:naked-keys true} nil))))
   (testing "naked keys fails when not supported"
     (is (thrown? #?(:clj Exception, :cljs js/Error)
                  (m/-parse-entries
-                   [::x] false nil)))))
+                   [::x] nil nil)))))
 
 (deftest eval-test
   (is (= 2 ((m/eval inc) 1)))
@@ -311,15 +316,8 @@
             #?(:clj Exception, :cljs js/Error)
             (m/schema [:ref int?]))))
 
-    (testing "lazy refs allow invalid refs"
-      (let [schema (m/schema [:ref {:lazy true} "invalid"])]
-        (is schema)
-        (testing "fail when used"
-          (is (thrown? #?(:clj Exception, :cljs js/Error) (m/validate schema 1))))))
-
     (testing "recursion"
-      (let [ConsCell (m/schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
-                                ::cons])]
+      (let [ConsCell (m/schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}} ::cons])]
 
         (is (true? (m/validate ConsCell [1 nil])))
         (is (true? (m/validate ConsCell [1 [2 nil]])))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -311,6 +311,12 @@
             #?(:clj Exception, :cljs js/Error)
             (m/schema [:ref int?]))))
 
+    (testing "lazy refs allow invalid refs"
+      (let [schema (m/schema [:ref {:lazy true} "invalid"])]
+        (is schema)
+        (testing "fail when used"
+          (is (thrown? #?(:clj Exception, :cljs js/Error) (m/validate schema 1))))))
+
     (testing "recursion"
       (let [ConsCell (m/schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
                                 ::cons])]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -673,8 +673,8 @@
 
       (is (results= {:schema schema,
                      :value {:type :worm}
-                     :errors [{:path []
-                               :in []
+                     :errors [{:path [:type]
+                               :in [:type]
                                :schema schema
                                :value {:type :worm}
                                :type :malli.core/invalid-dispatch-value}]}

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -351,3 +351,19 @@
            (-> [:enum "foo" "bar" "buzz" "biff"]
                (m/explain "baz")
                (me/humanize))))))
+
+(deftest multi-error-test
+  (let [schema [:multi {:dispatch :type}
+                ["plus" [:map [:value int?]]]
+                ["minus" [:map [:value int?]]]]]
+
+    (is (= {:type ["invalid dispatch value"]}
+           (-> schema
+               (m/explain {:type "minuz"})
+               (me/humanize))))
+
+    (is (= {:type ["did you mean minus"]}
+           (-> schema
+               (m/explain {:type "minuz"})
+               (me/with-spell-checking)
+               (me/humanize))))))


### PR DESCRIPTION
Allows creating `:ref`s that are not checked at creation time. This allows schemas to pulled lazily from external sources.

```clj
(require '[malli.core :as m])
(require '[malli.registry :as mr])

(defn LazyRegistry [default-registry f]
  (let [cache* (atom {})
        registry* (atom nil)]
    (reset!
      registry*
      (mr/composite-registry
        default-registry
        (reify
          mr/Registry
          (-schema [_ name]
            (or (@cache* name)
                (do (println "loading" (pr-str name))
                    (when-let [schema (f name)]
                      (swap! cache* assoc name (m/schema schema {:registry @registry*}))
                      schema))))
          (-schemas [_] @cache*))))))

(def registry
  (LazyRegistry
    m/default-registry
    ;; map simulates a fetch by name from a remote source
    {"map1" [:map [:type [:= "map1"]] [:x :int]]
     "map2" [:map [:type [:= "map2"]] [:y :int]]
     "map3" [:map [:type [:= "map3"]] [:z :int]]}))

(def schema
  (m/schema
    [:multi {:dispatch :type}
     ["map1" [:ref {:lazy true} "map1"]]
     ["map2" [:ref {:lazy true} "map2"]]
     ["map3" [:ref {:lazy true} "map3"]]]))

(m/validate
  schema
  {:type "map3", :z 1}
  {:registry registry})
;loading "map3"
;=> true

;; reuse cached
(m/validate
  schema
  {:type "map3", :z 1}
  {:registry registry})
;=> true
```