### PR TITLE
mt/key-transformer can define targets

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -374,11 +374,12 @@
        {:decoders {:map transform}
         :encoders {:map transform}}))))
 
-(defn key-transformer [{:keys [decode encode]}]
+(defn key-transformer [{:keys [decode encode types] :or {types #{:map}}}]
   (let [transform (fn [f stage] (if f {stage (-transform-map-keys f)}))]
-    (transformer
-      {:decoders {:map (transform decode :enter)}
-       :encoders {:map (transform encode :leave)}})))
+    (transformer (cond (set? types) {:decoders (zipmap types (repeat (transform decode :enter)))
+                                     :encoders (zipmap types (repeat (transform encode :leave)))}
+                       (= :default types) {:default-decoder (transform decode :enter)
+                                           :default-encoder (transform encode :leave)}))))
 
 (defn default-value-transformer []
   (let [get-default (fn [schema] (some-> schema m/properties :default))


### PR DESCRIPTION
Fixes #246 by adding `:types` key to `mt/key-transformer`. Not enabled by default.

variations:

```clj
;; defaults, effects just :map
(mt/key-transformer {:decode ->keyword})

;; same, but explicit options
(mt/key-transformer {:decode ->keyword, :types #{:map}})

;; effects :map & :multi
(mt/key-transformer {:decode ->keyword, :types #{:map :multi}})

;; effects all map VALUES
(mt/key-transformer {:decode ->keyword, :types :default})
```

in action:

```clj
(m/decode
  [:multi {:dispatch :type
           :malli/type :map
           :decode/string #(update % :type ->keyword)}
   [:sized [:map [:type [:= :sized]] [:size int?]]]
   [:human [:map [:type [:= :human]] [:name string?] [:address [:map [:country keyword?]]]]]]
  {"Type" "human"
   :Name "Tiina"
   :sizE "98"
   :Address {:country "finland"
             :street "this is an extra key"}}
  (mt/transformer
    (mt/key-transformer {:decode ->keyword, :types :default})
    mt/string-transformer
    mt/strip-extra-keys-transformer))
;{:type :human
; :name "Tiina"
; :address {:country :finland}}
```