### PR TITLE
mu/find

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -135,10 +135,10 @@
   (-set-children schema (assoc (-children schema) key value)))
 
 (defn -get-entries [schema key default]
-  (or (if (and (vector? key) (= ::val (nth key 0)))
-        (some (fn [[k s]] (if (= k (nth key 1)) s)) (-entries schema))
-        (some (fn [[k _ s]] (if (= k key) s)) (-children schema)))
-      default))
+  (or (some (if (and (vector? key) (= ::find (nth key 0)))
+              (fn [[k :as e]] (when (= k (nth key 1)) e))
+              (fn [[k _ s]] (when (= k key) s)))
+            (-children schema)) default))
 
 (defn -set-entries [schema key value]
   (let [found (atom nil)

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -1,5 +1,5 @@
 (ns malli.util
-  (:refer-clojure :exclude [merge select-keys get get-in dissoc assoc update assoc-in update-in])
+  (:refer-clojure :exclude [merge select-keys find get get-in dissoc assoc update assoc-in update-in])
   (:require [clojure.core :as c]
             [malli.core :as m]))
 
@@ -237,6 +237,14 @@
    (dissoc ?schema key nil))
   ([?schema key options]
    (transform-entries ?schema #(remove (fn [[k]] (= key k)) %) options)))
+
+(defn find
+  "Like [[clojure.core/find]], but for MapSchemas."
+  ([?schema k]
+   (find ?schema k nil))
+  ([?schema k options]
+   (let [schema (m/schema (or ?schema :map) options)]
+     (if schema (m/-get schema [::m/find k] nil)))))
 
 ;;
 ;; LensSchemas

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -819,3 +819,24 @@
                (m/form (m/deref s))))
         (is (= true (m/validate s {:x "x", :z "z"})))
         (is (= false (m/validate s {:x "x", :y "y" :z "z"})))))))
+
+(def Int (m/schema int?))
+
+(deftest find-test
+
+  (is (= [:b {:optional true} Int]
+         (mu/get [:map [:b {:optional true} Int]]
+                 [::m/find :b])))
+
+  (is (= [:b {:optional true} Int]
+         (mu/find [:map [:b {:optional true} Int]]
+                  :b)))
+
+  (is (= [:b {:optional true} Int]
+         (-> [:map [:a [:map [:b {:optional true} Int]]]]
+             (mu/get :a)
+             (mu/find :b))))
+
+  (is (= [:b {:optional true} Int]
+         (-> [:map [:a [:map [:b {:optional true} Int]]]]
+             (mu/get-in [:a [::m/find :b]])))))


### PR DESCRIPTION
Fix broken entry-finding convention, `:malli.core/find` instead of `malli.core/val`.

```clj
(mu/get [:map [:b {:optional true} int?]] [::m/find :b])
; => [:b {:optional true} int?]

(mu/find [:map [:b {:optional true} int?]] :b)
; => [:b {:optional true} int?]

(-> [:map [:a [:map [:b {:optional true} Int]]]]
    (mu/get :a)
    (mu/find :b))
; => [:b {:optional true} int?]

(-> [:map [:a [:map [:b {:optional true} Int]]]]
    (mu/get-in [:a [::m/find :b]]))
; => [:b {:optional true} int?]
```