### PR TITLE
malli.transform: add a guard against decoding unrepresentable ints (fixes #315)

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -60,6 +60,7 @@
                  (cond
                    (js/isNaN x') x
                    (> x' js/Number.MAX_SAFE_INTEGER) x
+                   (< x' js/Number.MIN_SAFE_INTEGER) x
                    :else x')))
       (catch #?(:clj Exception, :cljs js/Error) _ x))
     x))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -56,7 +56,11 @@
   (if (string? x)
     (try
       #?(:clj  (Long/parseLong x)
-         :cljs (let [x' (if (re-find #"\D" (subs x 1)) ##NaN (js/parseInt x 10))] (if (js/isNaN x') x x')))
+         :cljs (let [x' (if (re-find #"\D" (subs x 1)) ##NaN (js/parseInt x 10))]
+                 (cond
+                   (js/isNaN x') x
+                   (> x' js/Number.MAX_SAFE_INTEGER) x
+                   :else x')))
       (catch #?(:clj Exception, :cljs js/Error) _ x))
     x))
 

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -27,6 +27,10 @@
 (deftest string->long
   (is (= 1 (mt/-string->long "1")))
   (is (= 1 (mt/-string->long 1)))
+  (is (= 9007199254740991 (mt/-string->long "9007199254740991")))
+  ;; Unfortunately, the number in the CLJ branch here isn't representable in JS 'integers'.
+  (is (= #?(:clj 9007199254740993 :cljs "9007199254740993")
+         (mt/-string->long "9007199254740993")))
   (is (= "abba" (mt/-string->long "abba"))))
 
 (deftest string->double

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -28,9 +28,12 @@
   (is (= 1 (mt/-string->long "1")))
   (is (= 1 (mt/-string->long 1)))
   (is (= 9007199254740991 (mt/-string->long "9007199254740991")))
+  (is (= -9007199254740991 (mt/-string->long "-9007199254740991")))
   ;; Unfortunately, the number in the CLJ branch here isn't representable in JS 'integers'.
   (is (= #?(:clj 9007199254740993 :cljs "9007199254740993")
          (mt/-string->long "9007199254740993")))
+  (is (= #?(:clj -9007199254740993 :cljs "-9007199254740993")
+         (mt/-string->long "-9007199254740993")))
   (is (= "abba" (mt/-string->long "abba"))))
 
 (deftest string->double


### PR DESCRIPTION
This branch makes it so that Malli won't try to decode strings in JS that don't have a representable value in JS.

Any number larger than `js/Number.MAX_SAFE_INTEGER` isn't reliably representable in JS, so whilst "9007199254740992" decodes to 9007199254740992 as you'd expect, "9007199254740993" (one greater) decodes to 9007199254740992 as well.

This results in a disparity in what can be decoded as an integer between JS and Java but given that JS can't represent certain numbers that's what we have to accept, I think. :)

There's more context on the fact that for example this is hard to detect in #315.

Hopefully this isn't a breaking change, since the previous behaviour could be considered 'incorrect' (the decodes resulted in unexpected values).