### PR TITLE
declarative schema transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ After:
 ; => int?
 ```
 
-* the following utilities in `malli.util` do automatic top-level deref: `merge`, `union` and `select-keys`.
+* **BREAKING**: the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys` and `select-keys`.
 
 * `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Malli is in [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* `m/deref` returns original schema, does not throw, fixes [#284](https://github.com/metosin/malli/issues/284).
+* **CHANGE**: `m/deref` returns original schema, does not throw, fixes [#284](https://github.com/metosin/malli/issues/284).
+* **CHANGE**: the following utilities in `malli.util` deref top-level refs rwcursively: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
 * `m/deref-all` derefs all top-level references recursively, e.g.
 
 ```clj
@@ -24,12 +25,9 @@ Malli is in [alpha](README.md#alpha).
 ; => int?
 ```
 
-* the following utilities in `malli.util` deref top-level refs rwcursively: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
-
+* `:ref`, `:schema`, `::m/schema` have now generators, JSON Schema and Swagger support
 * `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
-
 * `m/walk` can walk over `:ref` and `:schema` reference schemas. Walking can be enabled using options `:malli.core/walk-refs` and `:malli.core/walk-schema-refs`.
-
 * Welcome [declarative schema transformations](README.md#declarative-schema-transformation)!
 
 * New options for SCI:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ After:
 ; => int?
 ```
 
-* **BREAKING**: the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys` and `select-keys`.
+* **BREAKING**: the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
 
 * `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,13 @@ After:
 ; => int?
 ```
 
-* the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`.
+* the following utilities in `malli.util` do automatic top-level deref: `merge`, `union` and `select-keys`.
 
 * `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
 
 * `m/walk` can walk over `:ref` and `:schema` reference schemas. Walking can be enabled using options `:malli.core/walk-refs` and `:malli.core/walk-schema-refs`.
+
+* Welcome [declarative schema transformations](README.md#declarative-schema-transformation)!
 
 * New options for SCI:
   * `:malli.core/disable-sci` for explicitly disabling `sci`, fixes [#276](https://github.com/metosin/malli/issues/276)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ Malli is in [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* **CHANGE**: `m/deref` returns original schema, does not throw, fixes [#284](https://github.com/metosin/malli/issues/284).
-* **CHANGE**: the following utilities in `malli.util` deref top-level refs rwcursively: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
+* **BREAKING (MINOR)**: `m/deref` returns original schema, does not throw, fixes [#284](https://github.com/metosin/malli/issues/284).
+* **BREAKING (MINOR)**: the following utilities in `malli.util` deref top-level refs recursively: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
 * `m/deref-all` derefs all top-level references recursively, e.g.
 
 ```clj
@@ -28,7 +28,33 @@ Malli is in [alpha](README.md#alpha).
 * `:ref`, `:schema`, `::m/schema` have now generators, JSON Schema and Swagger support
 * `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
 * `m/walk` can walk over `:ref` and `:schema` reference schemas. Walking can be enabled using options `:malli.core/walk-refs` and `:malli.core/walk-schema-refs`.
-* Welcome [declarative schema transformations](README.md#declarative-schema-transformation)!
+* Welcome declarative schema transformations!
+
+There are also declarative versions of schema transforming utilities in `malli.util/schemas`. These include `:merge`, `:union` and `:select-keys`:
+
+```clj
+(def registry (merge (m/default-schemas) (mu/schemas)))
+
+(def Merged
+  (m/schema
+    [:merge
+     [:map [:x :string]]
+     [:map [:y :int]]]
+    {:registry registry}))
+
+Merged
+;[:merge
+; [:map [:x :string]]
+; [:map [:y :int]]]
+
+(m/deref Merged)
+;[:map 
+; [:x :string] 
+; [:y :int]]
+
+(m/validate Merged {:x "kikka", :y 6})
+; => true
+```
 
 * New options for SCI:
   * `:malli.core/disable-sci` for explicitly disabling `sci`, fixes [#276](https://github.com/metosin/malli/issues/276)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,29 +16,15 @@ Malli is in [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* **BREAKING**: `m/deref` is recursive and does not throw: 
-
-Before:
-
-```clj
-(m/deref [:schema [:schema int?]])
-; => [:schema int?]
-
-(m/deref int?)
-; => Execution error
-```
-
-After:
+* `m/deref` returns original schema, does not throw, fixes [#284](https://github.com/metosin/malli/issues/284).
+* `m/deref-all` derefs all top-level references recursively, e.g.
 
 ```clj
-(m/deref [:schema [:schema int?]])
-; => int?
-
-(m/deref int?])
+(m/deref-all [:schema [:schema int?]])
 ; => int?
 ```
 
-* **BREAKING**: the following utilities in `malli.util` do automatic top-level deref: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
+* the following utilities in `malli.util` deref top-level refs rwcursively: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
 
 * `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
 

--- a/README.md
+++ b/README.md
@@ -848,6 +848,34 @@ and back, returning all paths:
 ; => [[0 :address 0 :lonlat]]
 ```
 
+## Declarative Schema Transformation
+
+There are also declarative versions of schema transforming utilitis. These include: `:merge`, `:union` and `:select-keys`. They are not in default registry:
+
+```clj
+(def registry (merge (m/default-schemas) (mu/schemas)))
+
+(def Merged
+  (m/schema
+    [:merge
+     [:map [:x :string]]
+     [:map [:y :int]]]
+    {:registry registry}))
+
+Merged
+;[:merge
+; [:map [:x :string]]
+; [:map [:y :int]]]
+
+(m/deref Merged)
+;[:map 
+; [:x :string] 
+; [:y :int]]
+
+(m/validate Merged {:x "kikka", :y 6})
+; => true
+```
+
 ## Persisting Schemas 
 
 Writing and Reading schemas as [EDN](https://github.com/edn-format/edn), no `eval` needed.

--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ and back, returning all paths:
 
 ## Declarative Schema Transformation
 
-There are also declarative versions of schema transforming utilitis. These include: `:merge`, `:union` and `:select-keys`. They are not in default registry:
+There are also declarative versions of schema transforming utilities in `malli.util/schemas`. These include `:merge`, `:union` and `:select-keys`:
 
 ```clj
 (def registry (merge (m/default-schemas) (mu/schemas)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1170,14 +1170,20 @@
        (-entries schema)))))
 
 (defn deref
-  "Derefs top-level `RefSchema`s recursively or returns original Schema."
+  "Derefs top-level `RefSchema`s or returns original Schema."
   ([?schema]
    (deref ?schema nil))
   ([?schema options]
-   (loop [schema (schema ?schema options)]
-     (if (satisfies? RefSchema schema)
-       (recur (-deref schema))
-       schema))))
+   (let [schema (schema ?schema options)]
+     (cond-> schema (satisfies? RefSchema schema) (-deref)))))
+
+(defn deref-all
+  "Derefs top-level `RefSchema`s recursively or returns original Schema."
+  ([?schema]
+   (deref-all ?schema nil))
+  ([?schema options]
+   (let [schema (deref ?schema options)]
+     (cond-> schema (satisfies? RefSchema schema) (recur options)))))
 
 ;;
 ;; eval

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -6,7 +6,7 @@
 
 (defn -lift [?schema]
   (let [schema (m/schema ?schema)]
-    (if (and (satisfies? m/RefSchema schema) (-> schema m/-deref m/type (= ::m/schema)))
+    (if (and (satisfies? m/RefSchema schema) (-> schema m/deref m/type (= ::m/schema)))
       ?schema [:schema {:registry {::schema ?schema}} ?schema])))
 
 (defn -collect [schema]
@@ -61,7 +61,7 @@
          sorted #(sort-by (m/-comp str first) %)
          wrap #(str "\"" % "\"")
          label (fn [k v] (str "\"{" k "|"
-                              (or (some->> (m/entries v) (map (fn [[k s]] (str k " " (esc (m/form (m/-deref s)))))) (str/join "\\l"))
+                              (or (some->> (m/entries v) (map (fn [[k s]] (str k " " (esc (m/form (m/deref s)))))) (str/join "\\l"))
                                   (esc (m/form v)))
                               "\\l}\""))
          > #(apply println %&)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -147,6 +147,10 @@
 (defmethod -schema-generator :schema [schema options] (generator (m/-deref schema) options))
 (defmethod -schema-generator ::m/schema [schema options] (generator (m/-deref schema) options))
 
+(defmethod -schema-generator :merge [schema options] (generator (m/-deref schema) options))
+(defmethod -schema-generator :union [schema options] (generator (m/-deref schema) options))
+(defmethod -schema-generator :select-keys [schema options] (generator (m/-deref schema) options))
+
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (merge (m/type-properties schema) (m/properties schema))
         gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema options) (-schema-generator schema options))))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -143,13 +143,13 @@
 (defmethod -schema-generator :qualified-symbol [_ _] (gen/such-that qualified-symbol? gen/symbol-ns))
 (defmethod -schema-generator :uuid [_ _] gen/uuid)
 
-(defmethod -schema-generator :ref [schema options] (generator (m/-deref schema) options))
-(defmethod -schema-generator :schema [schema options] (generator (m/-deref schema) options))
-(defmethod -schema-generator ::m/schema [schema options] (generator (m/-deref schema) options))
+(defmethod -schema-generator :ref [schema options] (generator (m/deref schema) options))
+(defmethod -schema-generator :schema [schema options] (generator (m/deref schema) options))
+(defmethod -schema-generator ::m/schema [schema options] (generator (m/deref schema) options))
 
-(defmethod -schema-generator :merge [schema options] (generator (m/-deref schema) options))
-(defmethod -schema-generator :union [schema options] (generator (m/-deref schema) options))
-(defmethod -schema-generator :select-keys [schema options] (generator (m/-deref schema) options))
+(defmethod -schema-generator :merge [schema options] (generator (m/deref schema) options))
+(defmethod -schema-generator :union [schema options] (generator (m/deref schema) options))
+(defmethod -schema-generator :select-keys [schema options] (generator (m/deref schema) options))
 
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (merge (m/type-properties schema) (m/properties schema))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -10,7 +10,7 @@
 (defn -ref [x] {:$ref (str "#/definitions/" x)})
 
 (defn -schema [schema options]
-  (let [result (-transform (m/-deref schema) options)]
+  (let [result (-transform (m/deref schema) options)]
     (if-let [ref (m/-ref schema)]
       (do (swap! (::definitions options) assoc ref result) (-ref ref))
       result)))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -2,6 +2,8 @@
   (:require [malli.core :as m]
             [clojure.set :as set]))
 
+(declare transform)
+
 (defprotocol JsonSchema
   (-accept [this children options] "transforms schema to JSON Schema"))
 
@@ -116,6 +118,10 @@
                  (-accept schema children options)
                  (accept (m/type schema) schema children options))
                (unlift-keys p :json-schema)))))
+
+(defmethod accept :merge [_ schema _ options] (transform (m/deref schema) options))
+(defmethod accept :union [_ schema _ options] (transform (m/deref schema) options))
+(defmethod accept :select-keys [_ schema _ options] (transform (m/deref schema) options))
 
 ;;
 ;; public api

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -33,6 +33,8 @@
                (json-schema/unlift-keys p :json-schema)
                (json-schema/unlift-keys p :swagger)))))
 
+(defn -transform [?schema options] (m/walk ?schema -swagger-walker options))
+
 ;;
 ;; public api
 ;;
@@ -41,4 +43,8 @@
   ([?schema]
    (transform ?schema nil))
   ([?schema options]
-   (m/walk ?schema -swagger-walker (assoc options ::m/walk-entry-vals true))))
+   (let [definitions (atom {})
+         options (merge options {::m/walk-entry-vals true
+                                 ::json-schema/definitions definitions
+                                 ::json-schema/transform -transform})]
+     (cond-> (-transform ?schema options) (seq @definitions) (assoc :definitions @definitions)))))

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -65,8 +65,8 @@
   ([?schema1 ?schema2]
    (merge ?schema1 ?schema2 nil))
   ([?schema1 ?schema2 options]
-   (let [[schema1 schema2 :as schemas] [(if ?schema1 (m/deref (m/schema ?schema1 options)))
-                                        (if ?schema2 (m/deref (m/schema ?schema2 options)))]
+   (let [[schema1 schema2 :as schemas] [(if ?schema1 (m/deref-all (m/schema ?schema1 options)))
+                                        (if ?schema2 (m/deref-all (m/schema ?schema2 options)))]
          {:keys [merge-default merge-required]
           :or {merge-default (fn [_ s2 _] s2)
                merge-required (fn [_ r2] r2)}} options]
@@ -195,7 +195,7 @@
 (defn transform-entries
   "Transforms entries with f."
   [?schema f options]
-  (let [schema (m/deref (m/schema ?schema options))]
+  (let [schema (m/deref-all (m/schema ?schema options))]
     (m/into-schema (m/type schema) (m/properties schema) (f (m/children schema)))))
 
 (defn optional-keys

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -451,7 +451,12 @@
       (testing "deref"
         (is (mu/equals (m/schema int?) (m/deref int?)))
         (is (mu/equals (m/schema int?) (m/deref [:schema int?])))
-        (is (mu/equals (m/schema int?) (m/deref [:schema [:schema [:schema int?]]]))))
+        (is (mu/equals (m/schema [:schema [:schema int?]]) (m/deref [:schema [:schema [:schema int?]]]))))
+
+      (testing "deref-all"
+        (is (mu/equals (m/schema int?) (m/deref-all int?)))
+        (is (mu/equals (m/schema int?) (m/deref-all [:schema int?])))
+        (is (mu/equals (m/schema int?) (m/deref-all [:schema [:schema [:schema int?]]]))))
 
       (is (true? (m/validate (over-the-wire schema) 1)))
 

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -394,3 +394,20 @@
                '({:a 10}
                  {:b 10}))
              (me/humanize)))))
+
+(deftest util-schemas-test
+  (let [registry (merge (m/default-schemas) (mu/schemas))]
+    (doseq [[schema errors] [[[:merge {:title "merge"}
+                               [:map [:x int?] [:y int?]]
+                               [:map [:z int?]]]
+                              {:y ["missing required key"]
+                               :z ["missing required key"]}]
+                             [[:union {:title "union"}
+                               [:map [:x int?] [:y int?]]
+                               [:map [:x string?]]]
+                              {:y ["missing required key"]}]
+                             [[:select-keys {:title "select-keys"}
+                               [:map [:x int?] [:y int?]]
+                               [:x]]]]
+            :let [schema (m/schema schema {:registry registry})]]
+      (is (= errors (-> schema (m/explain {:x 1}) (me/humanize)))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -342,6 +342,10 @@
     (is (mu/equals (mu/dissoc schema :b)
                    [:map {:title "map"}
                     [:a int?]
+                    [:c string?]]))
+    (is (mu/equals (mu/dissoc [:schema schema] :b)
+                   [:map {:title "map"}
+                    [:a int?]
                     [:c string?]]))))
 
 (deftest update-test
@@ -416,6 +420,8 @@
     (is (mu/equals (mu/optional-keys schema)
                    [:map [:x {:optional true} int?] [:y {:optional true} int?]]))
     (is (mu/equals (mu/optional-keys schema [:x :extra nil])
+                   [:map [:x {:optional true} int?] [:y int?]]))
+    (is (mu/equals (mu/optional-keys [:schema schema] [:x :extra nil])
                    [:map [:x {:optional true} int?] [:y int?]]))))
 
 (deftest required-keys-test
@@ -423,6 +429,8 @@
     (is (mu/equals (mu/required-keys schema)
                    [:map [:x int?] [:y int?]]))
     (is (mu/equals (mu/required-keys schema [:x :extra nil])
+                   [:map [:x int?] [:y {:optional false} int?]]))
+    (is (mu/equals (mu/required-keys [:schema schema] [:x :extra nil])
                    [:map [:x int?] [:y {:optional false} int?]]))))
 
 (deftest find-first-test

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -162,7 +162,14 @@
     (is (mu/equals (mu/select-keys schema [:a :b :extra])
                    [:map {:title "map"}
                     [:a int?]
-                    [:b {:optional true} int?]]))))
+                    [:b {:optional true} int?]]))
+
+    (testing "derefs automatically"
+      (is (mu/equals (mu/select-keys
+                       [:schema
+                        [:map [:a int?] [:b int?]]]
+                       [:a])
+                     [:map [:a int?]])))))
 
 ;;
 ;; LensSchemas
@@ -752,3 +759,55 @@
 
                  (mu/to-map-syntax schema {::m/walk-refs true
                                            ::m/walk-schema-refs true}))))))))
+
+(deftest declarative-schemas
+  (let [->> #(m/schema % {:registry (merge (mu/schemas) (m/default-schemas))})]
+
+    (testing "merge"
+      (let [s (->> [:merge
+                    [:map [:x :string]]
+                    [:map [:y :int]]
+                    [:schema [:map [:z {:optional true} :boolean]]]])]
+        (is (= [:merge
+                [:map [:x :string]]
+                [:map [:y :int]]
+                [:schema [:map [:z {:optional true} :boolean]]]]
+               (m/form s)))
+        (is (= [:map [:x :string] [:y :int] [:z {:optional true} :boolean]] (m/form (m/deref s))))
+        (is (= true (m/validate s {:x "x", :y 1, :z true})))
+        (is (= false (m/validate s {:x "x", :y "y"})))))
+
+    (testing "union"
+      (let [s (->> [:union
+                    [:map [:x :string]]
+                    [:schema [:map [:x :int]]]])]
+        (is (= [:union
+                [:map [:x :string]]
+                [:schema [:map [:x :int]]]]
+               (m/form s)))
+        (is (= [:map [:x [:or :string :int]]] (m/form (m/deref s))))
+        (is (= true (m/validate s {:x "x"}) (m/validate s {:x 1})))
+        (is (= false (m/validate s {:x true})))))
+
+    (testing "select-keys"
+      (let [s (->> [:select-keys
+                    [:schema
+                     [:map {:closed true}
+                      [:x :string]
+                      [:y :string]
+                      [:z :string]]]
+                    [:x :z]])]
+        (is (= [:select-keys
+                [:schema
+                 [:map {:closed true}
+                  [:x :string]
+                  [:y :string]
+                  [:z :string]]]
+                [:x :z]]
+               (m/form s)))
+        (is (= [:map {:closed true}
+                [:x :string]
+                [:z :string]]
+               (m/form (m/deref s))))
+        (is (= true (m/validate s {:x "x", :z "z"})))
+        (is (= false (m/validate s {:x "x", :y "y" :z "z"})))))))


### PR DESCRIPTION
* **BREAKING (MINOR)**: `m/deref` returns original schema, does not throw, fixes [#284](https://github.com/metosin/malli/issues/284).
* **BREAKING (MINOR)**: the following utilities in `malli.util` deref top-level refs recursively: `merge`, `union`, `transform-entries`, `optional-keys`, `required-keys`, `select-keys` and `dissoc`.
* `m/deref-all` derefs all top-level references recursively, e.g.

```clj
(m/deref-all [:schema [:schema int?]])
; => int?
```

* `:ref`, `:schema`, `::m/schema` have now generators, JSON Schema and Swagger support
* `mu/subschemas` walks over top-level `:ref` and all `:schema`s.
* `m/walk` can walk over `:ref` and `:schema` reference schemas. Walking can be enabled using options `:malli.core/walk-refs` and `:malli.core/walk-schema-refs`.
* Welcome declarative schema transformations!

There are also declarative versions of schema transforming utilities in `malli.util/schemas`. These include `:merge`, `:union` and `:select-keys`:

```clj
(def registry (merge (m/default-schemas) (mu/schemas)))

(def Merged
  (m/schema
    [:merge
     [:map [:x :string]]
     [:map [:y :int]]]
    {:registry registry}))

Merged
;[:merge
; [:map [:x :string]]
; [:map [:y :int]]]

(m/deref Merged)
;[:map 
; [:x :string] 
; [:y :int]]

(m/validate Merged {:x "kikka", :y 6})
; => true
```