### PR TITLE
malli.registry: allow dynamic/mutable registries to contain a registry, not just a map

### DIFF
--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -45,16 +45,16 @@
 (defn mutable-registry [db]
   (reify
     Registry
-    (-schema [_ type] (get @db type))
-    (-schemas [_] @db)))
+    (-schema [_ type] (-schema (registry @db) type))
+    (-schemas [_] (-schemas (registry @db)))))
 
 (def ^:dynamic *registry* {})
 
 (defn dynamic-registry []
   (reify
     Registry
-    (-schema [_ type] (get *registry* type))
-    (-schemas [_] *registry*)))
+    (-schema [_ type] (-schema (registry *registry*) type))
+    (-schemas [_] (-schemas (registry *registry*)))))
 
 (defn lazy-registry [default-registry provider]
   (let [cache* (atom {})


### PR DESCRIPTION
I was trying to do this:

```clojure
(binding [mr/*registry* (mr/lazy-registry ...)]
  ...)
```

... which isn't possible, because `dynamic-registry` is implemented like this:

```clojure
(def ^:dynamic *registry* {})

(defn dynamic-registry []
  (reify
    Registry
    (-schema [_ type] (get *registry* type))
    (-schemas [_] *registry*)))
```

... and mutable-registry is implemented the same way, assuming that the underlying db is a map.

It would be nice if `Registry` could just be implemented for `APersistentMap/IPersistentMap` and all of the ClojureScript maps directly, perhaps? I tried it out and it works well on Clojure, but I imagine there's a reason that things don't already work that way? I can start an issue for that if it's a tenable path, but that's a more extensive change of course.

Hopefully this option is relatively uncontroversial.

For usage with a map, due to the way `registry` works, this PR just turns `(get db type)` into a type check for `satisfies? Registry` vs `map?`, a reify and then a `(get db type)`.