### PR TITLE
Add :not base schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1561,7 +1561,7 @@ Type-like schemas: `:string`, `:int`, `:double`, `:boolean`, `.keyword`, `:symbo
 
 #### `malli.core/base-schemas`
 
-Contains `:and`, `:or`, `:map`, `:map-of`, `:vector`, `:sequential`, `:set`, `:tuple`, `:enum`, `:maybe`, `:multi`, `:re` and `:fn`.
+Contains `:and`, `:or`, `:not`, `:map`, `:map-of`, `:vector`, `:sequential`, `:set`, `:tuple`, `:enum`, `:maybe`, `:multi`, `:re` and `:fn`.
 
 ### Custom registry
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -519,7 +519,8 @@
               (when-not (validator x) (conj acc (-error (conj path 0) in this x)))))
           (-parser [_]
             (fn [x] (if (validator x) x ::invalid)))
-          (-transformer [this transformer method options] (throw (Exception. "Not implemented.")))
+          (-transformer [this transformer method options]
+            (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options] (throw (Exception. "Not implemented.")))
           (-properties [_] properties)
           (-options [_] options)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -513,9 +513,7 @@
           Schema
           (-type [_] :not)
           (-type-properties [_])
-          (-validator [_]
-            (let [validator (-validator schema)]
-              (complement #(validator %))))
+          (-validator [_] validator)
           (-explainer [this path]
             (fn explain [x in acc]
               (when-not (validator x) (conj acc (-error (conj path 0) in this x)))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -516,7 +516,7 @@
           (-validator [_] validator)
           (-explainer [this path]
             (fn explain [x in acc]
-              (when-not (validator x) (conj acc (-error (conj path 0) in this x)))))
+              (if-not (validator x) (conj acc (-error (conj path 0) in this x)) acc)))
           (-parser [_]
             (fn [x] (if (validator x) x ::invalid)))
           (-transformer [this transformer method options]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -517,7 +517,8 @@
           (-explainer [this path]
             (fn explain [x in acc]
               (when-not (validator x) (conj acc (-error (conj path 0) in this x)))))
-          (-conformer [_] (throw (Exception. "Not implemented.")))
+          (-conformer [_]
+            (fn [x] (if (validator x) x (-fail! ::nonconforming))))
           (-transformer [this transformer method options] (throw (Exception. "Not implemented.")))
           (-walk [this walker path options] (throw (Exception. "Not implemented.")))
           (-properties [_] properties)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -521,7 +521,9 @@
             (fn [x] (if (validator x) x ::invalid)))
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
-          (-walk [this walker path options] (throw (Exception. "Not implemented.")))
+          (-walk [this walker path options]
+            (if (-accept walker this path options)
+              (-outer walker this path (-inner-indexed walker path children options) options)))
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -517,8 +517,8 @@
           (-explainer [this path]
             (fn explain [x in acc]
               (when-not (validator x) (conj acc (-error (conj path 0) in this x)))))
-          (-conformer [_]
-            (fn [x] (if (validator x) x (-fail! ::nonconforming))))
+          (-parser [_]
+            (fn [x] (if (validator x) x ::invalid)))
           (-transformer [this transformer method options] (throw (Exception. "Not implemented.")))
           (-walk [this walker path options] (throw (Exception. "Not implemented.")))
           (-properties [_] properties)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -306,7 +306,23 @@
         (is (true? (m/validate schema1 false)))
         (is (false? (m/validate schema1 true)))
         (is (true? (m/validate schema2 true)))
-        (is (false? (m/validate schema2 false))))))
+        (is (false? (m/validate schema2 false)))))
+
+    (testing ":fn validation"
+      (let [schema (m/schema [:not [:fn #(= % 1)]])]
+        (is (true? (m/validate schema 2)))
+        (is (false? (m/validate schema 1)))
+        (is (true? (m/validate schema "string")))
+        (is (true? (m/validate schema :keyword)))))
+
+    (testing "function validation"
+      (let [schema1 (m/schema [:not pos?])
+            schema2 (m/schema [:not empty?])]
+        (is (true? (m/validate schema1 -1)))
+        (is (true? (m/validate schema1 0)))
+        (is (false? (m/validate schema1 1)))
+        (is (true? (m/validate schema2 "string")))
+        (is (false? (m/validate schema2 ""))))))
 
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -303,26 +303,80 @@
     (testing "boolean validation"
       (let [schema1 (m/schema [:not true?])
             schema2 (m/schema [:not false?])]
+
         (is (true? (m/validate schema1 false)))
-        (is (false? (m/validate schema1 true)))
+        (is (nil? (m/explain schema1 false)))
+
         (is (true? (m/validate schema2 true)))
-        (is (false? (m/validate schema2 false)))))
+        (is (nil? (m/explain schema2 true)))
+
+        (is (false? (m/validate schema1 true)))
+        (is (results= {:schema schema1
+                       :value true
+                       :errors [{:path [0]
+                                 :in []
+                                 :schema schema1
+                                 :value true}]}
+                      (m/explain schema1 true)))
+
+        (is (false? (m/validate schema2 false)))
+        (is (results= {:schema schema2
+                       :value false
+                       :errors [{:path [0]
+                                 :in []
+                                 :schema schema2
+                                 :value false}]}
+                      (m/explain schema2 false)))))
 
     (testing ":fn validation"
       (let [schema (m/schema [:not [:fn #(= % 1)]])]
         (is (true? (m/validate schema 2)))
-        (is (false? (m/validate schema 1)))
+        (is (nil? (m/explain schema 2)))
+
         (is (true? (m/validate schema "string")))
-        (is (true? (m/validate schema :keyword)))))
+        (is (nil? (m/explain schema "string")))
+
+        (is (true? (m/validate schema :keyword)))
+        (is (nil? (m/explain schema :keyword)))
+
+        (is (false? (m/validate schema 1)))
+        (is (results= {:schema schema
+                       :value 1
+                       :errors [{:path [0]
+                                 :in []
+                                 :schema schema
+                                 :value 1}]}
+                      (m/explain schema 1)))))
 
     (testing "function validation"
       (let [schema1 (m/schema [:not pos?])
             schema2 (m/schema [:not empty?])]
         (is (true? (m/validate schema1 -1)))
+        (is (nil? (m/explain schema1 -1)))
+
         (is (true? (m/validate schema1 0)))
-        (is (false? (m/validate schema1 1)))
+        (is (nil? (m/explain schema1 0)))
+
         (is (true? (m/validate schema2 "string")))
-        (is (false? (m/validate schema2 ""))))))
+        (is (nil? (m/explain schema2 "string")))
+
+        (is (false? (m/validate schema1 1)))
+        (is (results= {:schema schema1
+                       :value 1
+                       :errors [{:path [0]
+                                 :in []
+                                 :schema schema1
+                                 :value 1}]}
+                      (m/explain schema1 1)))
+
+        (is (false? (m/validate schema2 "")))
+        (is (results= {:schema schema2
+                       :value ""
+                       :errors [{:path [0]
+                                 :in []
+                                 :schema schema2
+                                 :value ""}]}
+                      (m/explain schema2 ""))))))
 
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -300,43 +300,6 @@
                       (m/explain schema 1))))))
 
   (testing ":not schema"
-    (testing "boolean validation"
-      (let [schema1 (m/schema [:not true?])
-            schema2 (m/schema [:not false?])]
-
-        (is (true? (m/validate schema1 false)))
-        (is (nil? (m/explain schema1 false)))
-        (is (= ::m/invalid (m/parse schema1 true)))
-        (is (= false (m/parse schema1 false)))
-        (is (= true (m/decode schema1 "true" mt/string-transformer)))
-        (is (= "false" (m/decode schema1 "false" mt/json-transformer)))
-
-        (is (true? (m/validate schema2 true)))
-        (is (nil? (m/explain schema2 true)))
-        (is (= true (m/parse schema2 true)))
-        (is (= ::m/invalid (m/parse schema2 false)))
-
-        (is (false? (m/validate schema1 true)))
-        (is (results= {:schema schema1
-                       :value true
-                       :errors [{:path [0]
-                                 :in []
-                                 :schema schema1
-                                 :value true}]}
-                      (m/explain schema1 true)))
-
-        (is (false? (m/validate schema2 false)))
-        (is (results= {:schema schema2
-                       :value false
-                       :errors [{:path [0]
-                                 :in []
-                                 :schema schema2
-                                 :value false}]}
-                      (m/explain schema2 false)))
-
-        (is (m/walk schema1 (m/schema-walker identity)))
-        (is (m/walk schema2 (m/schema-walker identity)))))
-
     (testing ":fn validation"
       (let [schema (m/schema [:not [:fn #(= % 1)]])]
         (is (true? (m/validate schema 2)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -299,6 +299,15 @@
                        :errors [{:path [1], :in [], :schema neg-int?, :value 1}]}
                       (m/explain schema 1))))))
 
+  (testing ":not schema"
+    (testing "boolean validation"
+      (let [schema1 (m/schema [:not true?])
+            schema2 (m/schema [:not false?])]
+        (is (true? (m/validate schema1 false)))
+        (is (false? (m/validate schema1 true)))
+        (is (true? (m/validate schema2 true)))
+        (is (false? (m/validate schema2 false))))))
+
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -306,9 +306,13 @@
 
         (is (true? (m/validate schema1 false)))
         (is (nil? (m/explain schema1 false)))
+        (is (= ::m/nonconforming (m/conform schema1 true)))
+        (is (= false (m/conform schema1 false)))
 
         (is (true? (m/validate schema2 true)))
         (is (nil? (m/explain schema2 true)))
+        (is (= true (m/conform schema2 true)))
+        (is (= ::m/nonconforming (m/conform schema2 false)))
 
         (is (false? (m/validate schema1 true)))
         (is (results= {:schema schema1
@@ -332,12 +336,15 @@
       (let [schema (m/schema [:not [:fn #(= % 1)]])]
         (is (true? (m/validate schema 2)))
         (is (nil? (m/explain schema 2)))
+        (is (= 2 (m/conform schema 2)))
 
         (is (true? (m/validate schema "string")))
         (is (nil? (m/explain schema "string")))
+        (is (= "string" (m/conform schema "string")))
 
         (is (true? (m/validate schema :keyword)))
         (is (nil? (m/explain schema :keyword)))
+        (is (= :keyword (m/conform schema :keyword)))
 
         (is (false? (m/validate schema 1)))
         (is (results= {:schema schema
@@ -346,19 +353,23 @@
                                  :in []
                                  :schema schema
                                  :value 1}]}
-                      (m/explain schema 1)))))
+                      (m/explain schema 1)))
+        (is (= ::m/nonconforming (m/conform schema 1)))))
 
     (testing "function validation"
       (let [schema1 (m/schema [:not pos?])
             schema2 (m/schema [:not empty?])]
         (is (true? (m/validate schema1 -1)))
         (is (nil? (m/explain schema1 -1)))
+        (is (= -1 (m/conform schema1 -1)))
 
         (is (true? (m/validate schema1 0)))
         (is (nil? (m/explain schema1 0)))
+        (is (= 0 (m/conform schema1 0)))
 
         (is (true? (m/validate schema2 "string")))
         (is (nil? (m/explain schema2 "string")))
+        (is (= "string" (m/conform schema2 "string")))
 
         (is (false? (m/validate schema1 1)))
         (is (results= {:schema schema1
@@ -368,6 +379,7 @@
                                  :schema schema1
                                  :value 1}]}
                       (m/explain schema1 1)))
+        (is (= ::m/nonconforming (m/conform schema1 1)))
 
         (is (false? (m/validate schema2 "")))
         (is (results= {:schema schema2
@@ -376,7 +388,8 @@
                                  :in []
                                  :schema schema2
                                  :value ""}]}
-                      (m/explain schema2 ""))))))
+                      (m/explain schema2 "")))
+        (is (= ::m/nonconforming (m/conform schema2 ""))))))
 
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -376,8 +376,9 @@
       (let [schema (m/schema [:map
                               [:a int?]
                               [:b [:not empty?]]
-                              [:c [:map [:d [:not [:fn #(= "test" %)]]]]]])]
-        (is (m/validate schema {:a 1 :b "Test" :c {:d "Malli"}}))
+                              [:c [:map [:d [:not [:fn #(= "test" %)]]]]]
+                              [:e [:not [:< 10]]]])]
+        (is (m/validate schema {:a 1 :b "Test" :c {:d "Malli"} :e 10}))
         (is (results= {:errors [{:in [:b]
                                  :message nil
                                  :path [:b 0]
@@ -385,8 +386,8 @@
                                  :type nil
                                  :value ""}]
                        :schema schema
-                       :value {:a 1, :b "", :c {:d "Malli"}}}
-                      (m/explain schema {:a 1 :b "" :c {:d "Malli"}})))
+                       :value {:a 1 :b "" :c {:d "Malli"} :e 10}}
+                      (m/explain schema {:a 1 :b "" :c {:d "Malli"} :e 10})))
         (is (results= {:errors [{:in [:c :d]
                                  :message nil
                                  :path [:c :d 0]
@@ -394,8 +395,17 @@
                                  :type nil
                                  :value "test"}]
                        :schema schema
-                       :value {:a 1, :b "Test", :c {:d "test"}}}
-                      (m/explain schema {:a 1 :b "Test" :c {:d "test"}}))))))
+                       :value {:a 1 :b "Test" :c {:d "test"} :e 10}}
+                      (m/explain schema {:a 1 :b "Test" :c {:d "test"} :e 10})))
+        (is (results= {:errors [{:in [:e]
+                                 :message nil
+                                 :path [:e 0]
+                                 :schema (mu/get-in schema [:e])
+                                 :type nil
+                                 :value 9}]
+                       :schema schema
+                       :value {:a 1 :b "Test" :c {:d "Malli"} :e 9}}
+                      (m/explain schema {:a 1 :b "Test" :c {:d "Malli"} :e 9}))))))
 
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -308,6 +308,8 @@
         (is (nil? (m/explain schema1 false)))
         (is (= ::m/invalid (m/parse schema1 true)))
         (is (= false (m/parse schema1 false)))
+        (is (= true (m/decode schema1 "true" mt/string-transformer)))
+        (is (= "false" (m/decode schema1 "false" mt/json-transformer)))
 
         (is (true? (m/validate schema2 true)))
         (is (nil? (m/explain schema2 true)))
@@ -337,6 +339,8 @@
         (is (true? (m/validate schema 2)))
         (is (nil? (m/explain schema 2)))
         (is (= 2 (m/parse schema 2)))
+        (is (= "2" (m/decode schema "2" mt/string-transformer)))
+        (is (= "2" (m/decode schema "2" mt/json-transformer)))
 
         (is (true? (m/validate schema "string")))
         (is (nil? (m/explain schema "string")))
@@ -362,6 +366,8 @@
         (is (true? (m/validate schema1 -1)))
         (is (nil? (m/explain schema1 -1)))
         (is (= -1 (m/parse schema1 -1)))
+        (is (= "-1" (m/decode schema1 "-1" mt/string-transformer)))
+        (is (= "-1" (m/decode schema1 "-1" mt/json-transformer)))
 
         (is (true? (m/validate schema1 0)))
         (is (nil? (m/explain schema1 0)))
@@ -370,6 +376,10 @@
         (is (true? (m/validate schema2 "string")))
         (is (nil? (m/explain schema2 "string")))
         (is (= "string" (m/parse schema2 "string")))
+        (is (= "string" (m/decode schema2 "string" mt/string-transformer)))
+        (is (= "" (m/decode schema2 "" mt/string-transformer)))
+        (is (= "string" (m/decode schema2 "string" mt/json-transformer)))
+        (is (= "" (m/decode schema2 "" mt/json-transformer)))
 
         (is (false? (m/validate schema1 1)))
         (is (results= {:schema schema1

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -306,13 +306,13 @@
 
         (is (true? (m/validate schema1 false)))
         (is (nil? (m/explain schema1 false)))
-        (is (= ::m/nonconforming (m/conform schema1 true)))
-        (is (= false (m/conform schema1 false)))
+        (is (= ::m/invalid (m/parse schema1 true)))
+        (is (= false (m/parse schema1 false)))
 
         (is (true? (m/validate schema2 true)))
         (is (nil? (m/explain schema2 true)))
-        (is (= true (m/conform schema2 true)))
-        (is (= ::m/nonconforming (m/conform schema2 false)))
+        (is (= true (m/parse schema2 true)))
+        (is (= ::m/invalid (m/parse schema2 false)))
 
         (is (false? (m/validate schema1 true)))
         (is (results= {:schema schema1
@@ -336,15 +336,15 @@
       (let [schema (m/schema [:not [:fn #(= % 1)]])]
         (is (true? (m/validate schema 2)))
         (is (nil? (m/explain schema 2)))
-        (is (= 2 (m/conform schema 2)))
+        (is (= 2 (m/parse schema 2)))
 
         (is (true? (m/validate schema "string")))
         (is (nil? (m/explain schema "string")))
-        (is (= "string" (m/conform schema "string")))
+        (is (= "string" (m/parse schema "string")))
 
         (is (true? (m/validate schema :keyword)))
         (is (nil? (m/explain schema :keyword)))
-        (is (= :keyword (m/conform schema :keyword)))
+        (is (= :keyword (m/parse schema :keyword)))
 
         (is (false? (m/validate schema 1)))
         (is (results= {:schema schema
@@ -354,22 +354,22 @@
                                  :schema schema
                                  :value 1}]}
                       (m/explain schema 1)))
-        (is (= ::m/nonconforming (m/conform schema 1)))))
+        (is (= ::m/invalid (m/parse schema 1)))))
 
     (testing "function validation"
       (let [schema1 (m/schema [:not pos?])
             schema2 (m/schema [:not empty?])]
         (is (true? (m/validate schema1 -1)))
         (is (nil? (m/explain schema1 -1)))
-        (is (= -1 (m/conform schema1 -1)))
+        (is (= -1 (m/parse schema1 -1)))
 
         (is (true? (m/validate schema1 0)))
         (is (nil? (m/explain schema1 0)))
-        (is (= 0 (m/conform schema1 0)))
+        (is (= 0 (m/parse schema1 0)))
 
         (is (true? (m/validate schema2 "string")))
         (is (nil? (m/explain schema2 "string")))
-        (is (= "string" (m/conform schema2 "string")))
+        (is (= "string" (m/parse schema2 "string")))
 
         (is (false? (m/validate schema1 1)))
         (is (results= {:schema schema1
@@ -379,7 +379,7 @@
                                  :schema schema1
                                  :value 1}]}
                       (m/explain schema1 1)))
-        (is (= ::m/nonconforming (m/conform schema1 1)))
+        (is (= ::m/invalid (m/parse schema1 1)))
 
         (is (false? (m/validate schema2 "")))
         (is (results= {:schema schema2
@@ -389,7 +389,7 @@
                                  :schema schema2
                                  :value ""}]}
                       (m/explain schema2 "")))
-        (is (= ::m/nonconforming (m/conform schema2 ""))))))
+        (is (= ::m/invalid (m/parse schema2 ""))))))
 
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -332,7 +332,10 @@
                                  :in []
                                  :schema schema2
                                  :value false}]}
-                      (m/explain schema2 false)))))
+                      (m/explain schema2 false)))
+
+        (is (m/walk schema1 (m/schema-walker identity)))
+        (is (m/walk schema2 (m/schema-walker identity)))))
 
     (testing ":fn validation"
       (let [schema (m/schema [:not [:fn #(= % 1)]])]
@@ -358,7 +361,9 @@
                                  :schema schema
                                  :value 1}]}
                       (m/explain schema 1)))
-        (is (= ::m/invalid (m/parse schema 1)))))
+        (is (= ::m/invalid (m/parse schema 1)))
+
+        (is (m/walk schema (m/schema-walker identity)))))
 
     (testing "function validation"
       (let [schema1 (m/schema [:not pos?])
@@ -399,7 +404,10 @@
                                  :schema schema2
                                  :value ""}]}
                       (m/explain schema2 "")))
-        (is (= ::m/invalid (m/parse schema2 ""))))))
+        (is (= ::m/invalid (m/parse schema2 "")))
+
+        (is (m/walk schema1 (m/schema-walker identity)))
+        (is (m/walk schema2 (m/schema-walker identity))))))
 
   (testing "comparator schemas"
     (let [schema (m/schema [:> 0])]


### PR DESCRIPTION
Fixes https://github.com/metosin/malli/issues/109

This PR adds `:not` schema, which acts as `complement`.