### PR TITLE
Schema parsing / conform

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1224,7 +1224,7 @@
           (-regex-transformer [_ transformer method options]
             (re-transformer properties (map #(-regex-transformer % transformer method options) children))))))))
 
-(defn -sequence-entry-schema [{:keys [type child-bounds re-validator re-explainer re-transformer] :as opts}]
+(defn -sequence-entry-schema [{:keys [type child-bounds re-validator re-explainer re-conformer re-transformer] :as opts}]
   ^{:type ::into-schema}
   (reify IntoSchema
     (-into-schema [_ properties children options]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1260,7 +1260,7 @@
             (re-validator properties (map (fn [[k _ s]] [k (-regex-validator s)]) children)))
           (-regex-explainer [_ path]
             (re-explainer properties (map (fn [[k _ s]] [k (-regex-explainer s (conj path k))]) children)))
-          (-regex-conformer [_] (re-conformer properties (map (fn [[k s]] [k (-into-regex-conformer s)]) children)))
+          (-regex-conformer [_] (re-conformer properties (map (fn [[k _ s]] [k (-into-regex-conformer s)]) children)))
           (-regex-transformer [_ transformer method options]
             (re-transformer properties (map (fn [[k _ s]] [k (-regex-transformer s transformer method options)])
                                             children))))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -62,6 +62,8 @@
   (-regex-conformer [this] "returns the raw internal regex conformer implementation")
   (-regex-transformer [this transformer method options] "returns the raw internal regex transformer implementation"))
 
+(declare conformer)
+
 (extend-type #?(:clj Object, :cljs default)
   RegexSchema
   (-regex-op? [_] false)
@@ -79,7 +81,7 @@
   (-regex-conformer [this]
     (if (satisfies? RefSchema this)
       (-regex-conformer (-deref this))
-      (re/item-parser (-validator this))))
+      (re/item-parser (conformer this))))
 
   (-regex-transformer [this transformer method options]
     (if (satisfies? RefSchema this)
@@ -1181,7 +1183,7 @@
             (-regex-conformer [_]
               (if internal?
                 (-regex-conformer child)
-                (re/item-parser (-validator child))))
+                (re/item-parser (conformer child))))
             (-regex-transformer [_ transformer method options]
               (if internal?
                 (-regex-transformer child transformer method options)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1601,12 +1601,12 @@
    :cat* (-sequence-entry-schema {:type :cat*, :child-bounds {}
                                   :re-validator (fn [_ children] (apply re/cat-validator children))
                                   :re-explainer (fn [_ children] (apply re/cat-explainer children))
-                                  :re-conformer (fn [_ children] (apply re/cat-parser children))
+                                  :re-conformer (fn [_ children] (apply re/cat*-parser children))
                                   :re-transformer (fn [_ children] (apply re/cat-transformer children))})
    :alt* (-sequence-entry-schema {:type :alt*, :child-bounds {:min 1}
                                   :re-validator (fn [_ children] (apply re/alt-validator children))
                                   :re-explainer (fn [_ children] (apply re/alt-explainer children))
-                                  :re-conformer (fn [_ children] (apply re/alt-parser children))
+                                  :re-conformer (fn [_ children] (apply re/alt*-parser children))
                                   :re-transformer (fn [_ children] (apply re/alt-transformer children))})})
 
 (defn base-schemas []

--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -77,11 +77,11 @@
             (k (inc pos) (rest coll))))
         (fail! driver pos [(miu/-error path in schema nil :malli.core/end-of-input)])))))
 
