### PR TITLE
welcome type-properties

### DIFF
--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -186,10 +186,12 @@
           default-locale :en} :as options}]
    (or (-message error (-error schema) locale options)
        (-message error (m/properties schema) locale options)
+       (-message error (m/type-properties schema) locale options)
        (-message error (errors (m/type schema)) locale options)
        (-message error (errors type) locale options)
        (-message error (-error schema) default-locale options)
        (-message error (m/properties schema) default-locale options)
+       (-message error (m/type-properties schema) default-locale options)
        (-message error (errors (m/type schema)) default-locale options)
        (-message error (errors type) default-locale options)
        (-message error (errors ::unknown) locale options)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -149,7 +149,7 @@
 (defmethod -schema-generator ::m/schema [schema options] (generator (m/-deref schema) options))
 
 (defn- -create [schema options]
-  (let [{:gen/keys [gen fmap elements]} (m/properties schema options)
+  (let [{:gen/keys [gen fmap elements]} (merge (m/type-properties schema) (m/properties schema))
         gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema options) (-schema-generator schema options))))
         elements (when elements (gen/elements elements))]
     (cond

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -110,7 +110,7 @@
 (defmethod accept :uuid [_ _ _ _] {:type "string" :format "uuid"})
 
 (defn- -json-schema-walker [schema _ children options]
-  (let [p (m/properties schema)]
+  (let [p (merge (m/type-properties schema) (m/properties schema))]
     (or (unlift p :json-schema)
         (merge (select p)
                (if (satisfies? JsonSchema schema)

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -23,7 +23,7 @@
 (defmethod accept :tuple [_ _ children _] {:type "array" :items {} :x-items children})
 
 (defn- -swagger-walker [schema _ children options]
-  (let [p (m/properties schema)]
+  (let [p (merge (m/type-properties schema) (m/properties schema))]
     (or (json-schema/unlift p :swagger)
         (json-schema/unlift p :json-schema)
         (merge (json-schema/select p)

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -1,5 +1,6 @@
 (ns malli.error-test
   (:require [clojure.test :refer [deftest testing is are]]
+            [malli.core-test]
             [malli.error :as me]
             [malli.core :as m]
             [malli.util :as mu]))
@@ -32,7 +33,9 @@
              [[int?
                {:error/message msg, :error/fn fn2}]
               "kikka" "should be an int, was kikka"
-              {:errors {'int? {:error/message "fail1", :error/fn (constantly "fail2")}}}]]]
+              {:errors {'int? {:error/message "fail1", :error/fn (constantly "fail2")}}}]
+             ;; type-properties
+             [malli.core-test/Over6 5 "should be over 6"]]]
       (is (= message (-> (m/explain schema value) :errors first (me/error-message opts)))))))
 
 (deftest with-spell-checking-test

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -144,7 +144,7 @@
   (let [values #{1 2 3 5 8 13}
         schema (reify
                  m/Schema
-                 (-validator [_] int?)
+                 (-type-properties [_])
                  (-properties [_])
                  mg/Generator
                  (-generator [_ _] (gen/elements values)))]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -1,5 +1,6 @@
 (ns malli.json-schema-test
   (:require [clojure.test :refer [deftest testing is are]]
+            [malli.core-test]
             [malli.json-schema :as json-schema]
             [malli.core :as m]))
 
@@ -68,10 +69,14 @@
       (-properties [_])
       (-type [_])
       (-form [_])
+      (-type-properties [_])
       (-validator [_] int?)
       (-walk [t w p o] (m/-outer w t p nil o))
       json-schema/JsonSchema
-      (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
+      (-accept [_ _ _] {:type "custom"})) {:type "custom"}]
+   ;; type-properties
+   [malli.core-test/Over6 {:type "integer", :format "int64", :minimum 6}]
+   [[malli.core-test/Over6 {:json-schema/example 42}] {:type "integer", :format "int64", :minimum 6, :example 42}]])
 
 (deftest json-schema-test
   (doseq [[schema json-schema] expectations]

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -69,10 +69,14 @@
    ;; protocols
    [(reify
       m/Schema
+      (-type-properties [_])
       (-properties [_])
       (-walk [t w p o] (m/-outer w t p nil o))
       swagger/SwaggerSchema
-      (-accept [_ _ _] {:type "custom"})) {:type "custom"}]])
+      (-accept [_ _ _] {:type "custom"})) {:type "custom"}]
+   ;; type-properties
+   [malli.core-test/Over6 {:type "integer", :format "int64", :minimum 6}]
+   [[malli.core-test/Over6 {:json-schema/example 42}] {:type "integer", :format "int64", :minimum 6, :example 42}]])
 
 (deftest swagger-test
   (doseq [[schema swagger-schema] expectations]


### PR DESCRIPTION
* `m/-type-properties` for Schemas, `m/type-properties` for users
* fixes #254 

## Custom Schema Types

Schema Types are described using `m/IntoSchema` protocol, which has a factory method
`(-into-schema [this properties children options])` to create the actual Schema instances. 
See `malli.core` for example implementations.

For simple cases, there is `m/-simple-schema`:

```clj
(require '[clojure.test.check.generators :as gen])

(def Over6
  (m/-simple-schema
    {:type :user/over6
     :pred #(and (int? %) (> % 6))
     :type-properties {:error/message "should be over 6"
                       :json-schema/type "integer"
                       :json-schema/format "int64"
                       :json-schema/minimum 6
                       :gen/gen (gen/large-integer* {:min 7})}}))

(m/into-schema? Over6)
; => true
```

`m/IntoSchema` can be both used as Schema (creating a Schema instance with `nil` properties
and children) and as Schema type to create new Schema instances without needing to
register the types:

```clj
(m/form (m/schema Over6))
; => true

(m/schema? (m/schema [Over6 {:title "over 6"}]))
; => true
```

`:pred` is used for validation:

```clj
(m/validate Over6 2)
; => false

(m/validate Over6 7)
; => true
```

`:type-properties` are shared for all schema instances and are used just like Schema
(instance) properties by many Schema applications, including [error messages](#custom-error-messages),
[value generation](#value-generation) and [json-schema](#json-schema) transformations.

```clj
(json-schema/transform Over6)
; => {:type "integer", :format "int64", :minimum 6}

(json-schema/transform [Over6 {:json-schema/example 42}])
; => {:type "integer", :format "int64", :minimum 6, :example 42}
```