### PR TITLE
Regex schemas

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,6 +6,8 @@
                                lambdaisland/kaocha-junit-xml {:mvn/version "0.0-70"}
                                metosin/spec-tools {:mvn/version "0.10.3"}
                                metosin/schema-tools {:mvn/version "0.12.2"}
+                               minimallist/minimallist {:mvn/version "0.0.6"}
+                               net.cgrand/seqexp {:mvn/version "0.6.2"}
                                borkdude/sci {:git/url "https://github.com/borkdude/sci.git"
                                              :sha "b310358cd41f761d7bbd50227a36d1160938ce71"}
                                prismatic/schema {:mvn/version "1.1.12"}

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -267,7 +267,7 @@
 (defn -into-explainer-regex [x path]
   (if (satisfies? RegexSchema x)
     (-explainer-regex x path)
-    (re/explain-item (-explainer x path))))
+    (re/explain-item x (-explainer x path))))
 
 ;;
 ;; Protocol Cache
@@ -1061,12 +1061,12 @@
           (-validator [this]
             (let [automaton (re/compile (re/asm
                                           include (-regex this)
-                                          end nil))]
+                                          end this))]
               (fn [x] (and (sequential? x) (boolean (re/exec-recognizer automaton x))))))
           (-explainer [this path]
             (let [automaton (re/compile (re/asm
                                           include (-explainer-regex this path)
-                                          end nil))]
+                                          end this))]
               (fn [x in acc]
                 (if (sequential? x)
                   (if-some [errors (re/exec-explainer automaton path x in -error)]
@@ -1106,10 +1106,14 @@
           Schema
           (-type [_] type)
           (-validator [this]
-            (let [automaton (re/compile (-regex this))]
+            (let [automaton (re/compile (re/asm
+                                          include (-regex this)
+                                          end this))]
               (fn [x] (and (sequential? x) (boolean (re/exec-recognizer automaton x))))))
           (-explainer [this path]
-            (let [automaton (re/compile (-explainer-regex this path))]
+            (let [automaton (re/compile (re/asm
+                                          include (-explainer-regex this path)
+                                          end this))]
               (fn [x in acc]
                 (if (sequential? x)
                   (if-some [errors (re/exec-explainer automaton path x in -error)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1051,7 +1051,7 @@
   (let [automaton (re/compile (re/asm
                                 include (-regex schema)
                                 end schema))]
-    (fn [x] (and (sequential? x) (boolean (re/exec-recognizer automaton x))))))
+    (fn [x] (and (sequential? x) (re/exec-recognizer automaton x)))))
 
 (defn- regex-explainer [schema path]
   (let [automaton (re/compile (re/asm

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1490,7 +1490,7 @@
                                            [1 "a" :b 3]]
                                           [[1 "a" :b "3"]]]]
                          [[:cat int? [:cat int? int?]] [[[1 2 3]] [[1 [2 3]]]]]
-                         #_[[:cat int? [:schema [:cat int? int?]]] [[[1 [2 3]]] [[1 2 3]]]]]]
+                         [[:cat int? [:schema [:cat int? int?]]] [[[1 [2 3]]] [[1 2 3]]]]]]
   (println)
   (println (form s))
   (doseq [v pass]
@@ -1514,16 +1514,16 @@
   [1 [["sika" "pakkasella"] :tosi] 12])
 
 (validate
-  [:schema {:registry {"hiccup" [:alt*
-                                 [:node [:cat*
-                                         [:name keyword?]
-                                         [:props [:? [:map-of keyword? any?]]]
-                                         [:children [:* [:ref "hiccup"]]]]]
-                                 [:primitive [:alt*
-                                              [:nil nil?]
-                                              [:boolean boolean?]
-                                              [:number number?]
-                                              [:text string?]]]]}}
+  [:schema {:registry {"hiccup" [:or
+                                 [:cat*
+                                  [:name keyword?]
+                                  [:props [:? [:map-of keyword? any?]]]
+                                  [:children [:* [:ref "hiccup"]]]]
+                                 [:or
+                                  nil?
+                                  boolean?
+                                  number?
+                                  string?]]}}
    "hiccup"]
   [:div {:class [:foo :bar]}
    [:p "Hello, world of data"]])

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [eval type -deref deref -lookup -key])
   (:require [malli.sci :as ms]
             [malli.regex :as re]
+            [malli.regex.macros :as rem]
             [malli.registry :as mr]
             [clojure.string :as str])
   #?(:clj (:import (java.util.regex Pattern)
@@ -1048,13 +1049,13 @@
           (-set [this key value] (-set-assoc-children this key value)))))))
 
 (defn- regex-validator [schema]
-  (let [automaton (re/compile (re/asm
+  (let [automaton (re/compile (rem/asm
                                 include (-regex schema)
                                 end schema))]
     (fn [x] (and (sequential? x) (re/exec-recognizer automaton x)))))
 
 (defn- regex-explainer [schema path]
-  (let [automaton (re/compile (re/asm
+  (let [automaton (re/compile (rem/asm
                                 include (-explainer-regex schema path)
                                 end schema))]
     (fn [x in acc]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -253,15 +253,14 @@
       max (fn [x] (<= x max)))))
 
 (defn -into-regex [x]
-  (println "-into-regex" x)
   (cond
     (satisfies? RegexSchema x) (-regex x)
     (= :ref (-type x)) (re/lazy (fn []
                                   (prn "lazy!" (-form x))
                                   (if (false? (:inlined (-properties x)))
-                                    (re/fn (-validator x))
+                                    (re/is (-validator x))
                                     (-into-regex (-deref x)))))
-    :else (re/fn (-validator x))))
+    :else (re/is (-validator x))))
 
 ;;
 ;; Protocol Cache

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [eval type -deref deref -lookup -key])
   (:require [malli.sci :as ms]
             [malli.regex :as re]
+            [malli.regex.compiler :as rec]
             [malli.regex.macros :as rem]
             [malli.registry :as mr]
             [clojure.string :as str])
@@ -1049,15 +1050,15 @@
           (-set [this key value] (-set-assoc-children this key value)))))))
 
 (defn- regex-validator [schema]
-  (let [automaton (re/compile (rem/asm
-                                include (-regex schema)
-                                end schema))]
+  (let [automaton (rec/compile (rem/asm
+                                 include (-regex schema)
+                                 end schema))]
     (fn [x] (and (sequential? x) (re/exec-recognizer automaton x)))))
 
 (defn- regex-explainer [schema path]
-  (let [automaton (re/compile (rem/asm
-                                include (-explainer-regex schema path)
-                                end schema))]
+  (let [automaton (rec/compile (rem/asm
+                                 include (-explainer-regex schema path)
+                                 end schema))]
     (fn [x in acc]
       (if (sequential? x)
         (if-some [errors (re/exec-explainer automaton path x in -error)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,11 +1,11 @@
 (ns malli.core
   (:refer-clojure :exclude [eval type -deref deref -lookup -key])
+  #?(:cljs (:require-macros [malli.regex.macros :as rem]))
   (:require [malli.sci :as ms]
             [malli.regex :as re]
             [malli.regex.compiler :as rec]
-            [malli.regex.macros :as rem]
-            [malli.registry :as mr]
-            [clojure.string :as str])
+            #?(:clj [malli.regex.macros :as rem])
+            [malli.registry :as mr])
   #?(:clj (:import (java.util.regex Pattern)
                    (clojure.lang IDeref MapEntry))))
 
@@ -131,9 +131,6 @@
      #(loop [ret ((first fs) %), fs (next fs)] (if fs (recur ((first fs) ret) (next fs)) ret)))))
 
 (defn -update [m k f] (assoc m k (f (get m k))))
-
-(defn -lazy [ref options]
-  (-into-schema (-ref-schema {:lazy true}) nil [ref] options))
 
 (defn -inner-indexed [walker path children options]
   (mapv (fn [[i c]] (-inner walker c (conj path i) options)) (map-indexed vector children)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1059,10 +1059,14 @@
           Schema
           (-type [_] type)
           (-validator [this]
-            (let [automaton (re/compile (-regex this))]
+            (let [automaton (re/compile (re/asm
+                                          include (-regex this)
+                                          end nil))]
               (fn [x] (and (sequential? x) (boolean (re/exec-recognizer automaton x))))))
           (-explainer [this path]
-            (let [automaton (re/compile (-explainer-regex this path))]
+            (let [automaton (re/compile (re/asm
+                                          include (-explainer-regex this path)
+                                          end nil))]
               (fn [x in acc]
                 (if (sequential? x)
                   (if-some [errors (re/exec-explainer automaton path x in -error)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1079,7 +1079,7 @@
     (if (= method :encode)
       {:enter (fn [coll]
                 (let [coll (enter-this coll)
-                      ts (re/exec-transformer-assignment automaton coll)]
+                      ts (re/exec-encoder-assignment automaton coll)]
                   (if ts
                     [(map (fn [{:keys [enter]} v] (if enter (enter v) v)) ts coll) ts]
                     [coll])))
@@ -1088,14 +1088,8 @@
                               (map (fn [{:keys [leave]} v] (if leave (leave v) v)) ts coll)
                               coll)))}
       {:enter (fn [coll]
-                (let [coll (enter-this coll)
-                      vts (re/exec-transformer-assignment automaton coll)]
-                  (if vts
-                    ;; OPTIMIZE:
-                    (let [[vs ts] (reduce (fn [[vs ts] [v t]] [(conj! vs v) (conj! ts t)])
-                                          [(transient []) (transient [])] vts)]
-                      [(persistent! vs) (persistent! ts)])
-                    [coll])))
+                (let [coll (enter-this coll)]
+                  (or (re/exec-decoder-assignment automaton coll) [coll])))
        :leave (fn [[coll ts]]
                 (leave-this (if ts
                               (map (fn [{:keys [leave]} v] (if leave (leave v) v)) ts coll)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -255,6 +255,7 @@
 (defn -into-regex [x]
   (cond
     (satisfies? RegexSchema x) (-regex x)
+    #_#_
     (= :ref (-type x)) (re/lazy (fn []
                                   (prn "lazy!" (-form x))
                                   (if (false? (:inlined (-properties x)))
@@ -1453,109 +1454,112 @@
 
 (defn << [success & ss]
   (str (if success "\u001B[32m" "\u001B[31m") (str/join " " ss) "\u001B[0m"))
+#_(
+   (defn << [success & ss]
+     (str (if success "\u001B[32m" "\u001B[31m") (str/join " " ss) "\u001B[0m"))
 
-(doseq [[s [pass fail]] [[[:+ int?] [[[1] [1 2 3]] [[] ["1"]]]]
-                         [[:* int?] [[[1] [1 2 3] []] [["1"]]]]
-                         [[:repeat int?] [[[1] [1 2 3] []] [["1"]]]]
-                         [[:repeat {:min 0} int?] [[[1] [1 2 3] []] [["1"]]]]
-                         [[:repeat {:min 1} int?] [[[1] [1 2 3]] [[] ["1"]]]]
-                         [[:repeat {:min 1, :max 2} int?] [[[1] [1 2]] [[1 2 3] [] ["1"]]]]
-                         [[:cat int? boolean?] [[[1 true]] [[1] ["1" true]]]]
-                         [[:cat* [:int int?] [:bool boolean?]] [[[1 true]] [[1] ["1" true]]]]
-                         [[:alt int? boolean?] [[[1] [true]] [[] ["1"] [1 "2"]]]]
-                         [[:alt* [:int int?] [:int boolean?]] [[[1] [true]] [[] ["1"] [1 "2"]]]]
-                         [[:cat
-                           int?
-                           [:alt
-                            string?
-                            keyword?
-                            [:cat
-                             string?
-                             keyword?]]
-                           int?] [[[1 "a" 3]
-                                   [1 :b 3]
-                                   [1 "a" :b 3]]
-                                  [[1 "a" :b "3"]]]]
-                         [[:cat*
-                           [:head int?]
-                           [:body [:alt*
-                                   [:option1 string?]
-                                   [:option2 keyword?]
-                                   [:option3 [:cat*
-                                              [:s string?]
-                                              [:k keyword?]]]]]
-                           [:tail int?]] [[[1 "a" 3]
-                                           [1 :b 3]
-                                           [1 "a" :b 3]]
-                                          [[1 "a" :b "3"]]]]
-                         [[:cat int? [:cat int? int?]] [[[1 2 3]] [[1 [2 3]]]]]
-                         [[:cat int? [:schema [:cat int? int?]]] [[[1 [2 3]]] [[1 2 3]]]]]]
-  (println)
-  (println (form s))
-  (doseq [v pass]
-    (let [ok (validate s v)]
-      (println (<< ok "+" (if ok "+" "-") v))))
-  (doseq [v fail]
-    (let [ok (not (validate s v))]
-      (println (<< ok "-" (if ok "-" "+") v)))))
+   (doseq [[s [pass fail]] [[[:+ int?] [[[1] [1 2 3]] [[] ["1"]]]]
+                            [[:* int?] [[[1] [1 2 3] []] [["1"]]]]
+                            [[:repeat int?] [[[1] [1 2 3] []] [["1"]]]]
+                            [[:repeat {:min 0} int?] [[[1] [1 2 3] []] [["1"]]]]
+                            [[:repeat {:min 1} int?] [[[1] [1 2 3]] [[] ["1"]]]]
+                            [[:repeat {:min 1, :max 2} int?] [[[1] [1 2]] [[1 2 3] [] ["1"]]]]
+                            [[:cat int? boolean?] [[[1 true]] [[1] ["1" true]]]]
+                            [[:cat* [:int int?] [:bool boolean?]] [[[1 true]] [[1] ["1" true]]]]
+                            [[:alt int? boolean?] [[[1] [true]] [[] ["1"] [1 "2"]]]]
+                            [[:alt* [:int int?] [:int boolean?]] [[[1] [true]] [[] ["1"] [1 "2"]]]]
+                            [[:cat
+                              int?
+                              [:alt
+                               string?
+                               keyword?
+                               [:cat
+                                string?
+                                keyword?]]
+                              int?] [[[1 "a" 3]
+                                      [1 :b 3]
+                                      [1 "a" :b 3]]
+                                     [[1 "a" :b "3"]]]]
+                            [[:cat*
+                              [:head int?]
+                              [:body [:alt*
+                                      [:option1 string?]
+                                      [:option2 keyword?]
+                                      [:option3 [:cat*
+                                                 [:s string?]
+                                                 [:k keyword?]]]]]
+                              [:tail int?]] [[[1 "a" 3]
+                                              [1 :b 3]
+                                              [1 "a" :b 3]]
+                                             [[1 "a" :b "3"]]]]
+                            [[:cat int? [:cat int? int?]] [[[1 2 3]] [[1 [2 3]]]]]
+                            [[:cat int? [:schema [:cat int? int?]]] [[[1 [2 3]]] [[1 2 3]]]]]]
+     (println)
+     (println (form s))
+     (doseq [v pass]
+       (let [ok (validate s v)]
+         (println (<< ok "+" (if ok "+" "-") v))))
+     (doseq [v fail]
+       (let [ok (not (validate s v))]
+         (println (<< ok "-" (if ok "-" "+") v)))))
 
-(validate
-  [:cat*
-   [:head int?]
-   [:body [:alt*
-           [:option1 string?]
-           [:option2 keyword?]
-           [:option3 [:schema
-                      [:cat*
-                       [:s [:tuple string? string?]]
-                       [:k keyword?]]]]]]
-   [:tail int?]]
-  [1 [["sika" "pakkasella"] :tosi] 12])
+   (validate
+     [:cat*
+      [:head int?]
+      [:body [:alt*
+              [:option1 string?]
+              [:option2 keyword?]
+              [:option3 [:schema
+                         [:cat*
+                          [:s [:tuple string? string?]]
+                          [:k keyword?]]]]]]
+      [:tail int?]]
+     [1 [["sika" "pakkasella"] :tosi] 12])
 
-(validate
-  [:schema {:registry {"hiccup" [:or
-                                 [:cat*
-                                  [:name keyword?]
-                                  [:props [:? [:map-of keyword? any?]]]
-                                  [:children [:* [:ref "hiccup"]]]]
-                                 [:or
-                                  nil?
-                                  boolean?
-                                  number?
-                                  string?]]}}
-   "hiccup"]
-  [:div {:class [:foo :bar]}
-   [:p "Hello, world of data"]])
-
-
-(validate
-  [:schema
-   [:alt*
-    [:node [:cat*
-            [:name keyword?]
-            [:props [:? [:map-of keyword? any?]]]
-            [:children [:* string? #_[:ref "hiccup"]]]]]]]
-  [:p {:a 1} "Hello, world of data"])
-
-(validate
-  [:alt
-   [:cat*
-    [:name keyword?]
-    [:props [:? [:map-of keyword? any?]]]
-    [:children [:* any?]]]]
-  [:div {:class "warning"} 123])
+   (validate
+     [:schema {:registry {"hiccup" [:or
+                                    [:cat*
+                                     [:name keyword?]
+                                     [:props [:? [:map-of keyword? any?]]]
+                                     [:children [:* [:ref "hiccup"]]]]
+                                    [:or
+                                     nil?
+                                     boolean?
+                                     number?
+                                     string?]]}}
+      "hiccup"]
+     [:div {:class [:foo :bar]}
+      [:p "Hello, world of data"]])
 
 
-(validate
-  [:alt*
-   [:node [:alt*
-           [:name keyword?]
-           [:props [:? [:map-of keyword? any?]]]
-           [:children [:* any? #_[:ref "hiccup"]]]]]
-   [:primitive [:alt*
-                [:nil nil?]
-                [:boolean boolean?]
-                [:number number?]
-                [:text string?]]]]
-  [:div {:class [:foo :bar]}
-   nil #_[:p "Hello, world of data"]])
+   (validate
+     [:schema
+      [:alt*
+       [:node [:cat*
+               [:name keyword?]
+               [:props [:? [:map-of keyword? any?]]]
+               [:children [:* string? #_[:ref "hiccup"]]]]]]]
+     [:p {:a 1} "Hello, world of data"])
+
+   (validate
+     [:alt
+      [:cat*
+       [:name keyword?]
+       [:props [:? [:map-of keyword? any?]]]
+       [:children [:* any?]]]]
+     [:div {:class "warning"} 123])
+
+
+   (validate
+     [:alt*
+      [:node [:alt*
+              [:name keyword?]
+              [:props [:? [:map-of keyword? any?]]]
+              [:children [:* any? #_[:ref "hiccup"]]]]]
+      [:primitive [:alt*
+                   [:nil nil?]
+                   [:boolean boolean?]
+                   [:number number?]
+                   [:text string?]]]]
+     [:div {:class [:foo :bar]}
+      nil #_[:p "Hello, world of data"]]))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1075,6 +1075,7 @@
         (reify
           Schema
           (-type [_] type)
+          (-type-properties [_])
           (-validator [this] (regex-validator this))
           (-explainer [this path] (regex-explainer this path))
           (-transformer [this transformer method options]
@@ -1109,6 +1110,7 @@
         (reify
           Schema
           (-type [_] type)
+          (-type-properties [_])
           (-validator [this] (regex-validator this))
           (-explainer [this path] (regex-explainer this path))
           (-transformer [this transformer method options]
@@ -1417,6 +1419,7 @@
   {:+ (-sequence-schema {:type :+, :re (fn [_ [child]] (re/+ child))})
    :* (-sequence-schema {:type :*, :re (fn [_ [child]] (re/* child))})
    :? (-sequence-schema {:type :?, :re (fn [_ [child]] (re/? child))})
+   ;; FIXME: ##Inf blows up:
    :repeat (-sequence-schema {:type :repeat, :re (fn [{:keys [min max] :or {min 0, max ##Inf}} [child]]
                                                    (re/repeat min max child))})
    :alt (-sequence-schema {:type :alt, :re (fn [_ children] (apply re/alt children))})

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,9 +1,13 @@
 (ns malli.core
   (:refer-clojure :exclude [eval type -deref deref -lookup -key])
   (:require [malli.sci :as ms]
-            [malli.registry :as mr])
+            [malli.regex :as re]
+            [malli.registry :as mr]
+            [clojure.string :as str])
   #?(:clj (:import (java.util.regex Pattern)
                    (clojure.lang IDeref MapEntry))))
+
+(declare ->regex)
 
 ;;
 ;; protocols and records
@@ -47,6 +51,9 @@
 (defprotocol RefSchema
   (-ref [this] "returns the reference name")
   (-deref [this] "returns the referenced schema"))
+
+(defprotocol RegexSchema
+  (-regex [this] "returns the regex"))
 
 (defprotocol Walker
   (-accept [this schema path options])
@@ -121,6 +128,9 @@
      #(loop [ret ((first fs) %), fs (next fs)] (if fs (recur ((first fs) ret) (next fs)) ret)))))
 
 (defn -update [m k f] (assoc m k (f (get m k))))
+
+(defn -lazy [ref options]
+  (-into-schema (-ref-schema {:lazy true}) nil [ref] options))
 
 (defn -inner-indexed [walker path children options]
   (mapv (fn [[i c]] (-inner walker c (conj path i) options)) (map-indexed vector children)))
@@ -241,6 +251,17 @@
       min (fn [x] (<= min x))
       (and max f) (fn [x] (<= (f x) max))
       max (fn [x] (<= x max)))))
+
+(defn -into-regex [x]
+  (println "-into-regex" x)
+  (cond
+    (satisfies? RegexSchema x) (-regex x)
+    (= :ref (-type x)) (re/lazy (fn []
+                                  (prn "lazy!" (-form x))
+                                  (if (false? (:inlined (-properties x)))
+                                    (re/fn (-validator x))
+                                    (-into-regex (-deref x)))))
+    :else (re/fn (-validator x))))
 
 ;;
 ;; Protocol Cache
@@ -1020,6 +1041,72 @@
           (-get [_ key default] (get children key default))
           (-set [this key value] (-set-assoc-children this key value)))))))
 
+(defn -sequence-schema [{:keys [type re]}]
+  ^{:type ::into-schema}
+  (reify IntoSchema
+    (-into-schema [_ properties children options]
+      ;(-check-children! type properties children {:min 1, :max 1})
+      (let [[child :as children] (map #(schema % options) children)
+            form (-create-form type properties (mapv -form children))]
+        ^{:type ::schema}
+        (reify
+          Schema
+          (-type [_] type)
+          (-validator [this]
+            (re/validator (-regex this)))
+          (-explainer [_ path] (-explainer child path))
+          (-transformer [this transformer method options]
+            (-parent-children-transformer this children transformer method options))
+          (-walk [this walker path options]
+            (if (-accept walker this path options)
+              (-outer walker this path [(-inner walker child path options)] options)))
+          (-properties [_] properties)
+          (-options [_] options)
+          (-children [_] children)
+          (-form [_] form)
+          LensSchema
+          (-keep [_])
+          (-get [_ key default] (if (= key 0) child default))
+          (-set [this key value] (if (= key 0)
+                                   (into-schema type properties [value])
+                                   (-fail! ::index-out-of-bounds {:schema this, :key key})))
+          RegexSchema
+          (-regex [_]
+            (re properties (map -into-regex children))))))))
+
+(defn -sequence-entry-schema [{:keys [type re]}]
+  ^{:type ::into-schema}
+  (reify IntoSchema
+    (-into-schema [_ properties children options]
+      ;(-check-children! type properties children {:min 1, :max 1})
+      (let [[child :as children] (mapv (fn [[k c]] [k (schema c options)]) children)
+            form (-create-form type properties (mapv (fn [[k s]] [k (-form s)]) children))]
+        ^{:type ::schema}
+        (reify
+          Schema
+          (-type [_] type)
+          (-validator [this]
+            (re/validator (-regex this)))
+          (-explainer [_ path] (-explainer child path))
+          (-transformer [this transformer method options]
+            (-parent-children-transformer this children transformer method options))
+          (-walk [this walker path options]
+            (if (-accept walker this path options)
+              (-outer walker this path [(-inner walker child path options)] options)))
+          (-properties [_] properties)
+          (-options [_] options)
+          (-children [_] children)
+          (-form [_] form)
+          LensSchema
+          (-keep [_])
+          (-get [_ key default] (if (= key 0) child default))
+          (-set [this key value] (if (= key 0)
+                                   (into-schema type properties [value])
+                                   (-fail! ::index-out-of-bounds {:schema this, :key key})))
+          RegexSchema
+          (-regex [_]
+            (re properties (map (fn [[k s]] [k (-into-regex s)]) children))))))))
+
 ;;
 ;; public api
 ;;
@@ -1299,6 +1386,17 @@
    :qualified-symbol (-qualified-symbol-schema)
    :uuid (-uuid-schema)})
 
+(defn sequence-schemas []
+  {:+ (-sequence-schema {:type :+, :re (fn [_ [child]] (re/+ child))})
+   :* (-sequence-schema {:type :*, :re (fn [_ [child]] (re/* child))})
+   :? (-sequence-schema {:type :?, :re (fn [_ [child]] (re/? child))})
+   :repeat (-sequence-schema {:type :repeat, :re (fn [{:keys [min max] :or {min 0, max ##Inf}} [child]]
+                                                   (re/repeat min max child))})
+   :alt (-sequence-schema {:type :alt, :re (fn [_ children] (apply re/alt children))})
+   :cat (-sequence-schema {:type :cat, :re (fn [_ children] (apply re/cat children))})
+   :cat* (-sequence-entry-schema {:type :cat*, :re (fn [_ children] (apply re/cat children))})
+   :alt* (-sequence-entry-schema {:type :alt*, :re (fn [_ children] (apply re/alt children))})})
+
 (defn base-schemas []
   {:and (-and-schema)
    :or (-or-schema)
@@ -1319,7 +1417,7 @@
    ::schema (-schema-schema {:raw true})})
 
 (defn default-schemas []
-  (merge (predicate-schemas) (class-schemas) (comparator-schemas) (type-schemas) (base-schemas)))
+  (merge (predicate-schemas) (class-schemas) (comparator-schemas) (type-schemas) (sequence-schemas) (base-schemas)))
 
 (def default-registry
   (mr/registry (cond (identical? mr/type "default") (default-schemas)
@@ -1353,3 +1451,112 @@
                :meta ~(meta name)
                :ns ns#
                :name ~name'}))))
+
+(defn << [success & ss]
+  (str (if success "\u001B[32m" "\u001B[31m") (str/join " " ss) "\u001B[0m"))
+
+(doseq [[s [pass fail]] [[[:+ int?] [[[1] [1 2 3]] [[] ["1"]]]]
+                         [[:* int?] [[[1] [1 2 3] []] [["1"]]]]
+                         [[:repeat int?] [[[1] [1 2 3] []] [["1"]]]]
+                         [[:repeat {:min 0} int?] [[[1] [1 2 3] []] [["1"]]]]
+                         [[:repeat {:min 1} int?] [[[1] [1 2 3]] [[] ["1"]]]]
+                         [[:repeat {:min 1, :max 2} int?] [[[1] [1 2]] [[1 2 3] [] ["1"]]]]
+                         [[:cat int? boolean?] [[[1 true]] [[1] ["1" true]]]]
+                         [[:cat* [:int int?] [:bool boolean?]] [[[1 true]] [[1] ["1" true]]]]
+                         [[:alt int? boolean?] [[[1] [true]] [[] ["1"] [1 "2"]]]]
+                         [[:alt* [:int int?] [:int boolean?]] [[[1] [true]] [[] ["1"] [1 "2"]]]]
+                         [[:cat
+                           int?
+                           [:alt
+                            string?
+                            keyword?
+                            [:cat
+                             string?
+                             keyword?]]
+                           int?] [[[1 "a" 3]
+                                   [1 :b 3]
+                                   [1 "a" :b 3]]
+                                  [[1 "a" :b "3"]]]]
+                         [[:cat*
+                           [:head int?]
+                           [:body [:alt*
+                                   [:option1 string?]
+                                   [:option2 keyword?]
+                                   [:option3 [:cat*
+                                              [:s string?]
+                                              [:k keyword?]]]]]
+                           [:tail int?]] [[[1 "a" 3]
+                                           [1 :b 3]
+                                           [1 "a" :b 3]]
+                                          [[1 "a" :b "3"]]]]
+                         [[:cat int? [:cat int? int?]] [[[1 2 3]] [[1 [2 3]]]]]
+                         #_[[:cat int? [:schema [:cat int? int?]]] [[[1 [2 3]]] [[1 2 3]]]]]]
+  (println)
+  (println (form s))
+  (doseq [v pass]
+    (let [ok (validate s v)]
+      (println (<< ok "+" (if ok "+" "-") v))))
+  (doseq [v fail]
+    (let [ok (not (validate s v))]
+      (println (<< ok "-" (if ok "-" "+") v)))))
+
+(validate
+  [:cat*
+   [:head int?]
+   [:body [:alt*
+           [:option1 string?]
+           [:option2 keyword?]
+           [:option3 [:schema
+                      [:cat*
+                       [:s [:tuple string? string?]]
+                       [:k keyword?]]]]]]
+   [:tail int?]]
+  [1 [["sika" "pakkasella"] :tosi] 12])
+
+(validate
+  [:schema {:registry {"hiccup" [:alt*
+                                 [:node [:cat*
+                                         [:name keyword?]
+                                         [:props [:? [:map-of keyword? any?]]]
+                                         [:children [:* [:ref "hiccup"]]]]]
+                                 [:primitive [:alt*
+                                              [:nil nil?]
+                                              [:boolean boolean?]
+                                              [:number number?]
+                                              [:text string?]]]]}}
+   "hiccup"]
+  [:div {:class [:foo :bar]}
+   [:p "Hello, world of data"]])
+
+
+(validate
+  [:schema
+   [:alt*
+    [:node [:cat*
+            [:name keyword?]
+            [:props [:? [:map-of keyword? any?]]]
+            [:children [:* string? #_[:ref "hiccup"]]]]]]]
+  [:p {:a 1} "Hello, world of data"])
+
+(validate
+  [:alt
+   [:cat*
+    [:name keyword?]
+    [:props [:? [:map-of keyword? any?]]]
+    [:children [:* any?]]]]
+  [:div {:class "warning"} 123])
+
+
+(validate
+  [:alt*
+   [:node [:alt*
+           [:name keyword?]
+           [:props [:? [:map-of keyword? any?]]]
+           [:children [:* any? #_[:ref "hiccup"]]]]]
+   [:primitive [:alt*
+                [:nil nil?]
+                [:boolean boolean?]
+                [:number number?]
+                [:text string?]]]]
+  [:div {:class [:foo :bar]}
+   nil #_[:p "Hello, world of data"]])

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -265,7 +265,9 @@
     :else (re/is (-validator x))))
 
 (defn -into-explainer-regex [x path]
-  (if (satisfies? RegexSchema x) (-explainer-regex x path) (re/is (-explainer x path))))
+  (if (satisfies? RegexSchema x)
+    (-explainer-regex x path)
+    (re/explain-item (-explainer x path))))
 
 ;;
 ;; Protocol Cache

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1077,6 +1077,7 @@
           (-type-properties [_])
           (-validator [this] (regex-validator this))
           (-explainer [this path] (regex-explainer this path))
+          ;; FIXME:
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options]
@@ -1112,6 +1113,7 @@
           (-type-properties [_])
           (-validator [this] (regex-validator this))
           (-explainer [this path] (regex-explainer this path))
+          ;; FIXME:
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options]
@@ -1462,6 +1464,7 @@
    :cat (-sequence-schema {:type :cat, :re (fn [_ children] (apply re/cat children))})
    :cat* (-sequence-entry-schema {:type :cat*, :re (fn [_ children] (apply re/cat children))})
    :alt* (-sequence-entry-schema {:type :alt*, :re (fn [_ children] (apply re/alt children))})
+
    :nested (-nested-schema)})
 
 (defn base-schemas []

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -213,6 +213,8 @@
 (defmethod -schema-generator :alt [schema options] (-alt-gen schema options))
 (defmethod -schema-generator :alt* [schema options] (-alt-gen schema options))
 
+(defmethod -schema-generator :nested [schema options] (generator (first (m/children schema options)) options))
+
 (defn- -create [schema options]
   (let [{:gen/keys [gen fmap elements]} (merge (m/type-properties schema) (m/properties schema))
         gen (or gen (when-not elements (if (satisfies? Generator schema) (-generator schema options) (-schema-generator schema options))))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -1,0 +1,163 @@
+(ns malli.regex
+  (:refer-clojure :exclude [fn cat repeat ? * +]))
+
+(defprotocol RegexSchema
+  (-matcher [_]))
+
+(defprotocol Match
+  (-end [_])
+  (-result [_])
+  (-continue [_]))
+
+(defn -tagged [k v]
+  #?(:clj (clojure.lang.MapEntry. k v), :cljs (MapEntry. tag ret nil)))
+
+(defn -parse [rs]
+  (reduce
+    (clojure.core/fn [[ms im] [i ?kr]]
+      (let [[k r] (if (vector? ?kr) [(first ?kr) (second ?kr)] [nil ?kr])]
+        [(conj ms (-matcher r)) (cond-> im k (assoc i k))]))
+    [[]] (->> rs (vec) (map-indexed vector))))
+
+(defn -static [result end]
+  #_(prn "-static" result end)
+  (reify Match
+    (-end [_] end)
+    (-result [_] result)
+    (-continue [_])))
+
+(defn fn [f]
+  (reify RegexSchema
+    (-matcher [_]
+      (clojure.core/fn [data size start]
+        #_(prn "FN:" data start f)
+        (if (< -1 start size)
+          (let [x (nth data start)]
+            (if (f x) (-static x start))))))))
+
+(defn lazy [f]
+  (reify RegexSchema
+    (-matcher [_]
+      (clojure.core/fn [data size start]
+        ((-matcher (f)) data size start)))))
+
+(defn alt [& rs]
+  (let [[matchers i->k] (-parse rs)
+        matchers-size (count matchers)
+        -key (or i->k identity)
+        -value (clojure.core/fn -value [res i f]
+                 (reify Match
+                   (-end [_] (-end res))
+                   (-result [_] (-tagged (-key i) (-result res)))
+                   (-continue [_] (f (inc i)))))
+        -continue (clojure.core/fn -continue [data size start i]
+                    (loop [i i]
+                      (if-not (= i matchers-size)
+                        (let [m (nth matchers i)]
+                          (or (some-> (m data size start) (-value i (partial -continue data size start)))
+                              (recur (inc i)))))))]
+    (reify RegexSchema
+      (-matcher [_] (clojure.core/fn [data size start] (-continue data size start 0))))))
+
+(defn cat [& rs]
+  (let [[matchers i->k] (-parse rs)
+        -result (if i->k #(->> % (map (clojure.core/fn [[k v]] [(i->k k) (-result v)])) (into {}))
+                         #(->> % (mapv (comp -result val))))
+        matchers-size (count matchers)
+        -value (clojure.core/fn -value [m i]
+                 (reify Match
+                   (-end [_] (-end (m i)))
+                   (-result [_] (-result m))
+                   (-continue [_]
+                     (loop [si i]
+                       (when-not (neg? si)
+                         (if-let [sr (some-> si m -continue)]
+                           (-value (assoc m si sr) i)
+                           (recur (dec si))))))))]
+    (reify RegexSchema
+      (-matcher [_]
+        (clojure.core/fn [data size start]
+          (loop [i 0, splits [start], results {}]
+            #_(prn "CAT:" (vals i->k) i splits results)
+            (cond
+              (neg? i) nil
+              (results i) (if-let [res (-continue (results i))]
+                            (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                            (recur (dec i) (pop splits) (dissoc results i)))
+              (>= i matchers-size) (-value results (dec i))
+              :else (do
+                      #_(prn "looking..." ((nth matchers i) data size (nth splits i)))
+                      (if-let [res ((nth matchers i) data size (nth splits i))]
+                        (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                        (if (pos? i) (recur (dec i) (pop splits) (dissoc results i))))))))))))
+
+(defn repeat [min max r]
+  (let [child-matcher (-matcher r)
+        -value (clojure.core/fn -value [v i]
+                 (reify Match
+                   (-end [_] (-end (v i)))
+                   (-result [_] (mapv -result v))
+                   (-continue [this]
+                     (loop [si i]
+                       (when-not (neg? si)
+                         (let [sr (some-> si v -continue)]
+                           (cond
+                             sr (-value (assoc v si sr) (dec i))
+                             (= i min 0) (-static [] (dec (-end this)))
+                             (>= i min) (-value (pop v) (dec i))
+                             :else (recur (dec si)))))))))]
+    (reify RegexSchema
+      (-matcher [_]
+        (clojure.core/fn [data size start]
+          (loop [i 0, splits [start], results []]
+            #_(prn "REP:" min max i data splits results)
+            (cond
+              (contains? results i) (if-let [res (-continue (results i))]
+                                      (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                                      (recur (dec i) (pop splits) (pop results)))
+              (>= i max) (-value results (dec i))
+              (and (>= i min) (= (last splits) size)) (if (zero? i) (-static results (dec size)) (-value results (dec i)))
+              (>= i 0) (do
+                         #_(prn "rep..." (nth splits i) (child-matcher data size (nth splits i)))
+                         (let [res (child-matcher data size (nth splits i))]
+                           (cond
+                             res (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                             ;(zero? i) nil
+                             (>= i min) (if (zero? i) (-static results (dec (nth splits i))) (-value results (dec i)))
+                             (pos? i) (recur (dec i) (pop splits) (if (contains? results i) (pop results) results))))))))))))
+
+
+(defn ? [r] (repeat 0 1 r))
+(defn * [r] (repeat 0 ##Inf r))
+(defn + [r] (repeat 1 ##Inf r))
+
+(defn validator [re]
+  (let [matcher (-matcher re)]
+    (clojure.core/fn [x]
+      (if (sequential? x)
+        (let [x (vec x), size (count x)]
+          (boolean (some-> (matcher x size 0) (-end) (= (dec size)))))))))
+
+(defn validate [re data] ((validator re) data))
+
+(defn parser [re]
+  (let [matcher (-matcher re)]
+    (clojure.core/fn [x]
+      (if (sequential? x)
+        (let [x (vec x)
+              size (count x)
+              result (matcher x size 0)]
+          (if (and result (= (-end result) (dec size)))
+            (-result result)))))))
+
+(defn parse [re data] ((parser re) data))
+
+(defn describer [re]
+  (let [matcher (-matcher re)]
+    (clojure.core/fn [x]
+      (let [x (vec x)]
+        (if-let [m (matcher x (count x) 0)]
+          {:result (-result m)
+           :rest (subvec x (inc (-end m)))})))))
+
+(defn describe [re data] ((describer re) data))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -174,9 +174,9 @@
   #{:label :jump :fork> :fork<})
 
 (def ^:private op->opcode
-  (zipmap (conj label-ops :pred :explain :save0 :save1) (range)))
+  (zipmap (conj label-ops :pred :explain :end :save0 :save1) (range)))
 
-(defmacro ^:private asm [& exprs]
+(defmacro asm [& exprs]
   (let [gen (gensym 'gen)
         exprs (partition 2 exprs)]
     `(let [~gen (memoize gensym)]
@@ -459,7 +459,7 @@
           save0 (recur pos buf state (inc pc) (save0 matches (aget args pc) pos))
           save1 (recur pos buf state (inc pc) (save1 matches (aget args pc) buf pos))
 
-          (pred explain) (fork! state pc matches)))
+          (pred explain end) (fork! state pc matches)))
 
       (= pc (alength opcodes)) (fork! state pc matches)
 
@@ -506,6 +506,10 @@
                             (recur (inc i) errors**))
                           (recur (inc i)
                                  (conj errors* (-error path in #_FIXME/arg arg nil ::end-of-input))))
+                end (if coll
+                      (recur (inc i)
+                             (conj errors* (-error path in #_FIXME/arg arg (first coll) ::input-remaining)))
+                      matches)
                 #_"add-thread! makes other opcodes impossible at this point"))
             matches))
         (do (set! errors errors*) nil))))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -261,7 +261,9 @@
     pred pred
     save1 anonymous))
 
-(defn explain-item [explainer] (asm explain explainer))
+(deftype ^:private Eczema [explain schema])
+
+(defn explain-item [schema explainer] (asm explain (Eczema. explainer schema)))
 
 (deftype ^:private CatFrame [children, ^long start]
   MatchFrame
@@ -500,15 +502,13 @@
                   in (conj in pos)]
               (opcode-case opcode
                 explain (if coll
-                          (let [errors** (arg (first coll) in errors*)]
+                          (let [errors** ((.-explain ^Eczema arg) (first coll) in errors*)]
                             (when (identical? errors** errors*)
                               (add-thread! self (inc pos) (conj buf (first coll)) state* (inc pc) matches))
                             (recur (inc i) errors**))
-                          (recur (inc i)
-                                 (conj errors* (-error path in #_FIXME/arg arg nil ::end-of-input))))
+                          (recur (inc i) (conj errors* (-error path in (.-schema ^Eczema arg) nil ::end-of-input))))
                 end (if coll
-                      (recur (inc i)
-                             (conj errors* (-error path in #_FIXME/arg arg (first coll) ::input-remaining)))
+                      (recur (inc i) (conj errors* (-error path in arg coll ::input-remaining)))
                       matches)
                 #_"add-thread! makes other opcodes impossible at this point"))
             matches))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -357,6 +357,11 @@
   APersistentVector
   (save0 [self _ _] self)
   (save1 [self _ _ _] self)
+  (fetch [self _ _] self)
+
+  MapEntry
+  (save0 [self _ _] self)
+  (save1 [self _ _ _] self)
   (fetch [self _ _] self))
 
 (defprotocol ^:private IVMState
@@ -439,7 +444,8 @@
                                      (first coll))]
                              (when ((.-validate arg) v)
                                (add-thread! self (inc pos) (conj buf (first coll)) state* (inc pc)
-                                            (conj matches [v (.-transformer arg)]))))) ; OPTIMIZE
+                                            (-tagged (conj (key matches) v)
+                                                     (conj (val matches) (.-transformer arg)))))))
                          (recur (inc i)))
                 end (if coll
                       (recur (inc i))
@@ -511,8 +517,11 @@
 (defn exec-explainer [automaton path coll in -error]
   (exec-automaton* automaton (->explanatory-vm automaton path in -error) coll sink-bank-fail))
 
-(defn exec-transformer-assignment [automaton coll]
+(defn exec-encoder-assignment [automaton coll]
   (exec-automaton* automaton (->vm automaton) coll []))
+
+(defn exec-decoder-assignment [automaton coll]
+  (exec-automaton* automaton (->vm automaton) coll (-tagged [] [])))
 
 (defn exec-tree-automaton [automaton coll]
   (exec-automaton* automaton (->vm automaton) coll (list (start-frame 0))))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -441,3 +441,13 @@
   (exec-automaton* automaton coll [(TreeStackFrame. {} 0)]))
 
 (defn exec-tree [re coll] (exec-tree-automaton (compile re) coll))
+
+;;;; Malli APIs
+
+(defn validator [re]
+  (let [automaton (compile re)]
+    (fn [x]
+      (boolean (and (sequential? x)
+                    (some-> (exec-automaton automaton x) :rest empty?))))))
+
+(defn validate [re data] ((validator re) data))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -3,7 +3,6 @@
   #?(:clj (:import [clojure.lang MapEntry]
                    [java.util Arrays])))
 
-;;; FIXME: Check that entire seq is consumed
 ;;; TODO: clojure.spec.alpha/spec equivalent
 
 #_(

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -543,7 +543,7 @@
             (.final_errors vm)))))))
 
 (defn exec-recognizer [automaton coll]
-  (exec-automaton* automaton (->vm automaton) coll sink-bank-succ))
+  (boolean (exec-automaton* automaton (->vm automaton) coll sink-bank-succ)))
 
 (defn exec-explainer [automaton path coll in -error]
   (exec-automaton* automaton (->explanatory-vm automaton path in -error) coll sink-bank-fail))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -1,163 +1,443 @@
 (ns malli.regex
-  (:refer-clojure :exclude [fn cat repeat ? * +]))
+  (:refer-clojure :exclude #_[fn cat repeat ? * +] [+ * repeat cat compile])
+  #?(:clj (:import [java.util Arrays])))
 
-(defprotocol RegexSchema
-  (-matcher [_]))
+#_(
+   (defprotocol RegexSchema
+     (-matcher [_]))
 
-(defprotocol Match
-  (-end [_])
-  (-result [_])
-  (-continue [_]))
+   (defprotocol Match
+     (-end [_])
+     (-result [_])
+     (-continue [_]))
 
-(defn -tagged [k v]
-  #?(:clj (clojure.lang.MapEntry. k v), :cljs (MapEntry. tag ret nil)))
+   (defn -tagged [k v]
+     #?(:clj (clojure.lang.MapEntry. k v), :cljs (MapEntry. tag ret nil)))
 
-(defn -parse [rs]
-  (reduce
-    (clojure.core/fn [[ms im] [i ?kr]]
-      (let [[k r] (if (vector? ?kr) [(first ?kr) (second ?kr)] [nil ?kr])]
-        [(conj ms (-matcher r)) (cond-> im k (assoc i k))]))
-    [[]] (->> rs (vec) (map-indexed vector))))
+   (defn -parse [rs]
+     (reduce
+       (clojure.core/fn [[ms im] [i ?kr]]
+         (let [[k r] (if (vector? ?kr) [(first ?kr) (second ?kr)] [nil ?kr])]
+           [(conj ms (-matcher r)) (cond-> im k (assoc i k))]))
+       [[]] (->> rs (vec) (map-indexed vector))))
 
-(defn -static [result end]
-  #_(prn "-static" result end)
-  (reify Match
-    (-end [_] end)
-    (-result [_] result)
-    (-continue [_])))
+   (defn -static [result end]
+     #_(prn "-static" result end)
+     (reify Match
+       (-end [_] end)
+       (-result [_] result)
+       (-continue [_])))
 
-(defn fn [f]
-  (reify RegexSchema
-    (-matcher [_]
-      (clojure.core/fn [data size start]
-        #_(prn "FN:" data start f)
-        (if (< -1 start size)
-          (let [x (nth data start)]
-            (if (f x) (-static x start))))))))
+   (defn fn [f]
+     (reify RegexSchema
+       (-matcher [_]
+         (clojure.core/fn [data size start]
+           #_(prn "FN:" data start f)
+           (if (< -1 start size)
+             (let [x (nth data start)]
+               (if (f x) (-static x start))))))))
 
-(defn lazy [f]
-  (reify RegexSchema
-    (-matcher [_]
-      (clojure.core/fn [data size start]
-        ((-matcher (f)) data size start)))))
+   (defn lazy [f]
+     (reify RegexSchema
+       (-matcher [_]
+         (clojure.core/fn [data size start]
+           ((-matcher (f)) data size start)))))
 
-(defn alt [& rs]
-  (let [[matchers i->k] (-parse rs)
-        matchers-size (count matchers)
-        -key (or i->k identity)
-        -value (clojure.core/fn -value [res i f]
-                 (reify Match
-                   (-end [_] (-end res))
-                   (-result [_] (-tagged (-key i) (-result res)))
-                   (-continue [_] (f (inc i)))))
-        -continue (clojure.core/fn -continue [data size start i]
-                    (loop [i i]
-                      (if-not (= i matchers-size)
-                        (let [m (nth matchers i)]
-                          (or (some-> (m data size start) (-value i (partial -continue data size start)))
-                              (recur (inc i)))))))]
-    (reify RegexSchema
-      (-matcher [_] (clojure.core/fn [data size start] (-continue data size start 0))))))
+   (defn alt [& rs]
+     (let [[matchers i->k] (-parse rs)
+           matchers-size (count matchers)
+           -key (or i->k identity)
+           -value (clojure.core/fn -value [res i f]
+                    (reify Match
+                      (-end [_] (-end res))
+                      (-result [_] (-tagged (-key i) (-result res)))
+                      (-continue [_] (f (inc i)))))
+           -continue (clojure.core/fn -continue [data size start i]
+                       (loop [i i]
+                         (if-not (= i matchers-size)
+                           (let [m (nth matchers i)]
+                             (or (some-> (m data size start) (-value i (partial -continue data size start)))
+                                 (recur (inc i)))))))]
+       (reify RegexSchema
+         (-matcher [_] (clojure.core/fn [data size start] (-continue data size start 0))))))
 
-(defn cat [& rs]
-  (let [[matchers i->k] (-parse rs)
-        -result (if i->k #(->> % (map (clojure.core/fn [[k v]] [(i->k k) (-result v)])) (into {}))
-                         #(->> % (mapv (comp -result val))))
-        matchers-size (count matchers)
-        -value (clojure.core/fn -value [m i]
-                 (reify Match
-                   (-end [_] (-end (m i)))
-                   (-result [_] (-result m))
-                   (-continue [_]
-                     (loop [si i]
-                       (when-not (neg? si)
-                         (if-let [sr (some-> si m -continue)]
-                           (-value (assoc m si sr) i)
-                           (recur (dec si))))))))]
-    (reify RegexSchema
-      (-matcher [_]
-        (clojure.core/fn [data size start]
-          (loop [i 0, splits [start], results {}]
-            #_(prn "CAT:" (vals i->k) i splits results)
-            (cond
-              (neg? i) nil
-              (results i) (if-let [res (-continue (results i))]
-                            (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
-                            (recur (dec i) (pop splits) (dissoc results i)))
-              (>= i matchers-size) (-value results (dec i))
-              :else (do
-                      #_(prn "looking..." ((nth matchers i) data size (nth splits i)))
-                      (if-let [res ((nth matchers i) data size (nth splits i))]
-                        (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
-                        (if (pos? i) (recur (dec i) (pop splits) (dissoc results i))))))))))))
+   (defn cat [& rs]
+     (let [[matchers i->k] (-parse rs)
+           -result (if i->k #(->> % (map (clojure.core/fn [[k v]] [(i->k k) (-result v)])) (into {}))
+                            #(->> % (mapv (comp -result val))))
+           matchers-size (count matchers)
+           -value (clojure.core/fn -value [m i]
+                    (reify Match
+                      (-end [_] (-end (m i)))
+                      (-result [_] (-result m))
+                      (-continue [_]
+                        (loop [si i]
+                          (when-not (neg? si)
+                            (if-let [sr (some-> si m -continue)]
+                              (-value (assoc m si sr) i)
+                              (recur (dec si))))))))]
+       (reify RegexSchema
+         (-matcher [_]
+           (clojure.core/fn [data size start]
+             (loop [i 0, splits [start], results {}]
+               #_(prn "CAT:" (vals i->k) i splits results)
+               (cond
+                 (neg? i) nil
+                 (results i) (if-let [res (-continue (results i))]
+                               (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                               (recur (dec i) (pop splits) (dissoc results i)))
+                 (>= i matchers-size) (-value results (dec i))
+                 :else (do
+                         #_(prn "looking..." ((nth matchers i) data size (nth splits i)))
+                         (if-let [res ((nth matchers i) data size (nth splits i))]
+                           (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                           (if (pos? i) (recur (dec i) (pop splits) (dissoc results i))))))))))))
+
+   (defn repeat [min max r]
+     (let [child-matcher (-matcher r)
+           -value (clojure.core/fn -value [v i]
+                    (reify Match
+                      (-end [_] (-end (v i)))
+                      (-result [_] (mapv -result v))
+                      (-continue [this]
+                        (loop [si i]
+                          (when-not (neg? si)
+                            (let [sr (some-> si v -continue)]
+                              (cond
+                                sr (-value (assoc v si sr) (dec i))
+                                (= i min 0) (-static [] (dec (-end this)))
+                                (>= i min) (-value (pop v) (dec i))
+                                :else (recur (dec si)))))))))]
+       (reify RegexSchema
+         (-matcher [_]
+           (clojure.core/fn [data size start]
+             (loop [i 0, splits [start], results []]
+               #_(prn "REP:" min max i data splits results)
+               (cond
+                 (contains? results i) (if-let [res (-continue (results i))]
+                                         (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                                         (recur (dec i) (pop splits) (pop results)))
+                 (>= i max) (-value results (dec i))
+                 (and (>= i min) (= (last splits) size)) (if (zero? i) (-static results (dec size)) (-value results (dec i)))
+                 (>= i 0) (do
+                            #_(prn "rep..." (nth splits i) (child-matcher data size (nth splits i)))
+                            (let [res (child-matcher data size (nth splits i))]
+                              (cond
+                                res (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
+                                ;(zero? i) nil
+                                (>= i min) (if (zero? i) (-static results (dec (nth splits i))) (-value results (dec i)))
+                                (pos? i) (recur (dec i) (pop splits) (if (contains? results i) (pop results) results))))))))))))
+
+
+   (defn ? [r] (repeat 0 1 r))
+   (defn * [r] (repeat 0 ##Inf r))
+   (defn + [r] (repeat 1 ##Inf r))
+
+   (defn validator [re]
+     (let [matcher (-matcher re)]
+       (clojure.core/fn [x]
+         (if (sequential? x)
+           (let [x (vec x), size (count x)]
+             (boolean (some-> (matcher x size 0) (-end) (= (dec size)))))))))
+
+   (defn validate [re data] ((validator re) data))
+
+   (defn parser [re]
+     (let [matcher (-matcher re)]
+       (clojure.core/fn [x]
+         (if (sequential? x)
+           (let [x (vec x)
+                 size (count x)
+                 result (matcher x size 0)]
+             (if (and result (= (-end result) (dec size)))
+               (-result result)))))))
+
+   (defn parse [re data] ((parser re) data))
+
+   (defn describer [re]
+     (let [matcher (-matcher re)]
+       (clojure.core/fn [x]
+         (let [x (vec x)]
+           (if-let [m (matcher x (count x) 0)]
+             {:result (-result m)
+              :rest (subvec x (inc (-end m)))})))))
+
+   (defn describe [re data] ((describer re) data)))
+
+;;;; Compiler
+
+(def ^:private label-ops
+  #{:label :jump :fork> :fork<})
+
+(def ^:private op->opcode
+  (zipmap (conj label-ops :pred :save0 :save1) (range)))
+
+(defmacro ^:private asm [& exprs]
+  (let [gen (gensym 'gen)
+        exprs (partition 2 exprs)]
+    `(let [~gen (memoize gensym)]
+       (concat
+         ~@(map
+             (fn [[op arg]]
+               (let [op (keyword op)]
+                 (if (contains? op->opcode op)
+                   [op (if (contains? label-ops op)
+                         `(~gen ~(keyword arg))
+                         arg)]
+                   (do
+                     (assert (= op :include))
+                     arg))))
+             exprs)))))
+
+(defn- patch
+  "Resolve labels to offsets.
+  (idempotent)"
+  [instructions]
+  (let [[insts labels] (reduce (fn [[insts labels] [op arg]]
+                                 (if (= :label op)
+                                   [insts (assoc labels arg (quot (count insts) 2))]
+                                   [(conj insts op arg) labels]))
+                               [[] {}] (partition 2 instructions))
+        code-length (quot (count insts) 2)]
+    (loop [pc 0, [op arg & rinsts] insts, insts []]
+      (if (< pc code-length)
+        (let [arg (if (contains? label-ops op)
+                    (if-some [dest (get labels arg)]
+                      (- dest pc)
+                      arg)
+                    arg)]
+          (recur (inc pc) rinsts (conj insts op arg)))
+        insts))))
+
+(deftype CompiledPattern [opcodes args])
+
+(defn- codegen [instructions]
+  (let [inst-count (quot (count instructions) 2)
+        bytecodes (byte-array inst-count)
+        args (object-array inst-count)]
+    (loop [pc 0, [op arg & rinsts] instructions]
+      (if (< pc inst-count)
+        (do
+          (aset bytecodes pc (byte (doto (get op->opcode op) assert)))
+          (aset args pc arg)
+          (recur (inc pc) rinsts))
+        (CompiledPattern. bytecodes args)))))
+
+(defn compile [r] (-> r patch codegen))
+
+;;;; Combinators
+
+(defn is [pred] (asm pred pred))
+
+(defn cat [& rs] (mapcat identity rs))
+
+(defn alt
+  ([r] r)
+  ([r & rs]
+   (asm
+     fork> l1
+     include r
+     jump l2
+     label l1
+     include (apply alt rs)
+     label l2)))
+
+(defn ? [r]
+  (asm
+    fork> end
+    include r
+    label end))
+
+(defn * [r]
+  (asm
+    label start
+    fork> end
+    include r
+    jump start
+    label end))
+
+(defn + [r]
+  (asm
+    label start
+    include r
+    fork< start))
 
 (defn repeat [min max r]
-  (let [child-matcher (-matcher r)
-        -value (clojure.core/fn -value [v i]
-                 (reify Match
-                   (-end [_] (-end (v i)))
-                   (-result [_] (mapv -result v))
-                   (-continue [this]
-                     (loop [si i]
-                       (when-not (neg? si)
-                         (let [sr (some-> si v -continue)]
-                           (cond
-                             sr (-value (assoc v si sr) (dec i))
-                             (= i min 0) (-static [] (dec (-end this)))
-                             (>= i min) (-value (pop v) (dec i))
-                             :else (recur (dec si)))))))))]
-    (reify RegexSchema
-      (-matcher [_]
-        (clojure.core/fn [data size start]
-          (loop [i 0, splits [start], results []]
-            #_(prn "REP:" min max i data splits results)
-            (cond
-              (contains? results i) (if-let [res (-continue (results i))]
-                                      (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
-                                      (recur (dec i) (pop splits) (pop results)))
-              (>= i max) (-value results (dec i))
-              (and (>= i min) (= (last splits) size)) (if (zero? i) (-static results (dec size)) (-value results (dec i)))
-              (>= i 0) (do
-                         #_(prn "rep..." (nth splits i) (child-matcher data size (nth splits i)))
-                         (let [res (child-matcher data size (nth splits i))]
-                           (cond
-                             res (recur (inc i) (conj splits (inc (-end res))) (assoc results i res))
-                             ;(zero? i) nil
-                             (>= i min) (if (zero? i) (-static results (dec (nth splits i))) (-value results (dec i)))
-                             (pos? i) (recur (dec i) (pop splits) (if (contains? results i) (pop results) results))))))))))))
+  (cond
+    (pos? min) (cat (apply cat (clojure.core/repeat min r)) (repeat 0 (- max min) r))
+    (pos? max) (? r (repeat 0 (dec max) r))
+    :else (asm)))
 
+;;;; Pike VM
 
-(defn ? [r] (repeat 0 1 r))
-(defn * [r] (repeat 0 ##Inf r))
-(defn + [r] (repeat 1 ##Inf r))
+(defmacro ^:private opcode-case [op & body]
+  (letfn [(convert-pat [pat]
+            (if (symbol? pat)
+              (doto (get op->opcode (keyword pat)) assert)
+              (map convert-pat pat)))]
+    `(case ~op
+       ~@(->> body
+              (partition 2)
+              (mapcat (fn [[pat expr]] [(convert-pat pat) expr]))))))
 
-(defn validator [re]
-  (let [matcher (-matcher re)]
-    (clojure.core/fn [x]
-      (if (sequential? x)
-        (let [x (vec x), size (count x)]
-          (boolean (some-> (matcher x size 0) (-end) (= (dec size)))))))))
+(defn- make-bitset ^bytes [max-val]
+  (byte-array (quot (dec (clojure.core/+ max-val 8)) 8)))
 
-(defn validate [re data] ((validator re) data))
+(defn- clear-bitset! [^bytes set] (Arrays/fill set (byte 0)))
 
-(defn parser [re]
-  (let [matcher (-matcher re)]
-    (clojure.core/fn [x]
-      (if (sequential? x)
-        (let [x (vec x)
-              size (count x)
-              result (matcher x size 0)]
-          (if (and result (= (-end result) (dec size)))
-            (-result result)))))))
+(defn- bitset-set! [^bytes set, ^long v]
+  (let [byte-index (quot v 8)
+        bit-index (rem v 8)]
+    (aset set byte-index (unchecked-byte (bit-or (aget set byte-index)
+                                                 (bit-shift-left 1 bit-index))))
+    nil))
 
-(defn parse [re data] ((parser re) data))
+(defn- bitset-contains? [^bytes set, ^long v]
+  (let [byte-index (quot v 8)
+        bit-index (rem v 8)]
+    (= (bit-and (bit-shift-right (aget set byte-index) bit-index)
+                1)
+       1)))
 
-(defn describer [re]
-  (let [matcher (-matcher re)]
-    (clojure.core/fn [x]
-      (let [x (vec x)]
-        (if-let [m (matcher x (count x) 0)]
-          {:result (-result m)
-           :rest (subvec x (inc (-end m)))})))))
+(defprotocol RegisterBank
+  (save0 [bank id v])
+  (save1 [bank id v])
+  (fetch [bank coll0 coll]))
 
-(defn describe [re data] ((describer re) data))
+(defprotocol ^:private IMatch
+  (decode-match [self coll]))
+
+(deftype ^:private Match [^long start, ^long end]
+  #?(:clj Object :cljs default)
+  (toString [_] (prn-str [start end]))
+
+  IMatch
+  (decode-match [_ coll] (take (- end start) (drop start coll))))
+
+(extend-protocol RegisterBank
+  clojure.lang.APersistentMap
+  (save0 [m id start] (assoc m id (Match. start start)))
+  (save1 [m id end] (update m id (fn [^Match match] (Match. (.-start match) end))))
+  (fetch [m coll0 coll]
+    (-> (reduce-kv (fn [acc k match] (assoc! acc k (decode-match match coll0)))
+                   (transient {:rest coll})
+                   m)
+        persistent!)))
+
+(defrecord ^:private TreeStackFrame [children, ^long start])
+
+(defrecord ^:private MatchNode [children, ^long start, ^long end]
+  IMatch
+  (decode-match [_ coll] (take (- end start) (drop start coll))))
+
+(extend-protocol RegisterBank
+  clojure.lang.APersistentVector
+  (save0 [stack _ start] (conj stack (TreeStackFrame. {} start)))
+  (save1 [stack id end]
+    ;; 'return' `node`:
+    (let [^TreeStackFrame callee-frame (peek stack)
+          node (MatchNode. (.-children callee-frame) (.-start callee-frame) end)
+          stack (pop stack)]
+      ;; Update 'caller' state:
+      (update stack (dec (count stack))
+              (fn [^TreeStackFrame caller-frame]
+                (TreeStackFrame. (update (.-children caller-frame) id (fnil conj []) node)
+                                 (.-start caller-frame))))))
+  (fetch [stack coll0 coll]
+    (letfn [(fetch-node [^MatchNode node]
+              (fetch-children {:match (decode-match node coll0)}
+                              (.-children node)))
+            (fetch-children [acc children]
+              (-> (reduce-kv (fn [m id children]
+                               (assoc! m (if (vector? id) (peek id) id) (mapv fetch-node children)))
+                             (transient acc)
+                             children)
+                  persistent!))]
+      (fetch-children {:rest coll}
+                      (.-children ^TreeStackFrame (peek stack))))))
+
+(defprotocol ^:private IVMState
+  (thread-count [state])
+  (fork! [state pc matches])
+  (truncate! [state]))
+
+(deftype ^:private VMState [^:unsynchronized-mutable ^long nthreads pcs matchess]
+  IVMState
+  (thread-count [_] nthreads)
+
+  (fork! [_ pc matches]
+    (let [i nthreads]
+      (set! nthreads (inc i))
+      (aset ^longs pcs i ^long pc)
+      (aset ^"[Ljava.lang.Object;" matchess i matches)))
+
+  (truncate! [_] (set! nthreads 0)))
+
+(defn- exec-automaton* [^CompiledPattern automaton coll0 registers]
+  (let [^bytes opcodes (.-opcodes automaton)
+        ^"[Ljava.lang.Object;" args (.-args automaton)
+        inst-count (alength opcodes)
+        visited (make-bitset inst-count)
+        state (VMState. 0 (long-array inst-count) (object-array inst-count))
+        state* (VMState. 0 (long-array inst-count) (object-array inst-count))
+
+        add-thread! (fn [^long pos, ^VMState state, ^long pc, matches]
+                      (clear-bitset! visited)
+                      ;; Micro-optimization: lambda-lift `add!` by hand:
+                      (letfn [(add! [^long pos, ^VMState state, ^long pc, matches]
+                                (cond
+                                  (< pc (alength opcodes))
+                                  (when-not (bitset-contains? visited pc)
+                                    (bitset-set! visited pc)
+                                    (opcode-case (aget opcodes pc)
+                                                 jump (recur pos state (clojure.core/+ pc (long (aget args pc))) matches)
+                                                 fork> (do
+                                                         (add! pos state (inc pc) matches)
+                                                         (recur pos state (clojure.core/+ pc (long (aget args pc))) matches))
+                                                 fork< (do
+                                                         (add! pos state (clojure.core/+ pc (long (aget args pc))) matches)
+                                                         (recur pos state (inc pc) matches))
+
+                                                 save0 (recur pos state (inc pc) (save0 matches (aget args pc) pos))
+                                                 save1 (recur pos state (inc pc) (save1 matches (aget args pc) pos))
+
+                                                 pred (fork! state pc matches)))
+
+                                  (= pc (alength opcodes)) (fork! state pc matches)
+
+                                  :else nil))]
+                        (add! pos state pc matches)))
+
+        match-item (fn [^long pos, coll, ^VMState state, ^VMState state*]
+                     (loop [i 0]
+                       (when (< i (thread-count state))
+                         (let [pc (aget ^longs (.-pcs state) i)
+                               matches (aget ^"[Ljava.lang.Object;" (.-matchess state) i)]
+                           (if (< pc inst-count)
+                             (let [opcode (aget opcodes pc)
+                                   arg (aget args pc)]
+                               (opcode-case opcode
+                                            pred (when (and coll (arg (first coll)))
+                                                   (add-thread! (inc pos) state* (inc pc) matches))
+                                            #_"add-thread! makes other opcodes impossible at this point")
+                               (recur (inc i)))
+                             matches)))))]
+
+    (add-thread! 0 state 0 registers)
+    (loop [pos 0, coll (seq coll0), state state, state* state*, longest nil]
+      (let [longest (or (match-item pos coll state state*) longest)]
+        (if (and (> (thread-count state*) 0) coll)
+          (do
+            (truncate! state)
+            (recur (inc pos) (next coll) state* state longest))
+          (when longest
+            (fetch longest coll0 (or coll ()))))))))
+
+(defn exec-automaton [automaton coll] (exec-automaton* automaton coll {}))
+
+(defn exec [re coll] (exec-automaton (compile re) coll))
+
+(defn exec-tree-automaton [automaton coll]
+  (exec-automaton* automaton coll [(TreeStackFrame. {} 0)]))
+
+(defn exec-tree [re coll] (exec-tree-automaton (compile re) coll))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -305,7 +305,7 @@
 
 ;;;; Pike VM
 
-(def ^:private +int-bitwidth+ 32)
+(def ^:private ^:const +int-bitwidth+ 32)
 
 (defn- make-bitset ^ints [max-val]
   (int-array (quot (dec (clojure.core/+ max-val +int-bitwidth+)) +int-bitwidth+)))

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -480,6 +480,9 @@
                        (when (and coll (arg (first coll)))
                          (add-thread! self (inc pos) (conj buf (first coll)) state* (inc pc) matches))
                        (recur (inc i)))
+                end (if coll
+                      (recur (inc i))
+                      matches)
                 #_"add-thread! makes other opcodes impossible at this point"))
             matches)))))
 

--- a/src/malli/regex.cljc
+++ b/src/malli/regex.cljc
@@ -7,8 +7,6 @@
                    [clojure.lang MapEntry APersistentVector]
                    [java.util Arrays])))
 
-;;; TODO: clojure.spec.alpha/spec equivalent
-
 #_(
    (defprotocol RegexSchema
      (-matcher [_]))

--- a/src/malli/regex/compiler.cljc
+++ b/src/malli/regex/compiler.cljc
@@ -1,0 +1,44 @@
+(ns malli.regex.compiler
+  (:refer-clojure :exclude [compile]))
+
+(def label-ops
+  #{:label :jump :fork> :fork<})
+
+(def op->opcode
+  (zipmap (conj label-ops :pred :explain :end :save0 :save1) (range)))
+
+(defn- patch
+  "Resolve labels to offsets.
+  (idempotent)"
+  [instructions]
+  (let [[insts labels] (reduce (fn [[insts labels] [op arg]]
+                                 (if (= :label op)
+                                   [insts (assoc labels arg (quot (count insts) 2))]
+                                   [(conj insts op arg) labels]))
+                               [[] {}] (partition 2 instructions))
+        code-length (quot (count insts) 2)]
+    (loop [pc 0, [op arg & rinsts] insts, insts []]
+      (if (< pc code-length)
+        (let [arg (if (contains? label-ops op)
+                    (if-some [dest (get labels arg)]
+                      (- dest pc)
+                      arg)
+                    arg)]
+          (recur (inc pc) rinsts (conj insts op arg)))
+        insts))))
+
+(deftype CompiledPattern [opcodes args])
+
+(defn- codegen [instructions]
+  (let [inst-count (quot (count instructions) 2)
+        bytecodes (byte-array inst-count)
+        args (object-array inst-count)]
+    (loop [pc 0, [op arg & rinsts] instructions]
+      (if (< pc inst-count)
+        (do
+          (aset bytecodes pc (byte (doto (get op->opcode op) assert)))
+          (aset args pc arg)
+          (recur (inc pc) rinsts))
+        (CompiledPattern. bytecodes args)))))
+
+(defn compile [r] (-> r patch codegen))

--- a/src/malli/regex/compiler.cljc
+++ b/src/malli/regex/compiler.cljc
@@ -5,7 +5,7 @@
   #{:label :jump :fork> :fork<})
 
 (def op->opcode
-  (zipmap (conj label-ops :pred :explain :end :save0 :save1) (range)))
+  (zipmap (conj label-ops :pred :explain :encoder :decode :end :save0 :save1) (range)))
 
 (defn- patch
   "Resolve labels to offsets.

--- a/src/malli/regex/compiler.cljc
+++ b/src/malli/regex/compiler.cljc
@@ -31,7 +31,7 @@
 
 (defn- codegen [instructions]
   (let [inst-count (quot (count instructions) 2)
-        bytecodes (byte-array inst-count)
+        bytecodes (#?(:clj byte-array, :cljs make-array) inst-count)
         args (object-array inst-count)]
     (loop [pc 0, [op arg & rinsts] instructions]
       (if (< pc inst-count)

--- a/src/malli/regex/macros.clj
+++ b/src/malli/regex/macros.clj
@@ -1,0 +1,34 @@
+(ns malli.regex.macros)
+
+(def label-ops
+  #{:label :jump :fork> :fork<})
+
+(def op->opcode
+  (zipmap (conj label-ops :pred :explain :end :save0 :save1) (range)))
+
+(defmacro asm [& exprs]
+  (let [gen (gensym 'gen)
+        exprs (partition 2 exprs)]
+    `(let [~gen (memoize gensym)]
+       (concat
+         ~@(map
+             (fn [[op arg]]
+               (let [op (keyword op)]
+                 (if (contains? op->opcode op)
+                   [op (if (contains? label-ops op)
+                         `(~gen ~(keyword arg))
+                         arg)]
+                   (do
+                     (assert (= op :include))
+                     arg))))
+             exprs)))))
+
+(defmacro opcode-case [op & body]
+  (letfn [(convert-pat [pat]
+            (if (symbol? pat)
+              (doto (get op->opcode (keyword pat)) assert)
+              (map convert-pat pat)))]
+    `(case ~op
+       ~@(->> body
+              (partition 2)
+              (mapcat (fn [[pat expr]] [(convert-pat pat) expr]))))))

--- a/src/malli/regex/macros.clj
+++ b/src/malli/regex/macros.clj
@@ -1,10 +1,5 @@
-(ns malli.regex.macros)
-
-(def label-ops
-  #{:label :jump :fork> :fork<})
-
-(def op->opcode
-  (zipmap (conj label-ops :pred :explain :end :save0 :save1) (range)))
+(ns malli.regex.macros
+  (:require [malli.regex.compiler :refer [op->opcode label-ops]]))
 
 (defmacro asm [& exprs]
   (let [gen (gensym 'gen)

--- a/test/malli/re_test.cljc
+++ b/test/malli/re_test.cljc
@@ -1,0 +1,600 @@
+(ns malli.re-test
+  (:require [clojure.spec.alpha :as s]
+            [net.cgrand.seqexp :as se]
+            [minimallist.helper :as h]
+            [minimallist.core :as mc]
+            [net.cgrand.seqexp :as se]))
+
+;; spec
+[:cat]
+[:alt]
+[:?]
+[:*]
+[:+]
+
+;; seqxp
+[:*]
+[:+]
+[:?]
+[:repeat]
+[:*?]
+[:+?]
+[:??]
+[:repeat?]
+[:|]
+
+;; malli
+[:cat]
+[:alt]
+[:?]
+[:*]
+[:+]
+[:repeat]
+
+(se/exec
+  (se/*
+    (se/as :opts
+           (se/cat
+             (se/as :prop string?)
+             (se/as :val (se/| (se/as :s string?) (se/as :b boolean?))))))
+  ["-server" "foo" "-verbose" true "-user" "joe"])
+;{:rest (),
+; :match ("-server" "foo" "-verbose" true "-user" "joe"),
+; :opts ("-user" "joe"),
+; :prop ("-user"),
+; :val ("joe"),
+; :s ("joe"),
+; :b (true)}
+
+
+(s/conform
+  (s/* (s/cat :prop string?
+              :val (s/alt :s string?
+                          :b boolean?)))
+  ["-server" "foo" "-verbose" true "-user" "joe"])
+;[{:prop "-server", :val [:s "foo"]}
+; {:prop "-verbose", :val [:b true]}
+; {:prop "-user", :val [:s "joe"]}]
+
+(#'s/specize
+  (s/* (s/cat :prop string?
+              :val (s/alt :s string?
+                          :b boolean?))))
+
+(mc/describe
+  (h/cat [:1 (h/* (h/cat [:prop (h/fn string?)]
+                         [:val (h/alt [:s (h/fn string?)]
+                                      [:b (h/fn boolean?)])]))]
+         [:2 (h/+ (h/fn int?))])
+  ["-server" "foo" "-verbose" true "-user" "joe" 1 2])
+;[{:prop "-server", :val [:s "foo"]}
+; {:prop "-verbose", :val [:b true]}
+; {:prop "-user", :val [:s "joe"]}]
+
+(h/* (h/cat [:prop (h/fn string?)]
+            [:val (h/alt [:s (h/fn string?)]
+                         [:b (h/fn boolean?)])]))
+
+(mc/describe (h/repeat 2 3 (h/cat [0 (h/repeat 1 2 (h/fn int?))])) [1 2 3 4])
+; => [{:ints [1 2]} {:ints [3]} {:ints [4]}]
+
+(se/exec (se/repeat 2 3 (se/cat (se/repeat 1 2 int?))) [1 2 3 4])
+
+(mc/describe (h/+ (h/cat [:ints (h/* (h/fn int?))]
+                         [:ints (h/+ (h/fn int?))])) [1 2 3 4])
+; => [{:ints [1]} {:ints [2]} {:ints [3]} {:ints [4]}]
+
+(s/conform (s/+ (s/cat :ints (s/* int?)
+                       :ints2 (s/+ int?))) [1 2 3 4])
+; => [{:ints [1 2 3], :ints2 [4]}]
+
+
+(mc/describe (h/+ (h/+ (h/fn int?))) [1 2 3]) ; => [[1] [2] [3]]
+(s/conform (s/+ (s/+ int?)) [1 2 3]) ; => [[1 2 3]]
+
+(s/conform (s/+ (s/cat :int int?)) [1 2 3]) ; => [{:int 1} {:int 2} {:int 3}]
+
+(mc/valid?
+  (h/cat [:key (h/fn string?)]
+         [:value (h/fn string?)])
+  #_["" "2"]
+  {"" "2"})
+
+(def Config [:* [:cat
+                 [:prop string?]
+                 [:val [:alt
+                        [:s string?]
+                        [:b boolean?]]]]])
+
+
+(h/* (h/cat [:prop (h/fn string?)]
+            [:val (h/alt [:s (h/fn string?)]
+                         [:b (h/fn boolean?)])]))
+
+;;
+;; impl
+;;
+
+(require '[malli.core :as m])
+
+;; malli
+[:cat]
+[:alt]
+[:?]
+[:*]
+[:+]
+[:repeat]
+
+(defn -repeat-schema [{:keys [type min max]}]
+  ^{:type ::into-schema}
+  (reify m/IntoSchema
+    (-into-schema [_ properties children options]
+      (m/-check-children! type properties children {:min 1, :max 1})
+      (let [[child :as children] (map #(m/schema % options) children)
+            min (or min (:min properties))
+            max (or max (:max properties))
+            form (m/-create-form type properties (map m/-form children))]
+        ^{:type ::schema}
+        (reify
+          m/Schema
+          (-type [_] type)
+          (-validator [_]
+            (let [child-validator (m/-validator child)
+                  this-validator (cond
+                                   (= 0 min) (fn [x] (or (nil? x) (and (sequential? x) (let [c (count x)] (<= c max)))))
+                                   :else (fn [x] (and (sequential? x) (let [c (count x)] (<= min c max)))))]
+              (prn min max)
+              (fn [x]
+                (prn (this-validator x))
+                (and (this-validator x) (child-validator x)))))
+          (-explainer [_ path]
+            (let [explainer' (m/-explainer child (conj path 0))]
+              (fn explain [x in acc]
+                (if (nil? x) acc (explainer' x in acc)))))
+          (-transformer [this transformer method options]
+            (m/-parent-children-transformer this children transformer method options))
+          (-walk [this walker path options]
+            (if (m/-accept walker this path options)
+              (m/-outer walker this path (m/-inner-indexed walker path children options) options)))
+          (-properties [_] properties)
+          (-options [_] options)
+          (-children [_] children)
+          (-form [_] form)
+          m/LensSchema
+          (-keep [_])
+          (-get [_ key default] (if (= 0 key) child default))
+          (-set [this key value] (if (= 0 key)
+                                   (m/into-schema type properties [value])
+                                   (m/-fail! ::index-out-of-bounds {:schema this, :key key}))))))))
+
+(def registry (assoc (m/default-schemas) :* (-repeat-schema {:type :*, :min 0, :max ##Inf})))
+
+(m/validate [:* int?] [1 2 3] {:registry registry})
+
+(mc/describe
+  (h/cat [:head (h/repeat 1 3 (h/fn int?))]
+         [:head2 (h/fn int?)]
+         [:tail (h/* (h/fn int?))]
+         [:tail2 (h/* (h/fn string?))])
+  [1 2 3 4 5 "6" "7"])
+
+
+(h/cat [:head (h/repeat 1 3 (h/fn int?))]
+       [:head2 (h/fn int?)]
+       [:tail (h/* (h/fn int?))]
+       [:tail2 (h/* (h/fn string?))])
+
+(mc/describe
+  (h/repeat 1 3 (h/fn int?))
+  [1 2 3])
+
+(h/repeat 1 3 (h/fn int?))
+
+(h/cat [:head (h/repeat 1 3 (h/fn int?))]
+       [:head2 (h/fn int?)]
+       [:tail (h/* (h/fn int?))]
+       [:tail2 (h/* (h/fn string?))])
+
+(s/conform (s/* (s/cat :ints (s/+ int?))) '(0 1))
+
+(mc/describe
+  (h/* (h/cat [:ints (h/+ (h/fn int?))]))
+  '(0 1))
+
+[:cat]
+[:alt]
+[:?]
+[:*]
+[:+]
+[:repeat]
+
+
+;;
+;; impl
+;;
+
+(defn -repeat [min max child] {:type :repeat, :min min, :max max, :child child})
+(def -* (partial -repeat 0 ##Inf))
+(def -+ (partial -repeat 1 ##Inf))
+(defn -cat [children] {:type :cat, :children children})
+
+(defn -result [start min max]
+  (let [min' (+ min start)]
+    (loop [max' (+ max start), acc []]
+      (if (>= max' min')
+        (recur (dec max') (conj acc [min' max']))
+        acc))))
+
+(defn -repeat-impl [data size start {:keys [min max child]}]
+  (prn "-repeat-impl" start)
+  (loop [i 0]
+    (cond
+      (>= i max) (-result start min i)
+      (>= i size) (if (>= i min) (-result start min i))
+      (= i max) (-result start min i)
+      (child (nth data (+ i start))) (recur (inc i))
+      (>= i min) (-result start min i))))
+
+(declare -impl)
+
+(defn -cat-impl [data size start {:keys [children]}]
+  #_(-> (reduce
+          (fn [[start parts] child]
+            (if-let [res (-impl child data size start)]
+              [end (conj parts res)]
+              (reduced nil)))
+          [start []]
+          children)
+        (second)))
+
+(defn -impl [re data size start]
+  (let [res (case (:type re)
+              :repeat (-repeat-impl data size start re)
+              :cat (-cat-impl data size start re))]
+    (if-not (= ::invalid res)
+      res)))
+
+(defn impl [re data]
+  (-impl re (vec data) (count data) 0))
+
+(impl
+  #_(-repeat 2 4 string?)
+  (-cat [(-repeat 2 2 string?)
+         (-repeat 2 2 string?)])
+  '("1" "2" "3" "4" "5" "6" 5))
+
+;;
+;; benchmark
+;;
+
+(mc/describe (h/* (h/cat [:ints (h/+ (h/fn int?))])) '(0 1))
+(h/* (h/cat [:ints (h/+ (h/fn int?))]))
+
+(se/exec
+  (se/cat (se/as :1 (se/repeat 2 3 int?))
+          (se/as :2 (se/repeat 2 3 int?))
+          (se/as :3 (se/repeat 2 3 int?))
+          (se/as :4 (se/repeat 2 3 int?)))
+  (range 10))
+
+(require '[malli.regex :as mt])
+
+(mt/describe (mt/cat [(mt/+ (mt/fn int?))
+                      (mt/+ (mt/fn string?))
+                      (mt/+ (mt/fn int?))
+                      (mt/+ (mt/fn string?))])
+             [1 2 3 "4" "5" 6 7 8 9 "10"])
+
+(comment
+  (require '[criterium.core :as cc]))
+
+(comment
+  (let [data [1 2 3 "4" "5" 6 7 8 9 "10"]
+        re (se/cat (se/as 1 (se/+ int?))
+                   (se/as 2 (se/+ string?))
+                   (se/as 3 (se/+ int?))
+                   (se/as 4 (se/+ string?)))
+        mre (h/cat [1 (h/+ (h/fn int?))]
+                   [2 (h/+ (h/fn string?))]
+                   [3 (h/+ (h/fn int?))]
+                   [4 (h/+ (h/fn string?))])
+        mtre (mt/cat [(mt/+ (mt/fn int?))
+                      (mt/+ (mt/fn string?))
+                      (mt/+ (mt/fn int?))
+                      (mt/+ (mt/fn string?))])
+        describer (mt/describer mtre)
+        validator (mt/validator mtre)
+        sre (s/cat :1 (s/+ int?)
+                   :2 (s/+ string?)
+                   :3 (s/+ int?)
+                   :4 (s/+ string?))]
+
+    (println "\nMalli:")
+    (prn (describer data))
+    (prn (validator data))
+    ;; 8.272667 µs
+    (cc/quick-bench (describer data))
+    ;; 6.777152 µs
+    (cc/quick-bench (validator data))
+    #_(time
+        (dotimes [_ 10000]
+          (mtre data)))
+
+    (println "\nMinimallist:")
+    (prn (mc/describe mre data))
+    ;; 37.550816 µs
+    (cc/quick-bench (mc/describe mre data))
+    #_(time
+        (dotimes [_ 10000]
+          (mc/describe mre data)))
+
+    (println "\nSeqexp:")
+    (prn (se/exec re data))
+    ;; 72.690279 µs
+    (cc/quick-bench (se/exec re data))
+    #_(time
+        (dotimes [_ 10000]
+          (se/exec re data)))
+
+    (println "\nClojure.Spec:")
+    (prn (s/conform sre data))
+    ;; 103.550059 µs
+    (cc/quick-bench (s/conform sre data))
+    #_(time
+        (dotimes [_ 10000]
+          (s/conform sre data)))))
+
+(let [data (doall (range 10))
+      re (se/cat (se/as 1 (se/repeat 2 3 int?))
+                 (se/as 2 (se/repeat 2 3 int?))
+                 (se/as 3 (se/repeat 2 3 int?))
+                 (se/as 4 (se/repeat 2 3 int?)))
+      mre (h/cat [1 (h/repeat 2 3 (h/fn int?))]
+                 [2 (h/repeat 2 3 (h/fn int?))]
+                 [3 (h/repeat 2 3 (h/fn int?))]
+                 [4 (h/repeat 2 3 (h/fn int?))])
+      mtre (mt/cat [(mt/repeat 2 3 (mt/fn int?))
+                    (mt/repeat 2 3 (mt/fn int?))
+                    (mt/repeat 2 3 (mt/fn int?))
+                    (mt/repeat 2 3 (mt/fn int?))])
+      sre (s/cat :ints (s/+ int?))]
+
+  (let [describe (mt/describer mtre)]
+    (println "\nMalli")
+    (prn (describe data))
+    (time
+      (dotimes [_ 10000]
+        (describe data))))
+
+  (println "\nMinimallist")
+  (prn (mc/describe mre data))
+  (time
+    (dotimes [_ 10000]
+      (mc/describe mre data)))
+
+  #_#_#_(println "\nClojure.Spec")
+      (prn (s/conform sre data))
+      (time
+        (dotimes [_ 10000]
+          (s/conform sre data)))
+
+  (println "\nSeqexp")
+  (prn (se/exec re data))
+  (time
+    (dotimes [_ 10000]
+      (se/exec re data))))
+
+(comment
+  (let [re (se/* (se/cat (se/as :ints (se/+ int?))))
+        mre (h/* (h/cat [:ints (h/+ (h/fn int?))]))
+        sre (s/* (s/cat :ints (s/+ int?)))]
+
+    (println "\nMinimallist")
+    (prn (mc/describe mre '(0 1)))
+    (time
+      (dotimes [_ 10000]
+        (mc/describe mre '(0 1))))
+
+    (println "\nClojure.Spec")
+    (prn (s/conform sre '(0 1)))
+    (time
+      (dotimes [_ 10000]
+        (s/conform sre '(0 1))))
+
+    (println "\nSeqexp")
+    (prn (se/exec re '(0 1)))
+    (time
+      (dotimes [_ 10000]
+        (se/exec re '(0 1))))))
+
+(mc/describe
+  (h/cat [:1 (h/repeat 2 3 (h/fn int?))]
+         [:2 (h/repeat 2 3 (h/fn int?))]
+         [:3 (h/repeat 2 3 (h/fn int?))]
+         [:4 (h/repeat 2 3 (h/fn int?))])
+  (range 12))
+
+(h/cat [:1 (h/repeat 2 3 (h/fn int?))]
+       [:2 (h/repeat 2 3 (h/fn int?))]
+       [:3 (h/repeat 2 3 (h/fn int?))]
+       [:4 (h/repeat 2 3 (h/fn int?))])
+
+(#'mc/sequence-descriptions
+  {}
+  {:type :cat,
+   :entries [{:key :1,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}
+             {:key :2,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}
+             {:key :3,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}
+             {:key :4,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}]}
+
+  (range 10))
+
+#_(time
+    (dotimes [_ 100000]
+      (doall
+        (#'mc/sequence-descriptions
+          {}
+          {:type :repeat,
+           :min 2,
+           :max 4,
+           :elements-model {:type :fn,
+                            :fn int?}}
+          (range 10)))))
+
+(defn sd [context model seq-data]
+  (case (:type model)
+    :fn [{:rest (next seq-data)
+          :desc (first seq-data)}]
+    :cat (reduce-kv (fn [seq-descriptions index entry]
+                      (prn seq-descriptions)
+                      (mapcat (fn [acc]
+                                (->> (sd context (:model entry) (:rest acc))
+                                     (map (fn [seq-description]
+                                            {:rest (:rest seq-description)
+                                             :desc (assoc (:desc acc) (:key entry index) (:desc seq-description))}))))
+                              seq-descriptions))
+                    [{:rest seq-data
+                      :desc {}}]
+                    (:entries model))
+    :repeat (->> (iterate (fn [seq-descriptions]
+                            (mapcat (fn [acc]
+                                      (->> (sd context (:elements-model model) (:rest acc))
+                                           (map (fn [seq-description]
+                                                  {:rest (:rest seq-description)
+                                                   :desc (conj (:desc acc) (:desc seq-description))}))))
+                                    seq-descriptions))
+                          [{:rest seq-data
+                            :desc []}])
+                 (take-while seq)
+                 (take (inc (:max model))) ; inc because it includes the "match zero times"
+                 (drop (:min model))
+                 (reverse) ; longest repetitions first
+                 (apply concat))))
+
+(sd
+  {}
+  {:type :cat,
+   :entries [{:key :1,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}
+             {:key :2,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}
+             {:key :3,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}
+             {:key :4,
+              :model {:type :repeat,
+                      :min 2,
+                      :max 3,
+                      :elements-model {:type :fn,
+                                       :fn int?}}}]}
+  (range 10))
+
+(s/cat :1 (s/+ int?)
+       :2 (s/+ string?)
+       :3 (s/+ int?)
+       :4 (s/+ string?))
+
+(let [data (doall (range 10))
+      re (se/cat (se/as 1 (se/repeat 2 3 int?))
+                 (se/as 2 (se/repeat 2 3 int?))
+                 (se/as 3 (se/repeat 2 3 int?))
+                 (se/as 4 (se/repeat 2 3 int?)))
+      mre (h/cat [1 (h/repeat 2 3 (h/fn int?))]
+                 [2 (h/repeat 2 3 (h/fn int?))]
+                 [3 (h/repeat 2 3 (h/fn int?))]
+                 [4 (h/repeat 2 3 (h/fn int?))])
+      mtre (mt/cat [(mt/repeat 2 3 (mt/fn int?))
+                    (mt/repeat 2 3 (mt/fn int?))
+                    (mt/repeat 2 3 (mt/fn int?))
+                    (mt/repeat 2 3 (mt/fn int?))])
+      sre (s/cat :ints (s/+ int?))]
+
+  (let [describe (mt/describer mtre)]
+    (println "\nMalli")
+    (prn (describe data))
+    (time
+      (dotimes [_ 10000]
+        (describe data)))))
+
+;;
+;;
+;;
+
+(require '[malli.regex :as re])
+
+(comment
+  (let [data ["-server" "foo" "-verbose" true "-user" "joe"]]
+    (doseq [[n f] [["seqexp" (partial
+                               se/exec
+                               (se/*
+                                 (se/as :opts
+                                        (se/cat
+                                          (se/as :prop string?)
+                                          (se/as :val (se/| (se/as :s string?) (se/as :b boolean?)))))))]
+                   ["minimallist" (partial
+                                    mc/describe
+                                    (h/* (h/cat [:prop (h/fn string?)]
+                                                [:val (h/alt [:s (h/fn string?)]
+                                                             [:b (h/fn boolean?)])])))]
+                   ["spec" (partial
+                             s/conform
+                             (s/* (s/cat :prop string?
+                                         :val (s/alt :s string?
+                                                     :b boolean?))))]
+                   ["malli" (re/parser
+                              (re/* (re/cat [:prop (re/fn string?)]
+                                            [:val (re/alt [:s (re/fn string?)]
+                                                          [:b (re/fn boolean?)])])))]]]
+      (println n)
+      (prn (f data))
+      (cc/quick-bench (f data))
+      (println)))
+
+  (let [v (re/validator
+            (re/* (re/cat [:prop (re/fn string?)]
+                          [:val (re/alt [:s (re/fn string?)]
+                                        [:b (re/fn boolean?)])])))]
+    (cc/quick-bench (v ["-server" "foo" "-verbose" true "-user" "joe"]))))
+;
+;seqexp
+;Execution time mean : 86.832562 µs
+;
+;spec
+;Execution time mean : 39.515585 µs
+;
+;minimallist
+;Execution time mean : 18.580211 µs
+;
+;malli
+;Execution time mean : 6.191535 µs

--- a/test/malli/regex_test.cljc
+++ b/test/malli/regex_test.cljc
@@ -325,3 +325,15 @@
 
 (s/explain-data (s/cat :a (s/map-of int? (s/cat :first int?))) [{1 ["1"]}])
 (get-in [{1 ["1"]}] [0 1])
+
+;; validator <- impl without doing (much) garbage, parser without realizing results?
+;; parser <- realized results
+;; explain
+;;   <- only top-level error, "sequence doesn't match"?
+;;   <- all possible errors with lenghts
+;; transform <- first match that transforms
+
+;; backtracking -> bomb
+;; memoize -> muistin varaus
+;; vector -> hack?
+;; NFA ->

--- a/test/malli/regex_test.cljc
+++ b/test/malli/regex_test.cljc
@@ -1,28 +1,93 @@
 (ns malli.regex-test
   (:require [clojure.test :refer :all]
             [clojure.spec.alpha :as s]
-            [malli.regex :as re]))
+            [malli.core :as m]))
 
+(deftest predicates
+  (are [pred s r]
+    (= (m/validate [:cat pred] s) r)
+    pos? 3 false
+    pos? [] false
+    pos? [3] true
+    pos? [-3] false
+    pos? [3 3] false))
 
-(s/conform (s/+ int?) [])
-(re/parse (re/repeat 2 ##Inf (re/fn int?)) [1 2])
+(deftest catenation
+  (are [re s r]
+    (= (m/validate re s) r)
+    [:cat pos? [:= 4]] [] false
+    [:cat pos? [:= 4]] [3] false
+    [:cat pos? [:= 4]] [3 3] false
+    [:cat pos? [:= 4]] [3 4] true
+    [:cat pos? [:= 4]] [-3 3] false))
 
-(re/parse (re/cat [:type (re/fn keyword?)]
-                  [:props (re/? (re/fn map?))]
-                  #_(re/* (re/fn any?)))
-          [:p])
+(deftest choice
+  (are [re s r]
+    (= (m/validate re s) r)
+    [:alt pos? [:= 4]] [3] true
+    [:alt pos? [:= 4]] [4] true
+    [:alt pos? [:= 4]] [3 3] false
+    [:alt pos? [:= 4]] [3 4] false
+    [:alt pos? [:= 4]] [4 3] false
+    [:alt pos? [:= 4]] [-3 3] false))
 
-(re/parse (re/cat [:type (re/fn keyword?)]
-                  [:props (re/? (re/fn map?))]
-                  [:body (re/* (re/fn any?))])
-          [:p "Hello, world of data"])
+(deftest opt
+  (are [pred s r]
+    (= (m/validate [:? pred] s) r)
+    pos? 3 false
+    pos? [] true
+    pos? [3] true
+    pos? [-3] false
+    pos? [3 3] false))
 
-(re/parse (re/cat
-            [:type (re/fn keyword?)]
-            [:props (re/? (re/fn map?))]
-            [:body (re/* (re/fn int?))]) [:div {} 1 2 3])
+(deftest star
+  (are [pred s r]
+    (= (m/validate [:* pred] s) r)
+    pos? 3 false
+    pos? [] true
+    pos? [3] true
+    pos? [-3] false
+    pos? [3 3] true
+    pos? [3 -3] false))
 
-(s/* any?)
+(deftest plus
+  (are [pred s r]
+    (= (m/validate [:+ pred] s) r)
+    pos? 3 false
+    pos? [] false
+    pos? [3] true
+    pos? [-3] false
+    pos? [3 3] true
+    pos? [3 -3] false))
+
+(deftest repetition
+  (doseq [n (range 0 3)]
+    (is (not (m/validate [:repeat {:min 3, :max 7} [:= :x]] (repeat n :x)))))
+  (doseq [n (range 3 8)]
+    (is (m/validate [:repeat {:min 3, :max 7} [:= :x]] (repeat n :x))))
+  (doseq [n (range 8 16)]
+    (is (not (m/validate [:repeat {:min 3, :max 7} [:= :x]] (repeat n :x))))))
+
+(comment
+  (s/conform (s/+ int?) [])
+  (re/parse (re/repeat 2 ##Inf (re/fn int?)) [1 2])
+
+  (re/parse (re/cat [:type (re/fn keyword?)]
+                    [:props (re/? (re/fn map?))]
+                    #_(re/* (re/fn any?)))
+            [:p])
+
+  (re/parse (re/cat [:type (re/fn keyword?)]
+                    [:props (re/? (re/fn map?))]
+                    [:body (re/* (re/fn any?))])
+            [:p "Hello, world of data"])
+
+  (re/parse (re/cat
+              [:type (re/fn keyword?)]
+              [:props (re/? (re/fn map?))]
+              [:body (re/* (re/fn int?))]) [:div {} 1 2 3])
+
+  (s/* any?))
 
 (comment
   (s/def ::hiccup (s/alt :node (s/cat :name keyword?
@@ -90,227 +155,200 @@
       (when malli (testing "- malli" (is (= result (re/parse malli data)))))
       (when spec (testing "- spec" (is (= result (s/conform spec data))))))))
 
-(re/parse (re/* (re/fn int?)) [])
-(re/parse (re/alt [:number (re/fn int?)]
-                  [:sequence (re/cat [:string (re/fn string?)])]) 1)
+(comment
+  (re/parse (re/* (re/fn int?)) [])
+  (re/parse (re/alt [:number (re/fn int?)]
+                    [:sequence (re/cat [:string (re/fn string?)])]) 1)
 
-(s/conform
-  (s/cat :0 int?
-         :1 (s/* int?)
-         :2 (s/* int?)
-         :3 int?)
-  [1 2 3 4])
+  (s/conform
+    (s/cat :0 int?
+           :1 (s/* int?)
+           :2 (s/* int?)
+           :3 int?)
+    [1 2 3 4])
 
-(s/conform (s/alt :number int?
-                  :sequence (s/cat :string string?)) ["1"])
+  (s/conform (s/alt :number int?
+                    :sequence (s/cat :string string?)) ["1"])
 
-(require '[minimallist.helper :as h]
-         '[minimallist.core :as mc])
+  (require '[minimallist.helper :as h]
+           '[minimallist.core :as mc])
 
-(mc/describe
-  (h/cat [:0 (h/fn int?)]
-         [:1 (h/repeat 0 2 (h/fn int?))]
-         [:2 (h/repeat 0 2 (h/fn int?))]
-         [:3 (h/fn int?)])
-  [1 2 3 4 5])
+  (mc/describe
+    (h/cat [:0 (h/fn int?)]
+           [:1 (h/repeat 0 2 (h/fn int?))]
+           [:2 (h/repeat 0 2 (h/fn int?))]
+           [:3 (h/fn int?)])
+    [1 2 3 4 5])
 
-(require '[net.cgrand.seqexp :as se])
+  (require '[net.cgrand.seqexp :as se])
 
-(se/exec (se/cat (se/as :1 (se/repeat 0 2 int?))
-                 (se/as :2 (se/repeat 0 2 int?)))
-         [1 2])
+  (se/exec (se/cat (se/as :1 (se/repeat 0 2 int?))
+                   (se/as :2 (se/repeat 0 2 int?)))
+           [1 2])
 
 
-(let [test-data [;; fn
-                 (re/fn #(= 1 %))
-                 [[1] 1
-                  2 nil]
+  (let [test-data [;; fn
+                   (re/fn #(= 1 %))
+                   [[1] 1
+                    2 nil]
 
-                 ;; alt - not inside a sequence
-                 (re/alt [:number (re/fn int?)]
-                         [:sequence (re/cat (re/fn string?))])
-                 [1 nil
-                  ["1"] [:sequence ["1"]]
-                  [1] [:number 1]
-                  "1" nil]
+                   ;; alt - not inside a sequence
+                   (re/alt [:number (re/fn int?)]
+                           [:sequence (re/cat (re/fn string?))])
+                   [1 nil
+                    ["1"] [:sequence ["1"]]
+                    [1] [:number 1]
+                    "1" nil]
 
-                 ;; alt - inside a cat
-                 (re/cat (re/fn int?)
-                         (re/alt [:option1 (re/fn string?)]
-                                 [:option2 (re/fn keyword?)]
-                                 [:option3 (re/cat (re/fn string?)
-                                                   (re/fn keyword?))])
-                         (re/fn int?))
-                 [[1 "2" 3] [1 [:option1 "2"] 3]
-                  [1 :2 3] [1 [:option2 :2] 3]
-                  [1 "a" :b 3] [1 [:option3 ["a" :b]] 3]
-                  [1 ["a" :b] 3] nil]
+                   ;; alt - inside a cat
+                   (re/cat (re/fn int?)
+                           (re/alt [:option1 (re/fn string?)]
+                                   [:option2 (re/fn keyword?)]
+                                   [:option3 (re/cat (re/fn string?)
+                                                     (re/fn keyword?))])
+                           (re/fn int?))
+                   [[1 "2" 3] [1 [:option1 "2"] 3]
+                    [1 :2 3] [1 [:option2 :2] 3]
+                    [1 "a" :b 3] [1 [:option3 ["a" :b]] 3]
+                    [1 ["a" :b] 3] nil]
 
-                 ;; alt - inside a cat, but with :inline false on its cat entry
-                 #_#_(re/cat (re/fn int?)
-                             (re/alt [:option1 (re/fn string?)]
-                                     [:option2 (re/fn keyword?)]
-                                     [:option3 (re/not-inlined (re/cat (re/fn string?)
-                                                                       (re/fn keyword?)))])
-                             (re/fn int?))
-                     [[1 "2" 3] [1 [:option1 "2"] 3]
-                      [1 :2 3] [1 [:option2 :2] 3]
-                      [1 "a" :b 3] nil
-                      [1 ["a" :b] 3] [1 [:option3 ["a" :b]] 3]]
+                   ;; alt - inside a cat, but with :inline false on its cat entry
+                   #_#_(re/cat (re/fn int?)
+                               (re/alt [:option1 (re/fn string?)]
+                                       [:option2 (re/fn keyword?)]
+                                       [:option3 (re/not-inlined (re/cat (re/fn string?)
+                                                                         (re/fn keyword?)))])
+                               (re/fn int?))
+                       [[1 "2" 3] [1 [:option1 "2"] 3]
+                        [1 :2 3] [1 [:option2 :2] 3]
+                        [1 "a" :b 3] nil
+                        [1 ["a" :b] 3] [1 [:option3 ["a" :b]] 3]]
 
-                 ;; cat of cat, the inner cat is implicitly inlined
-                 (re/cat (re/fn int?)
-                         (re/cat (re/fn int?)))
-                 [[1 2] [1 [2]]
-                  [1] nil
-                  [1 [2]] nil
-                  [1 2 3] nil]
+                   ;; cat of cat, the inner cat is implicitly inlined
+                   (re/cat (re/fn int?)
+                           (re/cat (re/fn int?)))
+                   [[1 2] [1 [2]]
+                    [1] nil
+                    [1 [2]] nil
+                    [1 2 3] nil]
 
-                 ;; cat of cat, the inner cat is explicitly not inlined
-                 #_#_(re/cat (re/fn int?)
-                             (re/not-inlined (re/cat (re/fn int?))))
-                     [[1 [2]] [1 [2]]
-                      [1 '(2)] [1 [2]]
-                      [1] nil
-                      [1 2] nil
-                      [1 [2] 3] nil]
+                   ;; cat of cat, the inner cat is explicitly not inlined
+                   #_#_(re/cat (re/fn int?)
+                               (re/not-inlined (re/cat (re/fn int?))))
+                       [[1 [2]] [1 [2]]
+                        [1 '(2)] [1 [2]]
+                        [1] nil
+                        [1 2] nil
+                        [1 [2] 3] nil]
 
-                 ;; repeat - no collection type specified
-                 (re/repeat 0 2 (re/fn int?))
-                 [[] []
-                  [1] [1]
-                  [1 2] [1 2]
-                  '() []
-                  '(1) [1]
-                  '(2 3) [2 3]
-                  [1 2 3] nil
-                  '(1 2 3) nil]
+                   ;; repeat - no collection type specified
+                   (re/repeat 0 2 (re/fn int?))
+                   [[] []
+                    [1] [1]
+                    [1 2] [1 2]
+                    '() []
+                    '(1) [1]
+                    '(2 3) [2 3]
+                    [1 2 3] nil
+                    '(1 2 3) nil]
 
-                 ;; repeat - min > 0
-                 (re/repeat 2 3 (re/fn int?))
-                 [[] nil
-                  [1] nil
-                  [1 2] [1 2]
-                  [1 2 3] [1 2 3]
-                  [1 2 3 4] nil]
+                   ;; repeat - min > 0
+                   (re/repeat 2 3 (re/fn int?))
+                   [[] nil
+                    [1] nil
+                    [1 2] [1 2]
+                    [1 2 3] [1 2 3]
+                    [1 2 3 4] nil]
 
-                 ;; repeat - max = +Infinity
-                 (re/repeat 2 ##Inf (re/fn int?))
-                 [[] nil
-                  [1] nil
-                  [1 2] [1 2]
-                  [1 2 3] [1 2 3]]
+                   ;; repeat - max = +Infinity
+                   (re/repeat 2 ##Inf (re/fn int?))
+                   [[] nil
+                    [1] nil
+                    [1 2] [1 2]
+                    [1 2 3] [1 2 3]]
 
-                 ;; repeat - of a cat
-                 (re/repeat 1 2 (re/cat (re/fn int?)
-                                        (re/fn string?)))
-                 [[1 "a"] [[1 "a"]]
-                  [1 "a" 2 "b"] [[1 "a"] [2 "b"]]
-                  [] nil
-                  [1] nil
-                  [1 2] nil
-                  [1 "a" 2 "b" 3 "c"] nil]
+                   ;; repeat - of a cat
+                   (re/repeat 1 2 (re/cat (re/fn int?)
+                                          (re/fn string?)))
+                   [[1 "a"] [[1 "a"]]
+                    [1 "a" 2 "b"] [[1 "a"] [2 "b"]]
+                    [] nil
+                    [1] nil
+                    [1 2] nil
+                    [1 "a" 2 "b" 3 "c"] nil]
 
-                 ;; repeat - of a cat with :inlined false
-                 #_#_(re/repeat 1 2 (re/not-inlined (re/cat (re/fn int?)
-                                                            (re/fn string?))))
-                     [[[1 "a"]] [[1 "a"]]
-                      [[1 "a"] [2 "b"]] [[1 "a"] [2 "b"]]
-                      ['(1 "a") [2 "b"]] [[1 "a"] [2 "b"]]
-                      [] nil
-                      [1] nil
-                      [1 2] nil
-                      [1 "a"] nil
-                      [1 "a" 2 "b"] nil
-                      [1 "a" 2 "b" 3 "c"] nil]
+                   ;; repeat - of a cat with :inlined false
+                   #_#_(re/repeat 1 2 (re/not-inlined (re/cat (re/fn int?)
+                                                              (re/fn string?))))
+                       [[[1 "a"]] [[1 "a"]]
+                        [[1 "a"] [2 "b"]] [[1 "a"] [2 "b"]]
+                        ['(1 "a") [2 "b"]] [[1 "a"] [2 "b"]]
+                        [] nil
+                        [1] nil
+                        [1 2] nil
+                        [1 "a"] nil
+                        [1 "a" 2 "b"] nil
+                        [1 "a" 2 "b" 3 "c"] nil]
 
-                 ;; let / ref
-                 #_#_(re/let ['pos-even? (re/and (re/fn pos-int?)
-                                                 (re/fn even?))]
-                             (re/ref 'pos-even?))
-                     [0 nil
-                      1 nil
-                      2 2
-                      3 nil
-                      4 4]]]
+                   ;; let / ref
+                   #_#_(re/let ['pos-even? (re/and (re/fn pos-int?)
+                                                   (re/fn even?))]
+                               (re/ref 'pos-even?))
+                       [0 nil
+                        1 nil
+                        2 2
+                        3 nil
+                        4 4]]]
 
-  (doseq [[model data-description-pairs] (partition 2 test-data)]
-    (doseq [[data description] (partition 2 data-description-pairs)]
-      (is (= [data (re/parse model data)]
-             [data description])))))
+    (doseq [[model data-description-pairs] (partition 2 test-data)]
+      (doseq [[data description] (partition 2 data-description-pairs)]
+        (is (= [data (re/parse model data)]
+               [data description]))))))
 
-;;
-;; spike lee
-;;
+(comment
+  ;;
+  ;; spike lee
+  ;;
 
-(re/describe (re/repeat 2 3 (re/cat (re/repeat 1 2 (re/fn int?)))) [1 2 3 4])
-; => {:result [{0 [1 2]} {0 [3 4]}], :rest []}
+  (re/describe (re/repeat 2 3 (re/cat (re/repeat 1 2 (re/fn int?)))) [1 2 3 4])
+  ; => {:result [{0 [1 2]} {0 [3 4]}], :rest []}
 
-(re/describe (re/repeat 2 3 (re/cat (re/repeat 1 4 (re/fn int?)))) [1 2 3 4])
-; => {:result [{0 [1 2 3]} {0 [4]}], :rest []}
+  (re/describe (re/repeat 2 3 (re/cat (re/repeat 1 4 (re/fn int?)))) [1 2 3 4])
+  ; => {:result [{0 [1 2 3]} {0 [4]}], :rest []}
 
-(re/describe (re/repeat 1 ##Inf (re/cat (re/repeat 1 ##Inf (re/fn int?))
-                                        (re/repeat 0 ##Inf (re/fn int?)))) [1 2 3 4])
-; => {:result [{0 [1 2 3], 1 [4]}], :rest []}
+  (re/describe (re/repeat 1 ##Inf (re/cat (re/repeat 1 ##Inf (re/fn int?))
+                                          (re/repeat 0 ##Inf (re/fn int?)))) [1 2 3 4])
+  ; => {:result [{0 [1 2 3], 1 [4]}], :rest []}
 
-(re/describe (re/cat (re/+ (re/fn int?))
-                     (re/+ (re/fn string?))
-                     (re/+ (re/fn int?))
-                     (re/+ (re/fn string?)))
-             [1 2 3 "4" "5" 6 7 8 9 "10"])
-; => {:result {0 [1 2 3], 1 ["4" "5"], 2 [6 7 8 9], 3 ["10"]}, :rest []}
+  (re/describe (re/cat (re/+ (re/fn int?))
+                       (re/+ (re/fn string?))
+                       (re/+ (re/fn int?))
+                       (re/+ (re/fn string?)))
+               [1 2 3 "4" "5" 6 7 8 9 "10"])
+  ; => {:result {0 [1 2 3], 1 ["4" "5"], 2 [6 7 8 9], 3 ["10"]}, :rest []}
 
-(let [re (re/repeat 1 ##Inf (re/cat (re/repeat 1 ##Inf (re/fn int?))
-                                    (re/repeat 0 ##Inf (re/fn int?))))
-      valid? (re/validator re)
-      parse (re/parser re)
-      data [1 2 3 4]]
-  {:data data
-   :valid (valid? data)
-   :parsed (parse data)})
+  (let [re (re/repeat 1 ##Inf (re/cat (re/repeat 1 ##Inf (re/fn int?))
+                                      (re/repeat 0 ##Inf (re/fn int?))))
+        valid? (re/validator re)
+        parse (re/parser re)
+        data [1 2 3 4]]
+    {:data data
+     :valid (valid? data)
+     :parsed (parse data)})
 
-(let [re (re/* (re/cat (re/fn string?)
-                       (re/fn keyword?)))
-      parse (re/parser re)]
-  (parse ["-server" :foo "-verbose" :true "-user" :joe]))
+  (let [re (re/* (re/cat (re/fn string?)
+                         (re/fn keyword?)))
+        parse (re/parser re)]
+    (parse ["-server" :foo "-verbose" :true "-user" :joe]))
 
-(require '[clojure.spec.alpha :as s])
+  (require '[clojure.spec.alpha :as s])
 
-(s/def ::config (s/* (s/cat :prop string?, :val (s/alt :s string? :b boolean?))))
+  (s/def ::config (s/* (s/cat :prop string?, :val (s/alt :s string? :b boolean?))))
 
-(s/conform ::config ["-server" "foo" "-verbose" true "-user" "joe"])
-;[{:prop "-server", :val [:s "foo"]}
-; {:prop "-verbose", :val [:b true]}
-; {:prop "-user", :val [:s "joe"]}]
-
-(re/parse
-  (re/* (re/cat [:prop (re/fn string?)]
-                [:val (re/alt [:s (re/fn string?)]
-                              [:b (re/fn boolean?)])]))
-  ["-server" "foo" "-verbose" true "-user" "joe"])
-;[{:prop "-server", :val [:s "foo"]}
-; {:prop "-verbose", :val [:b true]}
-; {:prop "-user", :val [:s "joe"]}]
-
-[:* [:cat*
-     [:prop string?]
-     [:val [:alt*
-            [:s string?]
-            [:b boolean?]]]]]
-
-[:* [:cat string? [:alt string? boolean?]]]
-
-(do
-
-  (require '[malli.regex :as re])
-
-  #_(re/parse
-      [:* [:cat
-           [:prop string?]
-           [:val [:alt
-                  [:s string?]
-                  [:b boolean?]]]]]
-      ["-server" "foo" "-verbose" true "-user" "joe"])
+  (s/conform ::config ["-server" "foo" "-verbose" true "-user" "joe"])
+  ;[{:prop "-server", :val [:s "foo"]}
+  ; {:prop "-verbose", :val [:b true]}
+  ; {:prop "-user", :val [:s "joe"]}]
 
   (re/parse
     (re/* (re/cat [:prop (re/fn string?)]
@@ -321,10 +359,39 @@
   ; {:prop "-verbose", :val [:b true]}
   ; {:prop "-user", :val [:s "joe"]}]
 
-  )
+  [:* [:cat*
+       [:prop string?]
+       [:val [:alt*
+              [:s string?]
+              [:b boolean?]]]]]
 
-(s/explain-data (s/cat :a (s/map-of int? (s/cat :first int?))) [{1 ["1"]}])
-(get-in [{1 ["1"]}] [0 1])
+  [:* [:cat string? [:alt string? boolean?]]]
+
+  (do
+
+    (require '[malli.regex :as re])
+
+    #_(re/parse
+        [:* [:cat
+             [:prop string?]
+             [:val [:alt
+                    [:s string?]
+                    [:b boolean?]]]]]
+        ["-server" "foo" "-verbose" true "-user" "joe"])
+
+    (re/parse
+      (re/* (re/cat [:prop (re/fn string?)]
+                    [:val (re/alt [:s (re/fn string?)]
+                                  [:b (re/fn boolean?)])]))
+      ["-server" "foo" "-verbose" true "-user" "joe"])
+    ;[{:prop "-server", :val [:s "foo"]}
+    ; {:prop "-verbose", :val [:b true]}
+    ; {:prop "-user", :val [:s "joe"]}]
+
+    )
+
+  (s/explain-data (s/cat :a (s/map-of int? (s/cat :first int?))) [{1 ["1"]}])
+  (get-in [{1 ["1"]}] [0 1]))
 
 ;; validator <- impl without doing (much) garbage, parser without realizing results?
 ;; parser <- realized results

--- a/test/malli/regex_test.cljc
+++ b/test/malli/regex_test.cljc
@@ -1,0 +1,327 @@
+(ns malli.regex-test
+  (:require [clojure.test :refer :all]
+            [clojure.spec.alpha :as s]
+            [malli.regex :as re]))
+
+
+(s/conform (s/+ int?) [])
+(re/parse (re/repeat 2 ##Inf (re/fn int?)) [1 2])
+
+(re/parse (re/cat [:type (re/fn keyword?)]
+                  [:props (re/? (re/fn map?))]
+                  #_(re/* (re/fn any?)))
+          [:p])
+
+(re/parse (re/cat [:type (re/fn keyword?)]
+                  [:props (re/? (re/fn map?))]
+                  [:body (re/* (re/fn any?))])
+          [:p "Hello, world of data"])
+
+(re/parse (re/cat
+            [:type (re/fn keyword?)]
+            [:props (re/? (re/fn map?))]
+            [:body (re/* (re/fn int?))]) [:div {} 1 2 3])
+
+(s/* any?)
+
+(comment
+  (s/def ::hiccup (s/alt :node (s/cat :name keyword?
+                                      :props (s/? (s/map-of keyword? any?))
+                                      :children any? #_(s/* (s/spec ::hiccup)))
+                         :privitive (s/alt :nil nil?
+                                           :boolean boolean?
+                                           :number number?
+                                           :text string?)))
+
+  (s/conform ::hiccup [:div {:class [:foo :bar]}
+                       [:p "Hello, world of data"]])
+
+  (mh/valid? hiccup-model [:div {:class [:foo :bar]}
+                           [:p "Hello, world of data"]]))
+
+
+(comment
+
+  (def hiccup-model
+    (h/let ['hiccup (h/alt [:node (h/in-vector (h/cat [:name (h/fn keyword?)]
+                                                      [:props (h/? (h/map-of (h/fn keyword?) (h/fn any?)))]
+                                                      [:children (h/* (h/not-inlined (h/ref 'hiccup)))]))]
+                           [:primitive (h/alt [:nil (h/fn nil?)]
+                                              [:boolean (h/fn boolean?)]
+                                              [:number (h/fn number?)]
+                                              [:text (h/fn string?)])])]
+           (h/ref 'hiccup)))
+
+  (def expextations
+    [{:name "empty"
+      :data []
+      :result []
+      :malli (re/* (re/fn int?))
+      :spec (s/* int?)}
+
+     {:name "selecting right alt"
+      :data [1 "a" :b 3]
+      :result {:1 1, :2 [:option3 {:1 "a", :2 :b}], :3 3}
+      :malli (re/cat [:1 (re/fn int?)]
+                     [:2 (re/alt [:option1 (re/fn string?)]
+                                 [:option2 (re/fn keyword?)]
+                                 [:option3 (re/cat [:1 (re/fn string?)]
+                                                   [:2 (re/fn keyword?)])])]
+                     [:3 (re/fn int?)])
+      :spec (s/cat :1 int?
+                   :2 (s/alt :option1 string?
+                             :option2 keyword?
+                             :option3 (s/cat :1 string?
+                                             :2 keyword?))
+                   :3 int?)}
+
+     {:name "selecting right alt (anonymous)"
+      :data [1 "a" :b 3]
+      :result [1 [2 ["a" :b]] 3]
+      :malli (re/cat (re/fn int?)
+                     (re/alt (re/fn string?)
+                             (re/fn keyword?)
+                             (re/cat (re/fn string?)
+                                     (re/fn keyword?)))
+                     (re/fn int?))}])
+
+  (doseq [{:keys [name data result malli spec]} expextations]
+    (testing name
+      (when malli (testing "- malli" (is (= result (re/parse malli data)))))
+      (when spec (testing "- spec" (is (= result (s/conform spec data))))))))
+
+(re/parse (re/* (re/fn int?)) [])
+(re/parse (re/alt [:number (re/fn int?)]
+                  [:sequence (re/cat [:string (re/fn string?)])]) 1)
+
+(s/conform
+  (s/cat :0 int?
+         :1 (s/* int?)
+         :2 (s/* int?)
+         :3 int?)
+  [1 2 3 4])
+
+(s/conform (s/alt :number int?
+                  :sequence (s/cat :string string?)) ["1"])
+
+(require '[minimallist.helper :as h]
+         '[minimallist.core :as mc])
+
+(mc/describe
+  (h/cat [:0 (h/fn int?)]
+         [:1 (h/repeat 0 2 (h/fn int?))]
+         [:2 (h/repeat 0 2 (h/fn int?))]
+         [:3 (h/fn int?)])
+  [1 2 3 4 5])
+
+(require '[net.cgrand.seqexp :as se])
+
+(se/exec (se/cat (se/as :1 (se/repeat 0 2 int?))
+                 (se/as :2 (se/repeat 0 2 int?)))
+         [1 2])
+
+
+(let [test-data [;; fn
+                 (re/fn #(= 1 %))
+                 [[1] 1
+                  2 nil]
+
+                 ;; alt - not inside a sequence
+                 (re/alt [:number (re/fn int?)]
+                         [:sequence (re/cat (re/fn string?))])
+                 [1 nil
+                  ["1"] [:sequence ["1"]]
+                  [1] [:number 1]
+                  "1" nil]
+
+                 ;; alt - inside a cat
+                 (re/cat (re/fn int?)
+                         (re/alt [:option1 (re/fn string?)]
+                                 [:option2 (re/fn keyword?)]
+                                 [:option3 (re/cat (re/fn string?)
+                                                   (re/fn keyword?))])
+                         (re/fn int?))
+                 [[1 "2" 3] [1 [:option1 "2"] 3]
+                  [1 :2 3] [1 [:option2 :2] 3]
+                  [1 "a" :b 3] [1 [:option3 ["a" :b]] 3]
+                  [1 ["a" :b] 3] nil]
+
+                 ;; alt - inside a cat, but with :inline false on its cat entry
+                 #_#_(re/cat (re/fn int?)
+                             (re/alt [:option1 (re/fn string?)]
+                                     [:option2 (re/fn keyword?)]
+                                     [:option3 (re/not-inlined (re/cat (re/fn string?)
+                                                                       (re/fn keyword?)))])
+                             (re/fn int?))
+                     [[1 "2" 3] [1 [:option1 "2"] 3]
+                      [1 :2 3] [1 [:option2 :2] 3]
+                      [1 "a" :b 3] nil
+                      [1 ["a" :b] 3] [1 [:option3 ["a" :b]] 3]]
+
+                 ;; cat of cat, the inner cat is implicitly inlined
+                 (re/cat (re/fn int?)
+                         (re/cat (re/fn int?)))
+                 [[1 2] [1 [2]]
+                  [1] nil
+                  [1 [2]] nil
+                  [1 2 3] nil]
+
+                 ;; cat of cat, the inner cat is explicitly not inlined
+                 #_#_(re/cat (re/fn int?)
+                             (re/not-inlined (re/cat (re/fn int?))))
+                     [[1 [2]] [1 [2]]
+                      [1 '(2)] [1 [2]]
+                      [1] nil
+                      [1 2] nil
+                      [1 [2] 3] nil]
+
+                 ;; repeat - no collection type specified
+                 (re/repeat 0 2 (re/fn int?))
+                 [[] []
+                  [1] [1]
+                  [1 2] [1 2]
+                  '() []
+                  '(1) [1]
+                  '(2 3) [2 3]
+                  [1 2 3] nil
+                  '(1 2 3) nil]
+
+                 ;; repeat - min > 0
+                 (re/repeat 2 3 (re/fn int?))
+                 [[] nil
+                  [1] nil
+                  [1 2] [1 2]
+                  [1 2 3] [1 2 3]
+                  [1 2 3 4] nil]
+
+                 ;; repeat - max = +Infinity
+                 (re/repeat 2 ##Inf (re/fn int?))
+                 [[] nil
+                  [1] nil
+                  [1 2] [1 2]
+                  [1 2 3] [1 2 3]]
+
+                 ;; repeat - of a cat
+                 (re/repeat 1 2 (re/cat (re/fn int?)
+                                        (re/fn string?)))
+                 [[1 "a"] [[1 "a"]]
+                  [1 "a" 2 "b"] [[1 "a"] [2 "b"]]
+                  [] nil
+                  [1] nil
+                  [1 2] nil
+                  [1 "a" 2 "b" 3 "c"] nil]
+
+                 ;; repeat - of a cat with :inlined false
+                 #_#_(re/repeat 1 2 (re/not-inlined (re/cat (re/fn int?)
+                                                            (re/fn string?))))
+                     [[[1 "a"]] [[1 "a"]]
+                      [[1 "a"] [2 "b"]] [[1 "a"] [2 "b"]]
+                      ['(1 "a") [2 "b"]] [[1 "a"] [2 "b"]]
+                      [] nil
+                      [1] nil
+                      [1 2] nil
+                      [1 "a"] nil
+                      [1 "a" 2 "b"] nil
+                      [1 "a" 2 "b" 3 "c"] nil]
+
+                 ;; let / ref
+                 #_#_(re/let ['pos-even? (re/and (re/fn pos-int?)
+                                                 (re/fn even?))]
+                             (re/ref 'pos-even?))
+                     [0 nil
+                      1 nil
+                      2 2
+                      3 nil
+                      4 4]]]
+
+  (doseq [[model data-description-pairs] (partition 2 test-data)]
+    (doseq [[data description] (partition 2 data-description-pairs)]
+      (is (= [data (re/parse model data)]
+             [data description])))))
+
+;;
+;; spike lee
+;;
+
+(re/describe (re/repeat 2 3 (re/cat (re/repeat 1 2 (re/fn int?)))) [1 2 3 4])
+; => {:result [{0 [1 2]} {0 [3 4]}], :rest []}
+
+(re/describe (re/repeat 2 3 (re/cat (re/repeat 1 4 (re/fn int?)))) [1 2 3 4])
+; => {:result [{0 [1 2 3]} {0 [4]}], :rest []}
+
+(re/describe (re/repeat 1 ##Inf (re/cat (re/repeat 1 ##Inf (re/fn int?))
+                                        (re/repeat 0 ##Inf (re/fn int?)))) [1 2 3 4])
+; => {:result [{0 [1 2 3], 1 [4]}], :rest []}
+
+(re/describe (re/cat (re/+ (re/fn int?))
+                     (re/+ (re/fn string?))
+                     (re/+ (re/fn int?))
+                     (re/+ (re/fn string?)))
+             [1 2 3 "4" "5" 6 7 8 9 "10"])
+; => {:result {0 [1 2 3], 1 ["4" "5"], 2 [6 7 8 9], 3 ["10"]}, :rest []}
+
+(let [re (re/repeat 1 ##Inf (re/cat (re/repeat 1 ##Inf (re/fn int?))
+                                    (re/repeat 0 ##Inf (re/fn int?))))
+      valid? (re/validator re)
+      parse (re/parser re)
+      data [1 2 3 4]]
+  {:data data
+   :valid (valid? data)
+   :parsed (parse data)})
+
+(let [re (re/* (re/cat (re/fn string?)
+                       (re/fn keyword?)))
+      parse (re/parser re)]
+  (parse ["-server" :foo "-verbose" :true "-user" :joe]))
+
+(require '[clojure.spec.alpha :as s])
+
+(s/def ::config (s/* (s/cat :prop string?, :val (s/alt :s string? :b boolean?))))
+
+(s/conform ::config ["-server" "foo" "-verbose" true "-user" "joe"])
+;[{:prop "-server", :val [:s "foo"]}
+; {:prop "-verbose", :val [:b true]}
+; {:prop "-user", :val [:s "joe"]}]
+
+(re/parse
+  (re/* (re/cat [:prop (re/fn string?)]
+                [:val (re/alt [:s (re/fn string?)]
+                              [:b (re/fn boolean?)])]))
+  ["-server" "foo" "-verbose" true "-user" "joe"])
+;[{:prop "-server", :val [:s "foo"]}
+; {:prop "-verbose", :val [:b true]}
+; {:prop "-user", :val [:s "joe"]}]
+
+[:* [:cat*
+     [:prop string?]
+     [:val [:alt*
+            [:s string?]
+            [:b boolean?]]]]]
+
+[:* [:cat string? [:alt string? boolean?]]]
+
+(do
+
+  (require '[malli.regex :as re])
+
+  #_(re/parse
+      [:* [:cat
+           [:prop string?]
+           [:val [:alt
+                  [:s string?]
+                  [:b boolean?]]]]]
+      ["-server" "foo" "-verbose" true "-user" "joe"])
+
+  (re/parse
+    (re/* (re/cat [:prop (re/fn string?)]
+                  [:val (re/alt [:s (re/fn string?)]
+                                [:b (re/fn boolean?)])]))
+    ["-server" "foo" "-verbose" true "-user" "joe"])
+  ;[{:prop "-server", :val [:s "foo"]}
+  ; {:prop "-verbose", :val [:b true]}
+  ; {:prop "-user", :val [:s "joe"]}]
+
+  )
+
+(s/explain-data (s/cat :a (s/map-of int? (s/cat :first int?))) [{1 ["1"]}])
+(get-in [{1 ["1"]}] [0 1])


### PR DESCRIPTION
Based on [Seqexp](https://github.com/cgrand/seqexp) but much optimized and extended.

WIP:
- [ ] transformers
- [ ] sufficient tests
- [ ] benchmarking
- [ ] (more) optimization
- [ ] cleanup
- [ ] docstrings
- [ ] documentation (README etc.)
- [ ] tree parsing (for non-regex schemas as well, e.g. `:or`)