-(defn item-parser [valid?]
+(defn item-parser [conform]
   (fn [_ _ pos coll k]
     (when (seq coll)
-      (let [v (first coll)]
-        (when (valid? v)
+      (let [v (conform (first coll))]
+        (when-not (= v :malli.core/nonconforming)
           (k v (inc pos) (rest coll)))))))
 
 (defn item-encoder [valid? encode]

--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -15,6 +15,11 @@
   failed; much simpler than the graph-structured stacks of GLL. And the register
   stack is only there for and used by :repeat.
 
+  NOTE: For the memoization to work correctly, every node in the schema tree
+  must get its own validation/explanation/... function instance. So even every
+  `(malli.impl.regex/cat)` call must return a new fn instance although it does not
+  close over anything.
+
   https://epsil.github.io/gll/ is a nice explanation of GLL parser combinators
   and has links to papers etc. It also inspired Instaparse, which Engelberg
   had a presentation about at Clojure/West 2014.
@@ -112,7 +117,17 @@
 
 (defn end-transformer [] (fn [_ _ coll* pos coll k] (when (empty? coll) (k coll* pos coll))))
 
+;;;; ## Unit
+
+(defn pure-parser [v] (fn [_ _ pos coll k] (k v pos coll)))
+
 ;;;; # Combinators
+
+;;;; ## Functor
+
+(defn fmap [f p]
+  (fn [driver regs pos coll k]
+    (p driver regs pos coll (fn [v pos coll] (k (f v) pos coll)))))
 
 ;;;; ## Catenation
 
@@ -198,13 +213,14 @@
            (reverse (cons r rs)))))
 
 (defn alt*-parser
-  ([[tag r]] (fn [driver pos coll k] (r driver pos coll (fn [v pos coll] (k (miu/-tagged tag v) pos coll)))))
+  ([[tag r]] (fmap (fn [v] (miu/-tagged tag v)) r))
   ([kr & krs]
    (let [krs (reverse (cons kr krs))]
      (reduce (fn [acc [tag r]]
-               (fn [driver regs pos coll k]
-                 (park-validator! driver acc regs pos coll k) ; remember fallback
-                 (park-validator! driver r regs pos coll (fn [v pos coll] (k (miu/-tagged tag v) pos coll)))))
+               (let [r (fmap (fn [v] (miu/-tagged tag v)) r)]
+                 (fn [driver regs pos coll k]
+                   (park-validator! driver acc regs pos coll k) ; remember fallback
+                   (park-validator! driver r regs pos coll k))))
              (alt*-parser (first krs))
              (rest krs)))))
 
@@ -222,7 +238,7 @@
 
 (defn ?-validator [p] (alt-validator p (cat-validator)))
 (defn ?-explainer [p] (alt-explainer p (cat-explainer)))
-(defn ?-parser [p] (alt-parser p (cat-parser)))
+(defn ?-parser [p] (alt-parser p (pure-parser nil)))
 (defn ?-transformer [p] (alt-transformer p (cat-transformer)))
 
 ;;;; ## Kleene Star
@@ -259,7 +275,7 @@
 
 (defn +-validator [p] (cat-validator p (*-validator p)))
 (defn +-explainer [p] (cat-explainer p (*-explainer p)))
-(defn +-parser [p] (cat-parser p (*-parser p)))
+(defn +-parser [p] (fmap (fn [[v vs]] (cons v vs)) (cat-parser p (*-parser p))))
 (defn +-transformer [p] (cat-transformer p (*-transformer p)))
 
 ;;;; ## Repeat
