### PR TITLE
Better handling of :ref and :schema references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ After:
 ; => int?
 ```
 
-* the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`
+* the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`.
+
+* `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
 
 * `m/walk` can walk over `:ref` and `:schema` reference schemas. Walking can be enabled using options `:malli.core/walk-refs` and `:malli.core/walk-schema-refs`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,36 @@ Malli is in [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* New options
+* **BREAKING**: `m/deref` is recursive and does not throw: 
+
+Before:
+
+```clj
+(m/deref [:schema [:schema int?]])
+; => [:schema int?]
+
+(m/deref int?)
+; => Execution error
+```
+
+After:
+
+```clj
+(m/deref [:schema [:schema int?]])
+; => int?
+
+(m/deref int?])
+; => int?
+```
+
+* the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`
+
+* `m/walk` can walk over `:ref` and `:schema` reference schemas. Walking can be enabled using options `:malli.core/walk-refs` and `:malli.core/walk-schema-refs`.
+
+* New options for SCI:
   * `:malli.core/disable-sci` for explicitly disabling `sci`, fixes [#276](https://github.com/metosin/malli/issues/276)
   * `:malli.core/sci-options` for configuring `sci`
+
 * `malli.transform/default-value-transformer` accepts options `:key` and `:defaults`:
 
 ```clj

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -98,6 +98,9 @@
 (defn -lazy [ref options]
   (-into-schema (-ref-schema {:lazy true}) nil [ref] options))
 
+(defn -boolean-fn [x]
+  (if (boolean? x) (constantly x) x))
+
 (defn -comp
   ([] identity)
   ([f] f)
@@ -919,7 +922,7 @@
            (-walk [this walker path options]
              (let [accept (fn [] (-inner walker (-ref) (into path [0 0]) (-update options ::walked-refs #(conj (or % #{}) ref))))]
                (if (-accept walker this path options)
-                 (if (or (not (::walk-refs options)) (contains? (::walked-refs options) ref))
+                 (if (or (not ((-boolean-fn (::walk-refs options false)) ref)) (contains? (::walked-refs options) ref))
                    (-outer walker this path [ref] options)
                    (-outer walker this path [(accept)] options)))))
            (-properties [_] properties)
@@ -955,7 +958,7 @@
               (-parent-children-transformer this children transformer method options))
             (-walk [this walker path options]
               (if (-accept walker this path options)
-                (if (or (not id) (::walk-schema-refs options))
+                (if (or (not id) ((-boolean-fn (::walk-schema-refs options false)) id))
                   (-outer walker this path (-inner-indexed walker path children options) options)
                   (-outer walker this path [id] options))))
             (-properties [_] properties)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1171,11 +1171,14 @@
        (-entries schema)))))
 
 (defn deref
-  "Derefs a `RefSchema`."
+  "Derefs top-level `RefSchema`s recursively or returns original Schema."
   ([?schema]
    (deref ?schema nil))
   ([?schema options]
-   (some-> (schema ?schema options) (-deref))))
+   (loop [schema (schema ?schema options)]
+     (if (satisfies? RefSchema schema)
+       (recur (-deref schema))
+       schema))))
 
 ;;
 ;; eval

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -89,17 +89,13 @@
     (seq children) (into [type] children)
     :else type))
 
-(defn -pointer [id schema options]
-  (-into-schema (-schema-schema {:id id}) nil [schema] options))
+(defn -pointer [id schema options] (-into-schema (-schema-schema {:id id}) nil [schema] options))
 
-(defn -reference? [?schema]
-  (or (string? ?schema) (qualified-keyword? ?schema)))
+(defn -reference? [?schema] (or (string? ?schema) (qualified-keyword? ?schema)))
 
-(defn -lazy [ref options]
-  (-into-schema (-ref-schema {:lazy true}) nil [ref] options))
+(defn -lazy [ref options] (-into-schema (-ref-schema {:lazy true}) nil [ref] options))
 
