### PR TITLE
Options for default-value-transformer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,13 +26,13 @@ Malli is in [alpha](README.md#alpha).
   [:map
    [:user [:map
            [:name :string]
-           [:desciption {:ui/default "-"} :string]]]]
+           [:description {:ui/default "-"} :string]]]]
   nil
   (mt/default-value-transformer
     {:key :ui/default
      :defaults {:map (constantly {})
                 :string (constantly "")}}))
-; => {:user {:name "", :desciption "-"}}
+; => {:user {:name "", :description "-"}}
 ```
 
 ## 0.1.0 (2020-10-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ Malli is in [alpha](README.md#alpha).
 * New options
   * `:malli.core/disable-sci` for explicitly disabling `sci`, fixes [#276](https://github.com/metosin/malli/issues/276)
   * `:malli.core/sci-options` for configuring `sci`
+* `malli.transform/default-value-transformer` accepts options `:key` and `:defaults`:
+
+```clj
+(m/decode
+  [:map
+   [:user [:map
+           [:name :string]
+           [:desciption {:ui/default "-"} :string]]]]
+  nil
+  (mt/default-value-transformer
+    {:key :ui/default
+     :defaults {:map (constantly {})
+                :string (constantly "")}}))
+; => {:user {:name "", :desciption "-"}}
+```
 
 ## 0.1.0 (2020-10-08)
 

--- a/README.md
+++ b/README.md
@@ -549,6 +549,22 @@ Applying default values:
 ; => 42
 ```
 
+With custom key and type defaults:
+
+```clj
+(m/decode
+  [:map
+   [:user [:map
+           [:name :string]
+           [:desciption {:ui/default "-"} :string]]]]
+  nil
+  (mt/default-value-transformer
+    {:key :ui/default
+     :defaults {:map (constantly {})
+                :string (constantly "")}}))
+; => {:user {:name "", :desciption "-"}}
+```
+
 Single sweep of defaults & string encoding:
 
 ```clj

--- a/README.md
+++ b/README.md
@@ -556,13 +556,13 @@ With custom key and type defaults:
   [:map
    [:user [:map
            [:name :string]
-           [:desciption {:ui/default "-"} :string]]]]
+           [:description {:ui/default "-"} :string]]]]
   nil
   (mt/default-value-transformer
     {:key :ui/default
      :defaults {:map (constantly {})
                 :string (constantly "")}}))
-; => {:user {:name "", :desciption "-"}}
+; => {:user {:name "", :description "-"}}
 ```
 
 Single sweep of defaults & string encoding:

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -657,7 +657,18 @@
   (testing "default false"
     (is (= {:user/verified false} (m/decode [:map [:user/verified [:and {:default false} boolean?]]] {} mt/default-value-transformer)))
     (is (= {:user/verified false} (m/decode [:map [:user/verified {:default false} boolean?]] {} mt/default-value-transformer)))
-    (is (= false (m/decode [:and {:default false} boolean?] nil mt/default-value-transformer)))))
+    (is (= false (m/decode [:and {:default false} boolean?] nil mt/default-value-transformer))))
+
+  (testing "with custom options"
+    (is (= false (m/decode [:and {:? false} boolean?] nil (mt/default-value-transformer {:key :?}))))
+    (is (= {:user {:first-name "", :last-name ""}}
+           (m/decode [:map
+                      [:user [:map
+                              [:first-name :string]
+                              [:last-name :string]]]]
+                     nil
+                     (mt/default-value-transformer {:defaults {:map (constantly {})
+                                                               :string (constantly "")}}))))))
 
 (deftest type-properties-based-transformations
   (is (= 12 (m/decode malli.core-test/Over6 "12" mt/string-transformer))))


### PR DESCRIPTION
* `malli.transform/default-value-transformer` accepts options `:key` and `:defaults`:

```clj
(m/decode
  [:map
   [:user [:map
           [:name :string]
           [:desciption {:ui/default "-"} :string]]]]
  nil
  (mt/default-value-transformer
    {:key :ui/default
     :defaults {:map (constantly {})
                :string (constantly "")}}))
; => {:user {:name "", :desciption "-"}}
```