### PR TITLE
Fix crash in humanize for maps

### DIFF
--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -132,8 +132,10 @@
 (defn- -assoc-in [acc value [p & ps] error]
   (cond
     p (let [acc' (-ensure (or acc (empty value)) p)
-            value' (if ps (-assoc-in (-get acc p) (-get value p) ps error) error)]
-        (-put acc' p value'))
+            error' (if (or ps (map? value))
+                     (-assoc-in (-get acc p) (-get value p) ps error)
+                     error)]
+        (-put acc' p error'))
     (map? value) (recur acc value [:malli/error] error)
     acc acc
     :else error))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -148,7 +148,20 @@
            (me/humanize
              {:value {},
               :errors [{:in [:x], :schema [:map [:x int?]], :type ::m/missing-key}
-                       {:in [:x], :schema [:map [:x int?]], :type ::m/missing-key}]})))))
+                       {:in [:x], :schema [:map [:x int?]], :type ::m/missing-key}]}))))
+
+  (testing "maps can have top level errors and key errors"
+    (is (= {:person {:malli/error ["should be a seq"],
+                     :name ["missing required key"]}}
+           (-> [:map [:person [:and seq? [:map [:name string?]]]]]
+               (m/explain {:person {}})
+               (me/humanize)))))
+
+  (testing "maps have errors inside"
+    (is (= {:person {:malli/error ["should be a seq"]}}
+           (-> [:map [:person seq?]]
+               (m/explain {:person {}})
+               (me/humanize))))))
 
 (deftest humanize-customization-test
   (let [schema [:map


### PR DESCRIPTION
This change makes it so that humanize always "descends" into maps, so errors that used to reside "on" a map now go inside in the :malli/error key. The alternative would be to have top level errors go "on" a map, but then move them inside the map as the need arises, but it seemed bad to have the format change based on what other errors are found.

Fixes #321