### PR TITLE
malli.util: add a rename-keys utility, similar to clojure.set

### DIFF
--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -171,6 +171,25 @@
                        [:a])
                      [:map [:a int?]])))))
 
+(deftest rename-keys-test
+  (let [schema [:map {:title "map"}
+                [:a int?]
+                [:b {:optional true} int?]
+                [:c string?]]]
+    (is (mu/equals (mu/rename-keys schema {}) schema))
+    (is (mu/equals (mu/rename-keys schema nil) schema))
+    (is (mu/equals (mu/rename-keys schema {:a :a}) schema))
+    (is (mu/equals (mu/rename-keys schema {:extra :k}) schema))
+    (is (mu/equals (mu/rename-keys schema {:a :b}) [:map {:title "map"}
+                                                    [:b int?]
+                                                    [:c string?]]))
+    (is (mu/equals (mu/rename-keys schema {:a :b
+                                           :b :c
+                                           :c :a}) [:map {:title "map"}
+                                                    [:b int?]
+                                                    [:c {:optional true} int?]
+                                                    [:a string?]]))))
+
 ;;
 ;; LensSchemas
 ;;


### PR DESCRIPTION
It looked to me that renaming keys isn't a completely trivial operation for a user to implement themselves (without a series of `dissoc`/`assoc` pairs that would be pretty inefficient), so I added in a utility for performing it using `transform-entries`.

This... may not be the best implementation possible, so if there's a better way that's preferred I can do that or it can just be swapped out.

Also I may be missing an existing simple solution to this. :)