-(defn -boolean-fn [x]
-  (if (boolean? x) (constantly x) x))
+(defn -boolean-fn [x] (cond (boolean? x) (constantly x) (ifn? x) x :else (constantly false)))
 
 (defn -comp
   ([] identity)

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -65,8 +65,8 @@
   ([?schema1 ?schema2]
    (merge ?schema1 ?schema2 nil))
   ([?schema1 ?schema2 options]
-   (let [[schema1 schema2 :as schemas] [(if ?schema1 (m/schema ?schema1 options))
-                                        (if ?schema2 (m/schema ?schema2 options))]
+   (let [[schema1 schema2 :as schemas] [(if ?schema1 (m/deref (m/schema ?schema1 options)))
+                                        (if ?schema2 (m/deref (m/schema ?schema2 options)))]
          {:keys [merge-default merge-required]
           :or {merge-default (fn [_ s2 _] s2)
                merge-required (fn [_ r2] r2)}} options]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -152,7 +152,7 @@
   ([?schema]
    (subschemas ?schema nil))
   ([?schema options]
-   (let [options (clojure.core/assoc options ::m/walk-schema-refs true)
+   (let [options (clojure.core/update options ::m/walk-schema-refs  (fnil identity true))
          schema (m/schema ?schema options)
          state (atom [])]
      (find-first schema (fn [s p _] (swap! state conj {:path p, :in (path->in schema p), :schema s}) nil) options)

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -152,9 +152,10 @@
   ([?schema]
    (subschemas ?schema nil))
   ([?schema options]
-   (let [schema (m/schema ?schema options)
+   (let [options (clojure.core/assoc options ::m/walk-schema-refs true)
+         schema (m/schema ?schema options)
          state (atom [])]
-     (find-first schema (fn [s path _] (swap! state conj {:path path, :in (path->in schema path), :schema s}) nil))
+     (find-first schema (fn [s p _] (swap! state conj {:path p, :in (path->in schema p), :schema s}) nil) options)
      @state)))
 
 (defn distinct-by

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -449,7 +449,9 @@
                (mt/transformer {:name :custom}))))
 
       (testing "deref"
-        (is (mu/equals (m/schema int?) (m/deref [:schema int?]))))
+        (is (mu/equals (m/schema int?) (m/deref int?)))
+        (is (mu/equals (m/schema int?) (m/deref [:schema int?])))
+        (is (mu/equals (m/schema int?) (m/deref [:schema [:schema [:schema int?]]]))))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -61,7 +61,11 @@
        [:query-params {:title "query2", :description "first", :summary "second"}
         [:map [:x string?] [:y int?]]]
        [:body-params
-        [:map [:z int?]]]]]]))
+        [:map [:z int?]]]]]]
+
+    [:schema [:schema [:map [:x int?]]]]
+    [:schema [:schema [:schema [:map [:y int?]]]]]
+    [:map [:x int?] [:y int?]]))
 
 (deftest union-test
   (are [?s1 ?s2 expected]
@@ -106,7 +110,11 @@
        [:query-params {:title "query2", :description "first", :summary "second"}
         [:map [:x [:or int? string?]] [:y int?]]]
        [:body-params
-        [:map [:z int?]]]]]]))
+        [:map [:z int?]]]]]]
+
+    [:schema [:schema [:map [:x int?]]]]
+    [:schema [:schema [:schema [:map [:y int?]]]]]
+    [:map [:x int?] [:y int?]]))
 
 (deftest update-properties-test
   (let [schema [:and {:x 0} int?]]


### PR DESCRIPTION
* fixes #281 

* **BREAKING**: `m/deref` is recursive and does not throw: 

Before:

```clj
(m/deref [:schema [:schema int?]])
; => [:schema int?]

(m/deref int?)
; => Execution error
```

After:

```clj
(m/deref [:schema [:schema int?]])
; => int?

(m/deref int?])
; => int?
```

* the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`.

* `m/walk` can walk over `:ref` and `:schema` reference schemas. Walking can be enabled using options `:malli.core/walk-refs` and `:malli.core/walk-schema-refs`.

* `mu/subschemas` walks over top-level `:ref` and all `:schema`s.

```clj
(mu/subschemas
  [:ref {:registry {"Address" [:map
                               [:street :string]
                               [:country "Country"]
                               [:address [:ref "Address"]]
                               [:neighbor [:ref "Neighbor"]]]
                    "Country" [:map [:name "CountryName"]]
                    "CountryName" [:= "finland"]
                    "Neighbor" [:ref "Address"]}}
   "Address"])
;[{:path [], :in [], :schema [:ref {:registry {"Address" [:map
;                                                         [:street :string]
;                                                         [:country "Country"]
;                                                         [:address [:ref "Address"]]
;                                                         [:neighbor [:ref "Neighbor"]]]
;                                              "Country" [:map [:name "CountryName"]]
;                                              "CountryName" [:= "finland"]
;                                              "Neighbor" [:ref "Address"]}}
;                             "Address"]}
; {:path [0 0], :in [], :schema [:map
;                                [:street :string]
;                                [:country "Country"]
;                                [:address [:ref "Address"]]
;                                [:neighbor [:ref "Neighbor"]]]}
; {:path [0 0 :street], :in [:street], :schema :string}
; {:path [0 0 :country], :in [:country], :schema "Country"}
; {:path [0 0 :country 0], :in [:country], :schema [:map [:name "CountryName"]]}
; {:path [0 0 :country 0 :name], :in [:country :name], :schema "CountryName"}
; {:path [0 0 :country 0 :name 0], :in [:country :name], :schema [:= "finland"]}
; {:path [0 0 :address], :in [:address], :schema [:ref "Address"]}
; {:path [0 0 :neighbor], :in [:neighbor], :schema [:ref "Neighbor"]}]
```