### PR TITLE
Qualify library names to avoid warnings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -9,7 +9,7 @@
                                borkdude/sci {:git/url "https://github.com/borkdude/sci.git"
                                              :sha "b310358cd41f761d7bbd50227a36d1160938ce71"}
                                prismatic/schema {:mvn/version "1.1.12"}
-                               meta-merge {:mvn/version "1.0.0"}
+                               meta-merge/meta-merge {:mvn/version "1.0.0"}
                                org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
                                                         :sha "8498f9cb352135579b6d3a0a5d15c40e5c2647ce"}}}
            :cljs-test-runner {:extra-deps {olical/cljs-test-runner {:mvn/version "3.7.0"}}
@@ -28,14 +28,14 @@
                                :sha "5c5dae9ae4b75941485a17872aa59e040a500aa4"}}
                  :main-opts ["-m" "mach.pack.alpha.skinny" "--no-libs"
                              "--project-path" "malli.jar"]}
-           :deploy {:extra-deps {deps-deploy {:mvn/version "RELEASE"}}
+           :deploy {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
                     :main-opts ["-m" "deps-deploy.deps-deploy" "deploy"
                                 "malli.jar"]}
-           :install {:extra-deps {deps-deploy {:mvn/version "RELEASE"}}
+           :install {:extra-deps {deps-deploy/deps-deploy {:mvn/version "RELEASE"}}
                      :main-opts ["-m" "deps-deploy.deps-deploy" "install"
                                  "malli.jar"]}
            :perf {:extra-paths ["perf"]
-                  :extra-deps {criterium {:mvn/version "0.4.5"}
+                  :extra-deps {criterium/criterium {:mvn/version "0.4.5"}
                                com.clojure-goes-fast/clj-async-profiler {:mvn/version "0.4.1"}}
                   :jvm-opts ["-server"
                              "-Xmx4096m"


### PR DESCRIPTION
Recent versions of Clojure tooling warn against the use of unqualified library names. This updates `deps.edn` to add a prefix to the library dependencies:
* `deps-deploy`
* `meta-merge`
* `criterium`

based on the following warning output:
```
DEPRECATED: Libs must be qualified, change deps-deploy => deps-deploy/deps-deploy (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
DEPRECATED: Libs must be qualified, change criterium => criterium/criterium (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
DEPRECATED: Libs must be qualified, change deps-deploy => deps-deploy/deps-deploy (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
DEPRECATED: Libs must be qualified, change meta-merge => meta-merge/meta-merge (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
DEPRECATED: Libs must be qualified, change deps-deploy => deps-deploy/deps-deploy (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
DEPRECATED: Libs must be qualified, change criterium => criterium/criterium (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
DEPRECATED: Libs must be qualified, change deps-deploy => deps-deploy/deps-deploy (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
DEPRECATED: Libs must be qualified, change meta-merge => meta-merge/meta-merge (/home/robert/.gitlibs/libs/metosin/malli/fbdb282c410d5c3d7c2d079bd9ee31e1e7956f34/deps.edn)
```