### PR TITLE
explicitly disabling sci & sci options, fixes #276

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* New options
+  * `:malli.core/disable-sci` for explicitly disabling `sci`, fixes [#276](https://github.com/metosin/malli/issues/276)
+  * `:malli.core/sci-options` for configuring `sci`
+
 ## 0.1.0 (2020-10-08)
 
 First stable release.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ it is not present, the malli function evaluater throws `:sci-not-available` exce
 
 For ClojureScript, you also need to require `sci.core` manually, either directly or via [`:preloads`](https://clojurescript.org/reference/compiler-options#preloads).
 
+For GraalVM, you need to require `sci.core` manually, before requiring any malli namespaces.
+
 ```clj
 (def my-schema
   [:and

--- a/README.md
+++ b/README.md
@@ -220,6 +220,15 @@ For GraalVM, you need to require `sci.core` manually, before requiring any malli
 ; => false
 ```
 
+**NOTE**: Malli uses `:termination-safe` option with sci, but [it might not be a good idea](https://github.com/borkdude/sci/issues/348)
+to read `sci` functions from untrusted sources. You can explictely disable with option `::m/disable-sci` and set the default options with `::m/sci-options`.
+
+```clj
+(m/validate [:fn 'int?] 1 {::m/disable-sci true})
+; Execution error
+; :malli.core/sci-not-available {:code int?}
+```
+
 ## Error Messages
 
 Detailed errors with `m/explain`:

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1191,7 +1191,7 @@
   (defn eval
     ([?code] (eval ?code nil))
     ([?code options] (cond (vector? ?code) ?code
-                           (-eval? ?code) (if (::enable-sci options true) ((-evaluator) ?code) (-fail! ?code))
+                           (-eval? ?code) (if (::disable-sci options true) (-fail! ?code) ((-evaluator) ?code))
                            :else ?code))))
 
 ;;

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1181,18 +1181,24 @@
 ;; eval
 ;;
 
+(defn -default-sci-options []
+  {:preset :termination-safe
+   :bindings {'m/properties properties
+              'm/type type
+              'm/children children
+              'm/entries entries}})
+
 (let [-fail! #(-fail! ::sci-not-available {:code %})
-      -evaluator (memoize (ms/evaluator {:preset :termination-safe
-                                         :bindings {'m/properties properties
-                                                    'm/type type
-                                                    'm/children children
-                                                    'm/entries entries}} -fail!))
-      -eval? #(or (symbol? %) (string? %) (sequential? %))]
+      -eval? #(or (symbol? %) (string? %) (sequential? %))
+      -evaluator (memoize ms/evaluator)]
   (defn eval
     ([?code] (eval ?code nil))
-    ([?code options] (cond (vector? ?code) ?code
-                           (-eval? ?code) (if (::disable-sci options true) (-fail! ?code) ((-evaluator) ?code))
-                           :else ?code))))
+    ([?code options]
+     (cond (vector? ?code) ?code
+           (-eval? ?code) (if (::disable-sci options)
+                            (-fail! ?code)
+                            (((-evaluator (or (::sci-options options) (-default-sci-options)) -fail!)) ?code))
+           :else ?code))))
 
 ;;
 ;; schema walker

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -86,8 +86,9 @@
   (if (map? x) (get x locale) x))
 
 (defn- -message [error x locale options]
-  (if x (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn) error options))
-            (-maybe-localized (:error/message x) locale))))
+  (let [options (or options (m/options (:schema error)))]
+    (if x (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn options) error options))
+              (-maybe-localized (:error/message x) locale)))))
 
 (defn- -ensure [x k]
   (if (sequential? x)
@@ -199,7 +200,7 @@
    (with-error-messages explanation nil))
   ([explanation {f :wrap :or {f identity} :as options}]
    (when explanation
-     (update explanation :errors (fn [errors] (map #(f (with-error-message % options)) errors))))))
+     (update explanation :errors (fn [errors] (doall (map #(f (with-error-message % options)) errors)))))))
 
 (defn with-spell-checking
   ([explanation]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -152,7 +152,7 @@
         gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema options) (-schema-generator schema options))))
         elements (when elements (gen/elements elements))]
     (cond
-      fmap (gen/fmap (m/eval fmap) (or elements gen (gen/return nil)))
+      fmap (gen/fmap (m/eval fmap (or options (m/options schema))) (or elements gen (gen/return nil)))
       elements elements
       gen gen
       :else (m/-fail! ::no-generator {:schema schema, :options options}))))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -306,7 +306,7 @@
   (let [->data (fn [ts default name key] {:transformers ts
                                           :default default
                                           :key (if name (keyword (str key "/" name)))})
-        ->eval (fn [x] (if (map? x) (reduce-kv (fn [x k v] (assoc x k (m/eval v))) x x) (m/eval x)))
+        ->eval (fn [x options] (if (map? x) (reduce-kv (fn [x k v] (assoc x k (m/eval v options))) x x) (m/eval x)))
         ->chain (m/-comp m/-transformer-chain m/-into-transformer)
         chain (->> ?transformers (keep identity) (mapcat #(if (map? %) [%] (->chain %))) (vec))
         chain' (->> chain (mapv #(let [name (some-> % :name name)]
@@ -319,13 +319,14 @@
         (-value-transformer [_ schema method options]
           (reduce
             (fn [acc {{:keys [key default transformers]} method}]
-              (if-let [?interceptor (or (some-> (get (m/properties schema) key) ->eval)
-                                        (some-> (get (m/type-properties schema) key) ->eval)
-                                        (get transformers (m/type schema))
-                                        default)]
-                (let [interceptor (-interceptor ?interceptor schema options)]
-                  (if (nil? acc) interceptor (-interceptor [acc interceptor] schema options)))
-                acc)) nil chain'))))))
+              (let [options (or options (m/options schema))]
+                (if-let [?interceptor (or (some-> (get (m/properties schema) key) (->eval options))
+                                          (some-> (get (m/type-properties schema) key) (->eval options))
+                                          (get transformers (m/type schema))
+                                          default)]
+                  (let [interceptor (-interceptor ?interceptor schema options)]
+                    (if (nil? acc) interceptor (-interceptor [acc interceptor] schema options)))
+                  acc))) nil chain'))))))
 
 (defn json-transformer
   ([]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -89,8 +89,13 @@
     (is (schema= [[:x [::m/val 'int?]] [:y [::m/val 'string?]]] (m/eval "(m/entries [:map [:x int?] [:y string?]])")))
     (is (schema= [[:x nil 'int?] [:y nil 'string?]] (m/eval "(m/children [:map [:x int?] [:y string?]])"))))
   (testing "with options"
-    (is (= 2 ((m/eval inc {::m/disable-sci true}) 1)))
-    (is (thrown? #?(:clj Exception, :cljs js/Error) ((m/eval 'inc {::m/disable-sci true}) 1)))))
+    (testing "disabling sci"
+      (is (= 2 ((m/eval inc {::m/disable-sci true}) 1)))
+      (is (thrown? #?(:clj Exception, :cljs js/Error) ((m/eval 'inc {::m/disable-sci true}) 1))))
+    (testing "custom bindings"
+      (let [f '(fn [schema] (m/form schema))]
+        (is (thrown? #?(:clj Exception, :cljs js/Error) ((m/eval f) :string)))
+        (is (= :string ((m/eval f {::m/sci-options {:bindings {'m/form m/form}}}) :string)))))))
 
 (deftest into-schema-test
   (is (form= [:map {:closed true} [:x int?]]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -89,8 +89,8 @@
     (is (schema= [[:x [::m/val 'int?]] [:y [::m/val 'string?]]] (m/eval "(m/entries [:map [:x int?] [:y string?]])")))
     (is (schema= [[:x nil 'int?] [:y nil 'string?]] (m/eval "(m/children [:map [:x int?] [:y string?]])"))))
   (testing "with options"
-    (is (= 2 ((m/eval inc {::m/enable-sci false}) 1)))
-    (is (thrown? #?(:clj Exception, :cljs js/Error) ((m/eval 'inc {::m/enable-sci false}) 1)))))
+    (is (= 2 ((m/eval inc {::m/disable-sci true}) 1)))
+    (is (thrown? #?(:clj Exception, :cljs js/Error) ((m/eval 'inc {::m/disable-sci true}) 1)))))
 
 (deftest into-schema-test
   (is (form= [:map {:closed true} [:x int?]]
@@ -139,7 +139,7 @@
       (testing "sci not available"
         (let [schema (m/schema
                        [string? {:decode/string '{:enter #(str "olipa_" %), :leave #(str % "_avaruus")}}]
-                       {::m/enable-sci false})]
+                       {::m/disable-sci true})]
 
           (is (thrown-with-msg?
                 #?(:clj Exception, :cljs js/Error)
@@ -151,10 +151,10 @@
                 #":malli.core/sci-not-available"
                 (m/decoder
                   [string? {:decode/string '{:enter #(str "olipa_" %), :leave #(str % "_avaruus")}}]
-                  {::m/enable-sci false} mt/string-transformer)))
+                  {::m/disable-sci true} mt/string-transformer)))
 
           (testing "direct options win"
-            (is (m/decoder schema {::m/enable-sci true} mt/string-transformer)))))
+            (is (m/decoder schema {::m/disable-sci false} mt/string-transformer)))))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -186,13 +186,9 @@
                                 (assoc-in ['int? :error/message :fi] "NUMERO")
                                 (assoc-in [::m/missing-key :error/message :fi] "PUUTTUVA AVAIN"))})))))))
 
-(-> (m/schema [:string {:error/fn '(constantly "FAIL")}] #_{::m/enable-sci false})
-    (m/explain ::invalid)
-    (me/with-error-messages))
-
 (deftest sci-not-available-test
   (testing "sci not available"
-    (let [schema (m/schema [:string {:error/fn '(constantly "FAIL")}] {::m/enable-sci false})]
+    (let [schema (m/schema [:string {:error/fn '(constantly "FAIL")}] {::m/disable-sci true})]
       (is (thrown-with-msg?
             #?(:clj Exception, :cljs js/Error)
             #":malli.core/sci-not-available"
@@ -206,16 +202,16 @@
             #":malli.core/sci-not-available"
             (-> [:string {:error/fn '(constantly "FAIL")}]
                 (m/explain ::invalid)
-                (me/with-error-messages {::m/enable-sci false}))))
+                (me/with-error-messages {::m/disable-sci true}))))
       (is (thrown-with-msg?
             #?(:clj Exception, :cljs js/Error)
             #":malli.core/sci-not-available"
             (-> [:string {:error/fn '(constantly "FAIL")}]
                 (m/explain ::invalid)
-                (me/humanize {::m/enable-sci false}))))
+                (me/humanize {::m/disable-sci true}))))
       (testing "direct options win"
-        (is (-> schema (m/explain ::invalid) (me/with-error-messages {::m/enable-sci true})))
-        (is (-> schema (m/explain ::invalid) (me/humanize {::m/enable-sci true})))))))
+        (is (-> schema (m/explain ::invalid) (me/with-error-messages {::m/disable-sci false})))
+        (is (-> schema (m/explain ::invalid) (me/humanize {::m/disable-sci false})))))))
 
 (deftest composing-with-and-test
 

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -186,6 +186,37 @@
                                 (assoc-in ['int? :error/message :fi] "NUMERO")
                                 (assoc-in [::m/missing-key :error/message :fi] "PUUTTUVA AVAIN"))})))))))
 
+(-> (m/schema [:string {:error/fn '(constantly "FAIL")}] #_{::m/enable-sci false})
+    (m/explain ::invalid)
+    (me/with-error-messages))
+
+(deftest sci-not-available-test
+  (testing "sci not available"
+    (let [schema (m/schema [:string {:error/fn '(constantly "FAIL")}] {::m/enable-sci false})]
+      (is (thrown-with-msg?
+            #?(:clj Exception, :cljs js/Error)
+            #":malli.core/sci-not-available"
+            (-> schema (m/explain ::invalid) (me/with-error-messages))))
+      (is (thrown-with-msg?
+            #?(:clj Exception, :cljs js/Error)
+            #":malli.core/sci-not-available"
+            (-> schema (m/explain ::invalid) (me/humanize))))
+      (is (thrown-with-msg?
+            #?(:clj Exception, :cljs js/Error)
+            #":malli.core/sci-not-available"
+            (-> [:string {:error/fn '(constantly "FAIL")}]
+                (m/explain ::invalid)
+                (me/with-error-messages {::m/enable-sci false}))))
+      (is (thrown-with-msg?
+            #?(:clj Exception, :cljs js/Error)
+            #":malli.core/sci-not-available"
+            (-> [:string {:error/fn '(constantly "FAIL")}]
+                (m/explain ::invalid)
+                (me/humanize {::m/enable-sci false}))))
+      (testing "direct options win"
+        (is (-> schema (m/explain ::invalid) (me/with-error-messages {::m/enable-sci true})))
+        (is (-> schema (m/explain ::invalid) (me/humanize {::m/enable-sci true})))))))
+
 (deftest composing-with-and-test
 
   (testing "top-level map-schemas are written in :malli/error"

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -87,7 +87,7 @@
           (mg/generate [:fn '(fn [x] (<= 0 x 10))]))))
 
   (testing "sci not available"
-    (let [schema (m/schema [:string {:gen/fmap '(partial str "kikka_")}] {::m/enable-sci false})]
+    (let [schema (m/schema [:string {:gen/fmap '(partial str "kikka_")}] {::m/disable-sci true})]
       (is (thrown-with-msg?
             #?(:clj Exception, :cljs js/Error)
             #":malli.core/sci-not-available"
@@ -95,9 +95,9 @@
       (is (thrown-with-msg?
             #?(:clj Exception, :cljs js/Error)
             #":malli.core/sci-not-available"
-            (mg/generator [:string {:gen/fmap '(partial str "kikka_")}] {::m/enable-sci false})))
+            (mg/generator [:string {:gen/fmap '(partial str "kikka_")}] {::m/disable-sci true})))
       (testing "direct options win"
-        (is (mg/generator schema {::m/enable-sci true})))))
+        (is (mg/generator schema {::m/disable-sci false})))))
 
   (testing "generator override"
     (testing "without generator"

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -86,6 +86,19 @@
           #":malli.generator/no-generator"
           (mg/generate [:fn '(fn [x] (<= 0 x 10))]))))
 
+  (testing "sci not available"
+    (let [schema (m/schema [:string {:gen/fmap '(partial str "kikka_")}] {::m/enable-sci false})]
+      (is (thrown-with-msg?
+            #?(:clj Exception, :cljs js/Error)
+            #":malli.core/sci-not-available"
+            (mg/generator schema)))
+      (is (thrown-with-msg?
+            #?(:clj Exception, :cljs js/Error)
+            #":malli.core/sci-not-available"
+            (mg/generator [:string {:gen/fmap '(partial str "kikka_")}] {::m/enable-sci false})))
+      (testing "direct options win"
+        (is (mg/generator schema {::m/enable-sci true})))))
+
   (testing "generator override"
     (testing "without generator"
       (let [schema [:fn {:gen/fmap '(fn [_] (rand-int 10))}


### PR DESCRIPTION
Option 2 for #276. A non-breaking change (opposed to option1).

Disabling `sci`:

```clj
(m/validate [:fn 'int?] 1)
; => true

(m/validate [:fn 'int?] 1 {::m/disable-sci true})
; Execution error
; :malli.core/sci-not-available {:code int?}
```

Custom `sci` options:

```clj
(m/validate [:fn '(fn [x] (< x (last (range 10))))] 1)
; => true

(m/validate [:fn '(fn [x] (< x (last (range 10))))] 1 {::m/sci-options {:realize-max 1}})
; => false
```