### PR TITLE
Building on top of #330

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ cljs-test-runner-out
 *.jar
 classes
 /demo
+/demosci
 /target
 .clj-kondo

--- a/README.md
+++ b/README.md
@@ -2048,8 +2048,24 @@ clj -Minstall
 
 ## Bundle size for cljs
 
+With default registry (37KB+ Gzipped)
+
 ```bash
+# no sci
 npx shadow-cljs run shadow.cljs.build-report app /tmp/report.html
+
+# with sci
+npx shadow-cljs run shadow.cljs.build-report app-sci /tmp/report.html
+```
+
+With minimal registry (2.4KB+ Gzipped)
+
+```bash
+# no sci
+npx shadow-cljs run shadow.cljs.build-report app2 /tmp/report.html
+
+# with sci
+npx shadow-cljs run shadow.cljs.build-report app2-sci /tmp/report.html
 ```
 
 ## Checking the generated code

--- a/README.md
+++ b/README.md
@@ -2071,11 +2071,11 @@ With sci (18Mb):
 
 ```clj
 ./bin/native-image demosci
-./demo '[:fn (fn [x] (and (int? x) (> x 10)))]]' '12'
+./demosci '[:fn (fn [x] (and (int? x) (> x 10)))]]' '12'
 ```
 
 ## License
 
-Copyright © 2019-2020 Metosin Oy and contributors.
+Copyright © 2019-2021 Metosin Oy and contributors.
 
 Available under the terms of the Eclipse Public License 2.0, see `LICENSE`.

--- a/bin/native-image
+++ b/bin/native-image
@@ -19,7 +19,7 @@ fi
 
 "$GRAALVM_HOME/bin/native-image" \
     -cp "$(clojure -A:graalvm -Spath):classes" \
-    -H:Name=demo \
+    -H:Name=$1 \
     -J-Dborkdude.dynaload.aot=true \
     -H:+ReportExceptionStackTraces \
     --initialize-at-build-time  \

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -8,6 +8,8 @@
                    (clojure.lang IDeref)
                    [malli.impl.util SchemaError])))
 
+(declare schema schema? into-schema into-schema? eval default-registry -simple-schema -val-schema -ref-schema -schema-schema -registry parser)
+
 ;;
 ;; protocols and records
 ;;
@@ -61,8 +63,6 @@
   (-regex-parser [this] "returns the raw internal regex parser implementation")
   (-regex-transformer [this transformer method options] "returns the raw internal regex transformer implementation"))
 
