### PR TITLE
Add JSON Schema conversion for `:=`

### DIFF
--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -74,7 +74,7 @@
 (defmethod accept :>= [_ _ [value] _] {:type "number" :format "double" :minimum value})
 (defmethod accept :< [_ _ [value] _] {:type "number" :format "double" :exclusiveMaximum value})
 (defmethod accept :<= [_ _ [value] _] {:type "number" :format "double" :maximum value})
-(defmethod accept := [_ _ _ _] {})
+(defmethod accept := [_ _ [value] _] {:const value})
 (defmethod accept :not= [_ _ _ _] {})
 
 (defmethod accept :and [_ _ children _] {:allOf children})

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -14,6 +14,7 @@
    [[:>= 6] {:type "number", :format "double", :minimum 6}]
    [[:< 6] {:type "number", :format "double", :exclusiveMaximum 6}]
    [[:<= 6] {:type "number", :format "double", :maximum 6}]
+   [[:= "x"] {:const "x"}]
    ;; base
    [[:and int? pos-int?] {:allOf [{:type "integer", :format "int64"}
                                   {:type "integer", :format "int64" :minimum 1}]}]


### PR DESCRIPTION
See https://json-schema.org/understanding-json-schema/reference/generic.html#constant-values

`const` got added in JSON Schema version 6. I couldn't find the minimum version that malli supports and if depending on version 6+ is ok or not.