@@ -313,7 +329,7 @@
       (fn [driver regs pos coll k] (compulsories driver (conj regs 0) pos coll k)))))
 
 (defn repeat-parser [min max p]
-  (let [rep-epsilon (cat-parser)]
+  (let [rep-epsilon (fn [_ _ coll* pos coll k] (k coll* pos coll))]
     (letfn [(compulsories [driver regs coll* pos coll k]
               (if (< (peek regs) min)
                 (p driver regs pos coll
@@ -334,7 +350,7 @@
                          (fn [driver regs coll* pos coll k]
                            (optionals driver (conj (pop regs) (inc (peek regs))) (conj coll* v) pos coll k))
                          regs coll* pos coll k)))) ; TCO
-                (k pos coll)))]
+                (k coll* pos coll)))]
       (fn [driver regs pos coll k] (compulsories driver (conj regs 0) [] pos coll k)))))
 
 (defn repeat-transformer [min max p]

--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -3,12 +3,6 @@
 
 (defn -tagged [k v] #?(:clj (MapEntry. k v), :cljs (MapEntry. k v nil)))
 
-(defn stateful-mapv [f coll s]
-  (let [s (volatile! s)]
-    [(mapv (fn [v] (let [[v* s*] (f v @s)] (vreset! s s*) v*))
-           coll)
-     @s]))
-
 (defn -fail!
   ([type]
    (-fail! type nil))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1258,7 +1258,7 @@
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
               nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
               ["foo"] ["foo" (miu/-tagged :s "foo")] nil
-              [0] [0 (miu/-tagged :s 0)] nil
+              [0] [0 (miu/-tagged :n 0)] nil
               ["foo" 0] nil [{:path [], :in [1], :schema s, :value 0, :type ::m/input-remaining}]
               [0 "foo"] nil [{:path [], :in [1], :schema s, :value "foo", :type ::m/input-remaining}])))
 
@@ -1296,8 +1296,8 @@
           0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
           "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
           nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
-          [] [] nil
-          ["foo"] ["foo"] nil
+          [] nil nil
+          ["foo"] "foo" nil
           [0] nil [{:path [0], :in [0], :schema string?, :value 0}
                    {:path [], :in [0], :schema s, :value 0, :type ::m/input-remaining}]
           ["foo" 0] nil [{:path [], :in [1], :schema s, :value 0, :type ::m/input-remaining}]))
@@ -1308,7 +1308,7 @@
                                      (repeat n [:= :a])))
               v (repeat n :a)]
           (is (m/validate s v))
-          (is (= (concat (repeat n []) v) (m/conform s v))))))
+          (is (= (concat (repeat n nil) v) (m/conform s v))))))
 
     (testing "*"
       (is (thrown? #?(:clj Exception, :cljs js/Error) (m/validator [:*])))


### PR DESCRIPTION
Something like this for #241 and the rest of #180?

Builds on top of #317.

* On failure, `(m/conform s v)` returns `:malli.core/nonconforming`
* For most schemas `(m/conform s v)` just returns something that is `=` to `v` (optimally, `v` itself).
* But for the (new) `:or*` (tagged `:or`) `(= (m/conform [:or* [:s string?] [:n int?]] 0) (miu/-tagged :n 0))`
    - Non-identity conforming like this propagates: `(= (m/conform [:tuple [:or* [:s string?] [:n int?]]] [0]) [(miu/-tagged :n 0)])`
* Seqexes conform much as in Spec:

```clj
(m/conform [:alt string? int?] [0]) ; => 0
(m/conform [:alt* [:s string?] [:n int?]] [0]) ; => (miu/-tagged :n 0)

(m/conform [:cat [:* string?] [:* int?]] ["foo" "bar" 1 2]) ; => [["foo" "bar"] [1 2]]
(m/conform [:cat* [:s [:* string?]] [:n [:* int?]]] ["foo" "bar" 1 2]) ; => {:s ["foo" "bar"], :n [1 2]}

(m/conform [:? string?] ["foo"]) ; => "foo"
(m/conform [:? string?] []) ; => nil

(m/conform [:* string?] ["foo" "bar"]) ; => ["foo" "bar"]
(m/conform [:* string?] []) ; => []

(m/conform [:+ string?] ["foo" "bar"]) ; => ("foo" "bar")
(m/conform [:+ string?] []) ; => :malli.core/nonconforming

(m/conform [:repeat {:min 1, :max 3} string?] []) ; => :malli.core/nonconforming
(m/conform [:repeat {:min 1, :max 3} string?] ["foo" "bar"]) ; => ["foo" "bar"]
(m/conform [:repeat {:min 1, :max 3} string?] ["foo" "bar" "baz" "quux"]) ; => :malli.core/nonconforming

(m/conform [:cat* [:s [:schema [:* string?]]]] [["foo" "bar"]]) ; => {:s ["foo" "bar"]}
```