-(declare parser)
-
 (extend-type #?(:clj Object, :cljs default)
   RegexSchema
   (-regex-op? [_] false)
@@ -104,7 +104,6 @@
 ;; impl
 ;;
 
-(declare schema schema? into-schema into-schema? eval default-registry -simple-schema -val-schema -ref-schema -schema-schema -registry)
 
 (defn -safe-pred [f] #(try (f %) (catch #?(:clj Exception, :cljs js/Error) _ false)))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -26,9 +26,7 @@
   (-type-properties [this] "returns schema type properties")
   (-validator [this] "returns a predicate function that checks if the schema is valid")
   (-explainer [this path] "returns a function of `x in acc -> maybe errors` to explain the errors for invalid values")
-  (-parser [this]
-    "return a function of `x -> parsed-x` to explain how schema is valid.
-    If the value is not valid for the schema, the function throws.")
+  (-parser [this] "return a function of `x -> parsed-x | ::m/invalid` to explain how schema is valid.")
   (-transformer [this transformer method options]
     "returns a function to transform the value for the given schema and method.
     Can also return nil instead of `identity` so that more no-op transforms can be elided.")

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -24,7 +24,7 @@
   (-type-properties [this] "returns schema type properties")
   (-validator [this] "returns a predicate function that checks if the schema is valid")
   (-explainer [this path] "returns a function of `x in acc -> maybe errors` to explain the errors for invalid values")
-  (-conformer [this]
+  (-parser [this]
     "return a function of `x -> parsed-x` to explain how schema is valid.
     If the value is not valid for the schema, the function throws.")
   (-transformer [this transformer method options]
@@ -58,10 +58,10 @@
   (-regex-op? [this] "is this a regex operator (e.g. :cat, :*...)")
   (-regex-validator [this] "returns the raw internal regex validator implementation")
   (-regex-explainer [this path] "returns the raw internal regex explainer implementation")
-  (-regex-conformer [this] "returns the raw internal regex conformer implementation")
+  (-regex-parser [this] "returns the raw internal regex parser implementation")
   (-regex-transformer [this transformer method options] "returns the raw internal regex transformer implementation"))
 
-(declare conformer)
+(declare parser)
 
 (extend-type #?(:clj Object, :cljs default)
   RegexSchema
@@ -77,10 +77,10 @@
       (-regex-explainer (-deref this) path)
       (re/item-explainer path this (-explainer this path))))
 
-  (-regex-conformer [this]
+  (-regex-parser [this]
     (if (satisfies? RefSchema this)
-      (-regex-conformer (-deref this))
-      (re/item-parser (conformer this))))
+      (-regex-parser (-deref this))
+      (re/item-parser (parser this))))
 
   (-regex-transformer [this transformer method options]
     (if (satisfies? RefSchema this)
@@ -119,7 +119,7 @@
 
 (def -error miu/-error)
 
-(defn -nonconforming? [x] #?(:clj (identical? x ::nonconforming), :cljs (keyword-identical? x ::nonconforming)))
+(defn -invalid? [x] #?(:clj (identical? x ::invalid), :cljs (keyword-identical? x ::invalid)))
 
 (defn -check-children! [type properties children {:keys [min max] :as opts}]
   (if (or (and min (< (count children) min)) (and max (> (count children) max)))
@@ -319,7 +319,7 @@
             (-explainer [this path]
               (fn explain [x in acc]
                 (if-not (validator x) (conj acc (-error path in this x)) acc)))
-            (-conformer [_] (fn [x] (if (validator x) x ::nonconforming)))
+            (-parser [_] (fn [x] (if (validator x) x ::invalid)))
             (-transformer [this transformer method options]
               (-coder (-value-transformer transformer this method options)))
             (-walk [this walker path options]
@@ -363,9 +363,9 @@
           (-explainer [_ path]
             (let [explainers (mapv (fn [[i c]] (-explainer c (conj path i))) (map-indexed vector children))]
               (fn explain [x in acc] (reduce (fn [acc' explainer] (explainer x in acc')) acc explainers))))
-          (-conformer [_]
-            (let [conformers (mapv -conformer children)]
-              (fn [x] (reduce (fn [x conformer] (conformer x)) x conformers))))
+          (-parser [_]
+            (let [parsers (mapv -parser children)]
+              (fn [x] (reduce (fn [x parser] (parser x)) x parsers))))
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options]
@@ -404,12 +404,12 @@
                     (let [acc'' (explainer x in acc')]
                       (if (identical? acc' acc'') (reduced acc) acc'')))
                   acc explainers))))
-          (-conformer [_]
-            (let [conformers (mapv -conformer children)]
-              (fn [x] (reduce (fn [_ conformer]
-                                (let [result (conformer x)]
-                                  (if (-nonconforming? result) result (reduced result))))
-                              ::nonconforming conformers))))
+          (-parser [_]
+            (let [parsers (mapv -parser children)]
+              (fn [x] (reduce (fn [_ parser]
+                                (let [result (parser x)]
+                                  (if (-invalid? result) result (reduced result))))
+                              ::invalid parsers))))
           (-transformer [this transformer method options]
             (let [this-transformer (-value-transformer transformer this method options)]
               (if (seq children)
@@ -464,12 +464,12 @@
                     (let [acc'' (explainer x in acc')]
                       (if (identical? acc' acc'') (reduced acc) acc'')))
                   acc explainers))))
-          (-conformer [_]
-            (let [conformers (mapv (fn [[k _ c]]
-                                     (let [c (-conformer c)]
-                                       (fn [x] (let [r (c x)]
-                                                 (if (-nonconforming? r) r (reduced (miu/-tagged k r))))))) children)]
-              (fn [x] (reduce (fn [_ conformer] (conformer x)) x conformers))))
+          (-parser [_]
+            (let [parsers (mapv (fn [[k _ c]]
+                                  (let [c (-parser c)]
+                                    (fn [x] (let [r (c x)]
+                                              (if (-invalid? r) r (reduced (miu/-tagged k r))))))) children)]
+              (fn [x] (reduce (fn [_ parser] (parser x)) x parsers))))
           (-transformer [this transformer method options]
             (let [this-transformer (-value-transformer transformer this method options)]
               (if (seq children)
@@ -519,7 +519,7 @@
            (-type-properties [_])
            (-validator [_] (-validator schema))
            (-explainer [_ path] (-explainer schema path))
-           (-conformer [_] (-conformer schema))
+           (-parser [_] (-parser schema))
            (-transformer [this transformer method options]
              (-parent-children-transformer this children transformer method options))
            (-walk [this walker path options]
@@ -601,24 +601,24 @@
                      (fn [acc explainer]
                        (explainer x in acc))
                      acc explainers)))))
-           (-conformer [_]
-             (let [conformers (cond-> (mapv
-                                        (fn [[key {:keys [optional]} schema]]
-                                          (let [conformer (-conformer schema)]
-                                            (fn [m]
-                                              (if-let [e (find m key)]
-                                                (let [v (val e)
-                                                      v* (conformer v)]
-                                                  (cond (-nonconforming? v*) (reduced v*)
-                                                        (identical? v* v) m
-                                                        :else (assoc m key v*)))
-                                                (if optional m (reduced ::nonconforming))))))
-                                        children)
-                                      closed (into [(fn [m]
-                                                      (reduce
-                                                        (fn [m k] (if (contains? keyset k) m (reduced (reduced ::nonconforming))))
-                                                        m (keys m)))]))]
-               (fn [x] (if (map? x) (reduce (fn [m conformer] (conformer m)) x conformers) ::nonconforming))))
+           (-parser [_]
+             (let [parsers (cond-> (mapv
+                                     (fn [[key {:keys [optional]} schema]]
+                                       (let [parser (-parser schema)]
+                                         (fn [m]
+                                           (if-let [e (find m key)]
+                                             (let [v (val e)
+                                                   v* (parser v)]
+                                               (cond (-invalid? v*) (reduced v*)
+                                                     (identical? v* v) m
+                                                     :else (assoc m key v*)))
+                                             (if optional m (reduced ::invalid))))))
+                                     children)
+                                   closed (into [(fn [m]
+                                                   (reduce
+                                                     (fn [m k] (if (contains? keyset k) m (reduced (reduced ::invalid))))
+                                                     m (keys m)))]))]
+               (fn [x] (if (map? x) (reduce (fn [m parser] (parser m)) x parsers) ::invalid))))
            (-transformer [this transformer method options]
              (let [this-transformer (-value-transformer transformer this method options)
                    ->children (some->> entries
@@ -683,19 +683,19 @@
                              (key-explainer key in)
                              (value-explainer value in))))
                     acc m)))))
-          (-conformer [_]
-            (let [key-conformer (-conformer key-schema)
-                  value-conformer (-conformer value-schema)]
+          (-parser [_]
+            (let [key-parser (-parser key-schema)
+                  value-parser (-parser value-schema)]
               (fn [m]
                 (if (map? m)
                   (reduce-kv (fn [acc k v]
-                               (let [k* (key-conformer k)
-                                     v* (value-conformer v)]
-                                 (if (or (-nonconforming? k*) (-nonconforming? v*))
-                                   (reduced ::nonconforming)
+                               (let [k* (key-parser k)
+                                     v* (value-parser v)]
+                                 (if (or (-invalid? k*) (-invalid? v*))
+                                   (reduced ::invalid)
                                    (assoc acc k* v*))))
                              (empty m) m)
-                  ::nonconforming))))
+                  ::invalid))))
           (-transformer [this transformer method options]
             (let [this-transformer (-value-transformer transformer this method options)
                   ->key (-transformer key-schema transformer method options)
@@ -753,19 +753,19 @@
                             (if (< i size)
                               (cond-> (or (explainer x (conj in (fin i x)) acc) acc) xs (recur (inc i) xs))
                               acc)))))))
-          (-conformer [_]
-            (let [child-conformer (-conformer schema)]
+          (-parser [_]
+            (let [child-parser (-parser schema)]
               (fn [x]
                 (cond
-                  (not (fpred x)) ::nonconforming
-                  (not (validate-limits x)) ::nonconforming
+                  (not (fpred x)) ::invalid
+                  (not (validate-limits x)) ::invalid
                   :else (let [x' (reduce
                                    (fn [acc v]
-                                     (let [v' (child-conformer v)]
-                                       (if (-nonconforming? v') (reduced ::nonconforming) (conj acc v'))))
+                                     (let [v' (child-parser v)]
+                                       (if (-invalid? v') (reduced ::invalid) (conj acc v'))))
                                    [] x)]
                           (cond
-                            (-nonconforming? x') x'
+                            (-invalid? x') x'
                             fempty (into fempty x')
                             :else x'))))))
           (-transformer [this transformer method options]
@@ -819,20 +819,20 @@
                   (not= (count x) size) (conj acc (-error path in this x ::tuple-size))
                   :else (loop [acc acc, i 0, [x & xs] x, [e & es] explainers]
                           (cond-> (e x (conj in i) acc) xs (recur (inc i) xs es)))))))
-          (-conformer [_]
-            (let [conformers (into {} (comp (map -conformer) (map-indexed vector)) children)]
+          (-parser [_]
+            (let [parsers (into {} (comp (map -parser) (map-indexed vector)) children)]
               (fn [x]
                 (cond
-                  (not (vector? x)) ::nonconforming
-                  (not= (count x) size) ::nonconforming
+                  (not (vector? x)) ::invalid
+                  (not= (count x) size) ::invalid
                   :else (reduce-kv (fn [x i c]
                                      (let [v (get x i)
                                            v* (c v)]
                                        (cond
-                                         (-nonconforming? v*) (reduced v*)
+                                         (-invalid? v*) (reduced v*)
                                          (identical? v* v) x
                                          :else (assoc x i v))))
-                                   x conformers)))))
+                                   x parsers)))))
           (-transformer [this transformer method options]
             (let [this-transformer (-value-transformer transformer this method options)
                   ->children (into {} (comp (map-indexed vector)
@@ -874,7 +874,7 @@
           (-explainer [this path]
             (fn explain [x in acc]
               (if-not (contains? schema x) (conj acc (-error (conj path 0) in this x)) acc)))
-          (-conformer [_] (fn [x] (if (contains? schema x) x ::nonconforming)))
+          (-parser [_] (fn [x] (if (contains? schema x) x ::invalid)))
           ;; TODO: should we try to derive the type from values? e.g. [:enum 1 2] ~> int?
           (-transformer [this transformer method options]
             (-coder (-value-transformer transformer this method options)))
@@ -916,9 +916,9 @@
                   (conj acc (-error path in this x (:type (ex-data e))))))))
           (-transformer [this transformer method options]
             (-coder (-value-transformer transformer this method options)))
-          (-conformer [_]
+          (-parser [_]
             (let [find (-safe-pred #(re-find re %))]
-              (fn [x] (if (find x) x ::nonconforming))))
+              (fn [x] (if (find x) x ::invalid))))
           (-walk [this walker path options]
             (if (-accept walker this path options)
               (-outer walker this path children options)))
@@ -954,9 +954,9 @@
                   acc)
                 (catch #?(:clj Exception, :cljs js/Error) e
                   (conj acc (-error path in this x (:type (ex-data e))))))))
-          (-conformer [this]
+          (-parser [this]
             (let [validator (-validator this)]
-              (fn [x] (if (validator x) x ::nonconforming))))
+              (fn [x] (if (validator x) x ::invalid))))
           (-transformer [this transformer method options]
             (-coder (-value-transformer transformer this method options)))
           (-walk [this walker path options]
@@ -991,9 +991,9 @@
             (let [explainer' (-explainer schema (conj path 0))]
               (fn explain [x in acc]
                 (if (nil? x) acc (explainer' x in acc)))))
-          (-conformer [_]
-            (let [conformer* (-conformer schema)]
-              (fn [x] (if (nil? x) x (conformer* x)))))
+          (-parser [_]
+            (let [parser* (-parser schema)]
+              (fn [x] (if (nil? x) x (parser* x)))))
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options]
@@ -1044,12 +1044,12 @@
                  (if-let [explainer (explainers (dispatch x))]
                    (explainer x in acc)
                    (conj acc (-error (->path path) (->path in) this x ::invalid-dispatch-value))))))
-           (-conformer [_]
-             (let [conformers (reduce-kv (fn [acc k s] (assoc acc k (-conformer s))) {} dispatch-map)]
+           (-parser [_]
+             (let [parsers (reduce-kv (fn [acc k s] (assoc acc k (-parser s))) {} dispatch-map)]
                (fn [x]
-                 (if-some [conformer (conformers (dispatch x))]
-                   (conformer x)
-                   ::nonconforming))))
+                 (if-some [parser (parsers (dispatch x))]
+                   (parser x)
+                   ::invalid))))
            (-transformer [this transformer method options]
              (let [this-transformer (-value-transformer transformer this method options)
                    ->children (reduce-kv (fn [acc k s]
@@ -1101,9 +1101,9 @@
            (-explainer [_ path]
              (let [explainer (-memoize (fn [] (-explainer (-ref) (conj path 0))))]
                (fn [x in acc] ((explainer) x in acc))))
-           (-conformer [_]
-             (let [conformer (-memoize (fn [] (-conformer (-ref))))]
-               (fn [x] ((conformer) x))))
+           (-parser [_]
+             (let [parser (-memoize (fn [] (-parser (-ref))))]
+               (fn [x] ((parser) x))))
            (-transformer [this transformer method options]
              (let [this-transformer (-value-transformer transformer this method options)
                    deref-transformer (-memoize (fn [] (-transformer (-ref) transformer method options)))]
@@ -1133,7 +1133,7 @@
            (-regex-op? [_] false)
            (-regex-validator [this] (-fail! ::potentially-recursive-seqex this))
            (-regex-explainer [this _] (-fail! ::potentially-recursive-seqex this))
-           (-regex-conformer [this] (-fail! ::potentially-recursive-seqex this))
+           (-regex-parser [this] (-fail! ::potentially-recursive-seqex this))
            (-regex-transformer [this _ _ _] (-fail! ::potentially-recursive-seqex this))))))))
 
 (defn -schema-schema [{:keys [id raw] :as opts}]
@@ -1153,7 +1153,7 @@
             (-type-properties [_])
             (-validator [_] (-validator child))
             (-explainer [_ path] (-explainer child path))
-            (-conformer [_] (-conformer child))
+            (-parser [_] (-parser child))
             (-transformer [this transformer method options]
               (-parent-children-transformer this children transformer method options))
             (-walk [this walker path options]
@@ -1185,10 +1185,10 @@
               (if internal?
                 (-regex-explainer child path)
                 (re/item-explainer path child (-explainer child path))))
-            (-regex-conformer [_]
+            (-regex-parser [_]
               (if internal?
-                (-regex-conformer child)
-                (re/item-parser (conformer child))))
+                (-regex-parser child)
+                (re/item-parser (parser child))))
             (-regex-transformer [_ transformer method options]
               (if internal?
                 (-regex-transformer child transformer method options)
@@ -1216,9 +1216,9 @@
             (let [validator (-validator this)]
               (fn explain [x in acc]
                 (if-not (validator x) (conj acc (-error path in this x)) acc))))
-          (-conformer [this]
+          (-parser [this]
             (let [validator (-validator this)]
-              (fn [x] (if (validator x) x ::nonconforming))))
+              (fn [x] (if (validator x) x ::invalid))))
           (-transformer [_ _ _ _])
           (-walk [this walker path options]
             (if (-accept walker this path options)
@@ -1241,14 +1241,14 @@
 
 (defn- regex-explainer [schema path] (re/explainer schema path (-regex-explainer schema path)))
 
-(defn- regex-conformer [schema] (re/parser (-regex-conformer schema)))
+(defn- regex-parser [schema] (re/parser (-regex-parser schema)))
 
 (defn- regex-transformer [schema transformer method options]
   (let [this-transformer (-value-transformer transformer schema method options)
         ->children (re/transformer (-regex-transformer schema transformer method options))]
     (-intercepting this-transformer ->children)))
 
-(defn -sequence-schema [{:keys [type child-bounds re-validator re-explainer re-conformer re-transformer] :as opts}]
+(defn -sequence-schema [{:keys [type child-bounds re-validator re-explainer re-parser re-transformer] :as opts}]
   ^{:type ::into-schema}
   (reify IntoSchema
     (-into-schema [_ properties children options]
@@ -1262,7 +1262,7 @@
           (-type-properties [_])
           (-validator [this] (regex-validator this))
           (-explainer [this path] (regex-explainer this path))
-          (-conformer [this] (regex-conformer this))
+          (-parser [this] (regex-parser this))
           (-transformer [this transformer method options] (regex-transformer this transformer method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
@@ -1283,11 +1283,11 @@
           (-regex-validator [_] (re-validator properties (map -regex-validator children)))
           (-regex-explainer [_ path]
             (re-explainer properties (map-indexed (fn [i child] (-regex-explainer child (conj path i))) children)))
-          (-regex-conformer [_] (re-conformer properties (map -regex-conformer children)))
+          (-regex-parser [_] (re-parser properties (map -regex-parser children)))
           (-regex-transformer [_ transformer method options]
             (re-transformer properties (map #(-regex-transformer % transformer method options) children))))))))
 
-(defn -sequence-entry-schema [{:keys [type child-bounds re-validator re-explainer re-conformer re-transformer] :as opts}]
+(defn -sequence-entry-schema [{:keys [type child-bounds re-validator re-explainer re-parser re-transformer] :as opts}]
   ^{:type ::into-schema}
   (reify IntoSchema
     (-into-schema [_ properties children options]
@@ -1301,7 +1301,7 @@
           (-type-properties [_])
           (-validator [this] (regex-validator this))
           (-explainer [this path] (regex-explainer this path))
-          (-conformer [this] (regex-conformer this))
+          (-parser [this] (regex-parser this))
           (-transformer [this transformer method options] (regex-transformer this transformer method options))
           (-walk [this walker path options]
             (if (-accept walker this path options)
@@ -1322,7 +1322,7 @@
           (-regex-validator [_] (re-validator properties (map (fn [[k _ s]] [k (-regex-validator s)]) children)))
           (-regex-explainer [_ path]
             (re-explainer properties (map (fn [[k _ s]] [k (-regex-explainer s (conj path k))]) children)))
-          (-regex-conformer [_] (re-conformer properties (map (fn [[k _ s]] [k (-regex-conformer s)]) children)))
+          (-regex-parser [_] (re-parser properties (map (fn [[k _ s]] [k (-regex-parser s)]) children)))
           (-regex-transformer [_ transformer method options]
             (re-transformer properties (map (fn [[k _ s]] [k (-regex-transformer s transformer method options)])
                                             children))))))))
@@ -1464,20 +1464,20 @@
   ([?schema value options]
    ((explainer ?schema options) value [] [])))
 
-(defn conformer
-  "Returns an pure conformer function of type `x -> either parsed-x ::nonconforming` for a given Schema"
+(defn parser
+  "Returns an pure parser function of type `x -> either parsed-x ::invalid` for a given Schema"
   ([?schema]
-   (conformer ?schema nil))
+   (parser ?schema nil))
   ([?schema options]
-   (-conformer (schema ?schema options))))
+   (-parser (schema ?schema options))))
 
-(defn conform
-  "Conforms a value against a given schema. Creates the `conformer` for every call.
-   When performance matters, (re-)use `conformer` instead."
+(defn parse
+  "parses a value against a given schema. Creates the `parser` for every call.
+   When performance matters, (re-)use `parser` instead."
   ([?schema value]
-   (conform ?schema value nil))
+   (parse ?schema value nil))
   ([?schema value options]
-   ((conformer ?schema options) value)))
+   ((parser ?schema options) value)))
 
 (defn decoder
   "Creates a value decoding function given a transformer and a schema."
@@ -1625,47 +1625,47 @@
   {:+ (-sequence-schema {:type :+, :child-bounds {:min 1, :max 1}
                          :re-validator (fn [_ [child]] (re/+-validator child))
                          :re-explainer (fn [_ [child]] (re/+-explainer child))
-                         :re-conformer (fn [_ [child]] (re/+-parser child))
+                         :re-parser (fn [_ [child]] (re/+-parser child))
                          :re-transformer (fn [_ [child]] (re/+-transformer child))})
    :* (-sequence-schema {:type :*, :child-bounds {:min 1, :max 1}
                          :re-validator (fn [_ [child]] (re/*-validator child))
                          :re-explainer (fn [_ [child]] (re/*-explainer child))
-                         :re-conformer (fn [_ [child]] (re/*-parser child))
+                         :re-parser (fn [_ [child]] (re/*-parser child))
                          :re-transformer (fn [_ [child]] (re/*-transformer child))})
    :? (-sequence-schema {:type :?, :child-bounds {:min 1, :max 1}
                          :re-validator (fn [_ [child]] (re/?-validator child))
                          :re-explainer (fn [_ [child]] (re/?-explainer child))
-                         :re-conformer (fn [_ [child]] (re/?-parser child))
+                         :re-parser (fn [_ [child]] (re/?-parser child))
                          :re-transformer (fn [_ [child]] (re/?-transformer child))})
    :repeat (-sequence-schema {:type :repeat, :child-bounds {:min 1, :max 1}
                               :re-validator (fn [{:keys [min max] :or {min 0, max ##Inf}} [child]]
                                               (re/repeat-validator min max child))
                               :re-explainer (fn [{:keys [min max] :or {min 0, max ##Inf}} [child]]
                                               (re/repeat-explainer min max child))
-                              :re-conformer (fn [{:keys [min max] :or {min 0, max ##Inf}} [child]]
-                                              (re/repeat-parser min max child))
+                              :re-parser (fn [{:keys [min max] :or {min 0, max ##Inf}} [child]]
+                                           (re/repeat-parser min max child))
                               :re-transformer (fn [{:keys [min max] :or {min 0, max ##Inf}} [child]]
                                                 (re/repeat-transformer min max child))})
 
    :cat (-sequence-schema {:type :cat, :child-bounds {}
                            :re-validator (fn [_ children] (apply re/cat-validator children))
                            :re-explainer (fn [_ children] (apply re/cat-explainer children))
-                           :re-conformer (fn [_ children] (apply re/cat-parser children))
+                           :re-parser (fn [_ children] (apply re/cat-parser children))
                            :re-transformer (fn [_ children] (apply re/cat-transformer children))})
    :alt (-sequence-schema {:type :alt, :child-bounds {:min 1}
                            :re-validator (fn [_ children] (apply re/alt-validator children))
                            :re-explainer (fn [_ children] (apply re/alt-explainer children))
-                           :re-conformer (fn [_ children] (apply re/alt-parser children))
+                           :re-parser (fn [_ children] (apply re/alt-parser children))
                            :re-transformer (fn [_ children] (apply re/alt-transformer children))})
    :cat* (-sequence-entry-schema {:type :cat*, :child-bounds {}
                                   :re-validator (fn [_ children] (apply re/cat-validator children))
                                   :re-explainer (fn [_ children] (apply re/cat-explainer children))
-                                  :re-conformer (fn [_ children] (apply re/cat*-parser children))
+                                  :re-parser (fn [_ children] (apply re/cat*-parser children))
                                   :re-transformer (fn [_ children] (apply re/cat-transformer children))})
    :alt* (-sequence-entry-schema {:type :alt*, :child-bounds {:min 1}
                                   :re-validator (fn [_ children] (apply re/alt-validator children))
                                   :re-explainer (fn [_ children] (apply re/alt-explainer children))
-                                  :re-conformer (fn [_ children] (apply re/alt*-parser children))
+                                  :re-parser (fn [_ children] (apply re/alt*-parser children))
                                   :re-transformer (fn [_ children] (apply re/alt-transformer children))})})
 
 (defn base-schemas []
@@ -1718,9 +1718,9 @@
 (defn -register-=>schema! [ns name value]
   (swap! -=>schemas* assoc-in [ns name]
          {:schema (=>schema value)
-          :meta   (meta name)
-          :ns     ns
-          :name   name}))
+          :meta (meta name)
+          :ns ns
+          :name name}))
 
 (defmacro => [name value]
   (let [name' `'~(symbol (str name))]

--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -27,7 +27,7 @@
   Despite the CPS and memoization, this implementation looks more like normal
   Clojure code than the 'Pike VM' in Seqexp. Hopefully JITs also see it that
   way and compile decent machine code for it. It is also much easier to extend
-  for actual parsing (e.g. encode, decode [and conform?]) instead of just
+  for actual parsing (e.g. encode, decode [and parse?]) instead of just
   recognition for `validate`."
 
   (:refer-clojure :exclude [+ * repeat cat])
@@ -77,11 +77,11 @@
             (k (inc pos) (rest coll))))
         (fail! driver pos [(miu/-error path in schema nil :malli.core/end-of-input)])))))
 
-(defn item-parser [conform]
+(defn item-parser [parse]
   (fn [_ _ pos coll k]
     (when (seq coll)
-      (let [v (conform (first coll))]
-        (when-not (= v :malli.core/nonconforming)
+      (let [v (parse (first coll))]
+        (when-not (= v :malli.core/invalid)
           (k v (inc pos) (rest coll)))))))
 
 (defn item-encoder [valid? encode]
@@ -532,7 +532,7 @@
 
 ;;;; # Parser
 
-;; Unused ATM but should soon be used to implement Spec `conform` equivalent:
+;; Unused ATM but should soon be used to implement Spec `parse` equivalent:
 (defn parser [p]
   (let [p (cat-parser p (end-parser))]
     (fn [coll]
@@ -546,8 +546,8 @@
                 (do
                   (thunk)
                   (if (succeeded? driver) (first (success-result driver)) (recur)))
-                :malli.core/nonconforming))))
-        :malli.core/nonconforming))))
+                :malli.core/invalid))))
+        :malli.core/invalid))))
 
 ;;;; # Transformer
 

--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -546,8 +546,8 @@
                 (do
                   (thunk)
                   (if (succeeded? driver) (first (success-result driver)) (recur)))
-                (miu/-fail! :malli.core/nonconforming)))))
-        (miu/-fail! :malli.core/nonconforming)))))
+                :malli.core/nonconforming))))
+        :malli.core/nonconforming))))
 
 ;;;; # Transformer
 

--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -532,7 +532,6 @@
 
 ;;;; # Parser
 
-;; Unused ATM but should soon be used to implement Spec `parse` equivalent:
 (defn parser [p]
   (let [p (cat-parser p (end-parser))]
     (fn [coll]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -135,8 +135,8 @@
                      :errors [(m/-error [] [] schema "1")]}
                     (m/explain schema "1")))
 
-      (is (= 1 (m/conform schema 1)))
-      (is (= ::m/nonconforming (m/conform schema "1")))
+      (is (= 1 (m/parse schema 1)))
+      (is (= ::m/invalid (m/parse schema "1")))
 
       (is (= 1 (m/decode schema "1" mt/string-transformer)))
       (is (= "1" (m/decode schema "1" mt/json-transformer)))
@@ -202,11 +202,11 @@
                               {:path [1 :neg], :in [], :schema neg-int?, :value 0}]}
                     (m/explain schema* 0)))
 
-      (is (= 1 (m/conform schema 1)))
-      (is (= ::m/nonconforming (m/conform schema 0)))
+      (is (= 1 (m/parse schema 1)))
+      (is (= ::m/invalid (m/parse schema 0)))
 
-      (is (= (miu/-tagged :pos 1) (m/conform schema* 1)))
-      (is (= ::m/nonconforming (m/conform schema* 0)))
+      (is (= (miu/-tagged :pos 1) (m/parse schema* 1)))
+      (is (= ::m/invalid (m/parse schema* 0)))
 
       (doseq [schema [schema schema*]]
         (is (= 1 (m/decode schema "1" mt/string-transformer)))
@@ -310,8 +310,8 @@
       (is (results= {:schema [:> 0], :value 0, :errors [{:path [], :in [], :schema [:> 0], :value 0}]}
                     (m/explain schema 0)))
 
-      (is (= 1 (m/conform schema 1)))
-      (is (= ::m/nonconforming (m/conform schema 0)))
+      (is (= 1 (m/parse schema 1)))
+      (is (= ::m/invalid (m/parse schema 0)))
 
       (is (= 1 (m/decode schema "1" mt/string-transformer)))
       (is (= "1" (m/decode schema "1" mt/json-transformer)))
@@ -338,8 +338,8 @@
       (is (results= {:schema [:enum 1 2], :value 0, :errors [{:path [0], :in [], :schema [:enum 1 2], :value 0}]}
                     (m/explain [:enum 1 2] 0)))
 
-      (is (= 1 (m/conform schema 1)))
-      (is (= ::m/nonconforming (m/conform schema 0)))
+      (is (= 1 (m/parse schema 1)))
+      (is (= ::m/invalid (m/parse schema 0)))
 
       ;; TODO: infer type from :enum
       #_(is (= 1 (m/decode schema "1" mt/string-transformer)))
@@ -368,9 +368,9 @@
       (is (results= {:schema [:maybe int?], :value "abba", :errors [{:path [0], :in [], :schema int?, :value "abba"}]}
                     (m/explain [:maybe int?] "abba")))
 
-      (is (= 1 (m/conform schema 1)))
-      (is (nil? (m/conform schema nil)))
-      (is (= ::m/nonconforming (m/conform schema "abba")))
+      (is (= 1 (m/parse schema 1)))
+      (is (nil? (m/parse schema nil)))
+      (is (= ::m/invalid (m/parse schema "abba")))
 
       (is (= 1 (m/decode schema "1" mt/string-transformer)))
       (is (= "1" (m/decode schema "1" mt/json-transformer)))
@@ -410,9 +410,9 @@
                                  :value [2]}]}
                       (m/explain ConsCell [1 [2]])))
 
-        (is (= [1 nil] (m/conform ConsCell [1 nil])))
-        (is (= [1 [2 nil]] (m/conform ConsCell [1 [2 nil]])))
-        (is (= ::m/nonconforming (m/conform ConsCell [1 [2]])))
+        (is (= [1 nil] (m/parse ConsCell [1 nil])))
+        (is (= [1 [2 nil]] (m/parse ConsCell [1 [2 nil]])))
+        (is (= ::m/invalid (m/parse ConsCell [1 [2]])))
 
         (is (= [1 ["two" [3 nil]]] (m/decode ConsCell ["1" ["two" ["3" nil]]] mt/string-transformer)))
         (is (= ["1" ["two" ["3" nil]]] (m/decode ConsCell ["1" ["two" ["3" nil]]] mt/json-transformer)))
@@ -492,8 +492,8 @@
 
                     (m/explain schema -1)))
 
-      (is (= 1 (m/conform schema 1)))
-      (is (= ::m/nonconforming (m/conform schema -1)))
+      (is (= 1 (m/parse schema 1)))
+      (is (= ::m/invalid (m/parse schema -1)))
 
       (is (= 1 (m/decode schema "1" mt/string-transformer)))
       (is (= "1" (m/decode schema "1" mt/json-transformer)))
@@ -551,10 +551,10 @@
         (is (results= {:schema schema, :value "abba", :errors [{:path [], :in [], :schema schema, :value "abba"}]}
                       (m/explain schema "abba")))
 
-        (is (= "a.b" (m/conform schema "a.b")))
-        (is (= ::m/nonconforming (m/conform schema "abba")))
-        (is (= ::m/nonconforming (m/conform schema ".b")))
-        (is (= ::m/nonconforming (m/conform schema false)))
+        (is (= "a.b" (m/parse schema "a.b")))
+        (is (= ::m/invalid (m/parse schema "abba")))
+        (is (= ::m/invalid (m/parse schema ".b")))
+        (is (= ::m/invalid (m/parse schema false)))
 
         (is (= 4 (m/decode
                    [:re {:decode/string '{:enter inc, :leave (partial * 2)}} ".*"]
@@ -581,10 +581,10 @@
         (is (results= {:schema schema, :value "abba", :errors [{:path [], :in [], :schema schema, :value "abba"}]}
                       (m/explain schema "abba")))
 
-        (is (= 12 (m/conform schema 12)))
-        (is (= ::m/nonconforming (m/conform schema 1)))
-        (is (= ::m/nonconforming (m/conform schema 20)))
-        (is (= ::m/nonconforming (m/conform schema "invalid")))
+        (is (= 12 (m/parse schema 12)))
+        (is (= ::m/invalid (m/parse schema 1)))
+        (is (= ::m/invalid (m/parse schema 20)))
+        (is (= ::m/invalid (m/parse schema "invalid")))
 
         (is (= 4 (m/decode
                    [:fn {:decode/string '{:enter inc, :leave (partial * 2)}} 'int?]
@@ -684,14 +684,14 @@
                                :message nil}]}
                     (m/explain closed-schema valid-with-extras)))
 
-      (is (= valid (m/conform schema valid)))
-      (is (= valid-with-extras (m/conform schema valid-with-extras)))
-      (is (= valid2 (m/conform schema valid2)))
-      (is (= ::m/nonconforming (m/conform schema invalid)))
-      (is (= ::m/nonconforming (m/conform schema "not-a-map")))
+      (is (= valid (m/parse schema valid)))
+      (is (= valid-with-extras (m/parse schema valid-with-extras)))
+      (is (= valid2 (m/parse schema valid2)))
+      (is (= ::m/invalid (m/parse schema invalid)))
+      (is (= ::m/invalid (m/parse schema "not-a-map")))
 
-      (is (= valid (m/conform closed-schema valid)))
-      (is (= ::m/nonconforming (m/conform closed-schema valid-with-extras)))
+      (is (= valid (m/parse closed-schema valid)))
+      (is (= ::m/invalid (m/parse closed-schema valid-with-extras)))
 
       (is (= {:x true} (m/decode schema {:x "true"} mt/string-transformer)))
       (is (= {:x true, :y 1} (m/decode schema {:x "true", :y "1"} mt/string-transformer)))
@@ -790,12 +790,12 @@
                                :type :malli.core/invalid-dispatch-value}]}
                     (m/explain schema invalid3)))
 
-      (is (= valid1 (m/conform schema valid1)))
-      (is (= valid2 (m/conform schema valid2)))
-      (is (= ::m/nonconforming (m/conform schema invalid1)))
-      (is (= ::m/nonconforming (m/conform schema invalid2)))
-      (is (= ::m/nonconforming (m/conform schema invalid3)))
-      (is (= ::m/nonconforming (m/conform schema "not-a-map")))
+      (is (= valid1 (m/parse schema valid1)))
+      (is (= valid2 (m/parse schema valid2)))
+      (is (= ::m/invalid (m/parse schema invalid1)))
+      (is (= ::m/invalid (m/parse schema invalid2)))
+      (is (= ::m/invalid (m/parse schema invalid3)))
+      (is (= ::m/invalid (m/parse schema "not-a-map")))
 
       (is (= {:type :sized, :size 10}
              (m/decode schema {:type "sized", :size "10"} mt/string-transformer)))
@@ -863,10 +863,10 @@
                              :value "18"}]}
                   (m/explain [:map-of string? int?] {:age "18"})))
 
-    (is (= {"age" 18} (m/conform [:map-of string? int?] {"age" 18})))
-    (is (= {:age 18} (m/conform [:map-of keyword? int?] {:age 18})))
-    (is (= ::m/nonconforming (m/conform [:map-of string? int?] {:age "18"})))
-    (is (= ::m/nonconforming (m/conform [:map-of string? int?] 1)))
+    (is (= {"age" 18} (m/parse [:map-of string? int?] {"age" 18})))
+    (is (= {:age 18} (m/parse [:map-of keyword? int?] {:age 18})))
+    (is (= ::m/invalid (m/parse [:map-of string? int?] {:age "18"})))
+    (is (= ::m/invalid (m/parse [:map-of string? int?] 1)))
 
     (is (= {1 1} (m/decode [:map-of int? pos-int?] {"1" "1"} mt/string-transformer)))
 
@@ -898,7 +898,7 @@
       (doseq [element [:vector :sequential :set]]
         (is (thrown? #?(:clj Exception, :cljs js/Error) (m/schema [element int? int?])))))
 
-    (testing "validation + conform"
+    (testing "validation + parse"
       (let [expectations {"vector" [[true [:vector int?] [1 2 3]]
                                     [false [:vector int?] [1 "2" 3]]
                                     [false [:vector int?] [1 2 "3"]]
@@ -967,7 +967,7 @@
           (testing name
             (is (= expected (m/validate schema value)))
             (is (= expected (m/validate (over-the-wire schema) value)))
-            (is (= (if expected value ::m/nonconforming) (m/conform schema value)))))))
+            (is (= (if expected value ::m/invalid) (m/parse schema value)))))))
 
     (testing "transform"
       (is (= {:x 1} (m/decode [:vector [:map [:x int?]]] {:x 1} (mt/transformer {:name "test"}))))
@@ -1154,7 +1154,7 @@
               (let [es errs]
                 (and (= (m/validate s v) (nil? es))
                      (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                     (= (m/conform s v) (if (nil? es) (if (= typ :cat) v v*) ::m/nonconforming))))
+                     (= (m/parse s v) (if (nil? es) (if (= typ :cat) v v*) ::m/invalid))))
 
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1168,7 +1168,7 @@
               (let [es errs]
                 (and (= (m/validate s v) (nil? es))
                      (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                     (= (m/conform s v) (if (nil? es) (if (= typ :cat) v v*) ::m/nonconforming))))
+                     (= (m/parse s v) (if (nil? es) (if (= typ :cat) v v*) ::m/invalid))))
 
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1184,7 +1184,7 @@
               (let [es errs]
                 (and (= (m/validate s v) (nil? es))
                      (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                     (= (m/conform s v) (if (nil? es) (if (= typ :cat) v v*) ::m/nonconforming))))
+                     (= (m/parse s v) (if (nil? es) (if (= typ :cat) v v*) ::m/invalid))))
 
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1203,7 +1203,7 @@
               (let [es errs]
                 (and (= (m/validate s v) (nil? es))
                      (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                     (= (m/conform s v) (if (nil? es) (if (= typ :cat) v v*) ::m/nonconforming))))
+                     (= (m/parse s v) (if (nil? es) (if (= typ :cat) v v*) ::m/invalid))))
 
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1221,8 +1221,8 @@
                 v [4 4 4 4]]
             (is (m/validate s v))
 
-            (is (= [[4 4 4] 4] (m/conform s v)))
-            (is (= {:pos [4 4 4], :four 4} (m/conform s* v)))))))
+            (is (= [[4 4 4] 4] (m/parse s v)))
+            (is (= {:pos [4 4 4], :four 4} (m/parse s* v)))))))
 
     (doseq [typ [:alt :alt*]]
       (testing typ
@@ -1236,7 +1236,7 @@
                     es errs]
                 (and (= (m/validate s v) (nil? es))
                      (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                     (= (m/conform s v) (if (nil? es) (if (= typ :alt) v* v**) ::m/nonconforming))))
+                     (= (m/parse s v) (if (nil? es) (if (= typ :alt) v* v**) ::m/invalid))))
 
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1252,7 +1252,7 @@
                     es errs]
                 (and (= (m/validate s v) (nil? es))
                      (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                     (= (m/conform s v) (if (nil? es) (if (= typ :alt) v* v**) ::m/nonconforming))))
+                     (= (m/parse s v) (if (nil? es) (if (= typ :alt) v* v**) ::m/invalid))))
 
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1270,7 +1270,7 @@
                     es errs]
                 (and (= (m/validate s v) (nil? es))
                      (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                     (= (m/conform s v) (if (nil? es) (if (= typ :alt) v* v**) ::m/nonconforming))))
+                     (= (m/parse s v) (if (nil? es) (if (= typ :alt) v* v**) ::m/invalid))))
 
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1291,7 +1291,7 @@
           (let [es errs]
             (and (= (m/validate s v) (nil? es))
                  (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                 (= (m/conform s v) (if (nil? es) v* ::m/nonconforming))))
+                 (= (m/parse s v) (if (nil? es) v* ::m/invalid))))
 
           0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
           "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1308,7 +1308,7 @@
                                      (repeat n [:= :a])))
               v (repeat n :a)]
           (is (m/validate s v))
-          (is (= (concat (repeat n nil) v) (m/conform s v))))))
+          (is (= (concat (repeat n nil) v) (m/parse s v))))))
 
     (testing "*"
       (is (thrown? #?(:clj Exception, :cljs js/Error) (m/validator [:*])))
@@ -1319,7 +1319,7 @@
           (let [es errs]
             (and (= (m/validate s v) (nil? es))
                  (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                 (= (m/conform s v) (if (nil? es) v ::m/nonconforming))))
+                 (= (m/parse s v) (if (nil? es) v ::m/invalid))))
 
           0 [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
           "foo" [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1341,7 +1341,7 @@
           (let [es errs]
             (and (= (m/validate s v) (nil? es))
                  (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                 (= (m/conform s v) (if (nil? es) v ::m/nonconforming))))
+                 (= (m/parse s v) (if (nil? es) v ::m/invalid))))
 
           0 [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
           "foo" [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1362,7 +1362,7 @@
           (let [es errs]
             (and (= (m/validate s v) (nil? es))
                  (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                 (= (m/conform s v) (if (nil? es) v ::m/nonconforming))))
+                 (= (m/parse s v) (if (nil? es) v ::m/invalid))))
 
           0 [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
           "foo" [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
@@ -1387,7 +1387,7 @@
           (let [es errs]
             (and (= (m/validate s v) (nil? es))
                  (results= (m/explain s v) (and es {:schema s, :value v, :errors es}))
-                 (= (m/conform s v) (if (nil? es) v ::m/nonconforming))))
+                 (= (m/parse s v) (if (nil? es) v ::m/invalid))))
 
           0 [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
           "foo" [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]


### PR DESCRIPTION
* `identical?` doesn't always work with CLJS, use `keyword-identical?` instead
* fix `:map-of` conform results
* do not throw, return a `::m/nonconformed` instead, much faster

```clj
(let [conform (m/conformer [:* [:cat*
                                [:prop string?]
                                [:val [:alt*
                                       [:b boolean?]
                                       [:s string?]]]]])]

  ;; 42µs => 3µs 
  (cc/quick-bench 
    (conform ["-server" "foo" "-verbose" true "-user" "joe"])))
```

* `conform` => `parse`, `::m/nonconformed` => `::m/invalid`

```clj
(m/parse
  [:* [:cat*
       [:prop string?]
       [:val [:alt*
              [:s string?]
              [:b boolean?]]]]]
  ["-server" "foo" "-verbose" true "-user" "joe"])
;[{:prop "-server", :val [:s "foo"]} 
; {:prop "-verbose", :val [:b true]} 
; {:prop "-user", :val [:s "joe"]}]
```