### PR TITLE
load lazily with dynaload, fix regression

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -209,7 +209,7 @@
   (reify IntoSchema
     (-into-schema [_ properties children options]
       (let [{:keys [type pred property-pred type-properties min max]
-             :or {min 0, max 0}}  (if (fn? ?props) (?props properties children) ?props)]
+             :or {min 0, max 0}} (if (fn? ?props) (?props properties children) ?props)]
         (-check-children! type properties children {:min min, :max max})
         (let [pvalidator (if property-pred (property-pred properties))
               validator (if pvalidator (fn [x] (and (pred x) (pvalidator x))) pred)
@@ -1165,16 +1165,16 @@
 ;; eval
 ;;
 
-(let [-eval (or (ms/evaluator {:preset :termination-safe
-                               :bindings {'m/properties properties
-                                          'm/type type
-                                          'm/children children
-                                          'm/entries entries}})
-                #(-fail! :sci-not-available {:code %}))
+(let [-evaluator (memoize (ms/evaluator {:preset :termination-safe
+                                         :bindings {'m/properties properties
+                                                    'm/type type
+                                                    'm/children children
+                                                    'm/entries entries}}
+                                        #(-fail! :sci-not-available {:code %})))
       -eval? (some-fn symbol? string? sequential?)]
   (defn eval [?code]
     (cond (vector? ?code) ?code
-          (-eval? ?code) (-eval ?code)
+          (-eval? ?code) ((-evaluator) ?code)
           :else ?code)))
 
 ;;

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -94,7 +94,7 @@
 #?(:clj
    (defn -re-gen [schema options]
      ;; [com.gfredericks/test.chuck "0.2.10"+]
-     (if-let [string-from-regex (dynaload/dynaload 'com.gfredericks.test.chuck.generators/string-from-regex {:default nil})]
+     (if-let [string-from-regex @(dynaload/dynaload 'com.gfredericks.test.chuck.generators/string-from-regex {:default nil})]
        (let [re (or (first (m/children schema options)) (m/form schema options))]
          (string-from-regex (re-pattern (str/replace (str re) #"^\^?(.*?)(\$?)$" "$1"))))
        (m/-fail! :test-chuck-not-available))))

--- a/src/malli/sci.cljc
+++ b/src/malli/sci.cljc
@@ -1,10 +1,11 @@
 (ns malli.sci
   (:require [borkdude.dynaload :as dynaload]))
 
-(defn evaluator [options]
+(defn evaluator [options fail!]
   (let [eval-string* (dynaload/dynaload 'sci.core/eval-string* {:default nil})
         init (dynaload/dynaload 'sci.core/init {:default nil})
         fork (dynaload/dynaload 'sci.core/fork {:default nil})]
-    (if (and eval-string* init fork)
-      (let [ctx (init options)]
-        (fn eval [s] (eval-string* (fork ctx) (str s)))))))
+    (fn [] (if (and @eval-string* @init @fork)
+             (let [ctx (init options)]
+               (fn eval [s] (eval-string* (fork ctx) (str s))))
+             fail!))))


### PR DESCRIPTION
also, sci is loaded only on first eval, making initial load fast if sci is not used.

```clj
(time (require '[malli.core :as m]))
"Elapsed time: 466.76624 msecs"
=> nil
(time (m/eval "(+ 1 1)"))
"Elapsed time: 1591.515317 msecs"
=> 2
(time (m/eval "(+ 1 1)"))
"Elapsed time: 0.587728 msecs"
=> 2
(time (m/eval "(+ 1 1)"))
"Elapsed time: 0.772357 msecs"
=> 2
```