### PR TITLE
Schemas know the IntoSchema that created it

### DIFF
--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1397,6 +1397,9 @@
 
 (deftest custom-simple-type-test
 
+  (testing "can be walked"
+    (is (m/walk Over6 (m/schema-walker identity))))
+
   (testing "with static type-properties"
     (let [over6 (m/schema [Over6 {:json-schema/example 42}])]
       (testing "form"


### PR DESCRIPTION
making `Schema` instances aware of the `IntoSchema` that created them. This makes schema utilities work with non-registered schemas too.

fixes this:

```clj
(def Over6
  (m/-simple-schema
    {:type :user/over6
     :pred #(and (int? %) (> % 6))
     :type-properties {:error/message "should be over 6"
                       :decode/string mt/-string->long
                       :json-schema/type "integer"
                       :json-schema/format "int64"
                       :json-schema/minimum 6
                       :gen/gen (gen/large-integer* {:min 7})}}))

(mu/closed-schema Over6)
; Execution error (ExceptionInfo) at malli.core/-fail! (core.cljc:79).
; :malli.core/invalid-schema {:schema :user/over6}
```