### PR TITLE
Expose function to register a function schema.

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1509,11 +1509,14 @@
                (-fail! ::overlapping-arities {:arities arity->=>})) s)
        (-fail! :invalid-=>schema {:type (type s), :schema s})))))
 
+(defn =>register-schema! [ns name value]
+  (swap! -=>schemas* assoc-in [ns name]
+         {:schema (=>schema value)
+          :meta   (meta name)
+          :ns     ns
+          :name   name}))
+
 (defmacro => [name value]
   (let [name' `'~(symbol (str name))]
     `(let [ns# (symbol (str *ns*))]
-       (swap! @#'-=>schemas* assoc-in [ns# ~name']
-              {:schema (=>schema ~value)
-               :meta ~(meta name)
-               :ns ns#
-               :name ~name'}))))
+       (=>register-schema! ns# ~name' ~value))))


### PR DESCRIPTION
Use case: I want to be able to store my function schemas in an edn file and to generate a clj-kondo config as part of my build process. Currently the only way to register a new function schema to the registry is using the "=>" macro which assumes the schema definition is in the same compilation unit as the function it specifies.
This patch exposes a new function  m/=>register-schema! which allows registering function schemas from a different compilation unit.