### PR TITLE
Fast schema creation

### DIFF
--- a/bin/node
+++ b/bin/node
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 echo 'Running CLJS test in Node with optimizations :none'
-clojure -A:test:cljs-test-runner -c '{:optimizations :none, :preloads [sci.core]}' "$@"
+clojure -M:test:cljs-test-runner -c '{:optimizations :none, :preloads [sci.core]}' "$@"
 
 echo 'Running CLJS test in Node with optimizations :advanced'
-clojure -A:test:cljs-test-runner -c '{:optimizations :advanced, :preloads [sci.core]}' "$@"
+clojure -M:test:cljs-test-runner -c '{:optimizations :advanced, :preloads [sci.core]}' "$@"

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -224,19 +224,21 @@
 ;; Protocol Cache
 ;;
 
-(let [extend (fn [this]
+(let [extend (fn [protocol this]
+               ;; cljs: class clojure.lang.PersistentList cannot be cast to class clojure.lang.Named
                #?(:clj (let [s? (satisfies? Schema this)
                              is? (satisfies? IntoSchema this)]
                          (extend-protocol Schemas (class this)
                            (-schema? [_] s?)
-                           (-into-schema? [_] is?)))))]
+                           (-into-schema? [_] is?))))
+               (satisfies? protocol this))]
   (extend-protocol Schemas
     nil
     (-schema? [_] false)
     (-into-schema? [_] false)
-    #?(:clj Object, :cljs object)
-    (-schema? [this] #?(:clj (extend this), :cljs (satisfies? Schema this)))
-    (-into-schema? [this] #?(:clj (extend this), :cljs (satisfies? IntoSchema this)))))
+    #?(:clj Object, :cljs default)
+    (-schema? [this] #?(:clj (extend Schema this)) (satisfies? Schema this))
+    (-into-schema? [this] #?(:clj (extend IntoSchema this)) (satisfies? IntoSchema this))))
 
 ;;
 ;; Schemas

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -9,6 +9,10 @@
 ;; protocols and records
 ;;
 
+(defprotocol Schemas
+  (-schema? [this])
+  (-into-schema? [this]))
+
 (defprotocol IntoSchema
   (-into-schema [this properties children options] "creates a new schema instance"))
 
@@ -215,6 +219,24 @@
       min (fn [x] (<= min x))
       (and max f) (fn [x] (<= (f x) max))
       max (fn [x] (<= x max)))))
+
+;;
+;; Protocol Cache
+;;
+
+(let [extend (fn [this]
+               #?(:clj (let [s? (satisfies? Schema this)
+                             is? (satisfies? IntoSchema this)]
+                         (extend-protocol Schemas (class this)
+                           (-schema? [_] s?)
+                           (-into-schema? [_] is?)))))]
+  (extend-protocol Schemas
+    nil
+    (-schema? [_] false)
+    (-into-schema? [_] false)
+    #?(:clj Object, :cljs object)
+    (-schema? [this] #?(:clj (extend this), :cljs (satisfies? Schema this)))
+    (-into-schema? [this] #?(:clj (extend this), :cljs (satisfies? IntoSchema this)))))
 
 ;;
 ;; Schemas
@@ -976,11 +998,11 @@
 
 (defn schema?
   "Checks if x is a Schema instance"
-  [x] (satisfies? Schema x))
+  [x] (-schema? x))
 
 (defn into-schema?
   "Checks if x is a IntoSchema instance"
-  [x] (satisfies? IntoSchema x))
+  [x] (-into-schema? x))
 
 (defn into-schema
   "Creates a Schema instance out of type, optional properties map and children"


### PR DESCRIPTION
Add a new protocol `Schemas` to enable Protocol cache for `satisfies?`. Makes schema-creation order of magnitude faster.

```clj
  ;; "Elapsed time: 10472.153783 msecs" =>  "Elapsed time: 524.153783 msecs"
  (time
    (prof/profile
      (dotimes [_ 50000]
        (m/validate [:map [:street :string]] {:street "hämeenkatu"}))))
```