### PR TITLE
Regex clarifications

### DIFF
--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -214,7 +214,7 @@
               (fn [driver regs pos coll k]
                 (park-validator! driver r* regs pos coll k) ; remember fallback
                 (park-validator! driver r regs pos coll k))))
-          (reverse ?krs)))
+          ?krs))
 
 (defn alt-explainer [& ?krs]
   (reduce (fn [acc ?kr]
@@ -222,25 +222,24 @@
               (fn [driver regs pos coll k]
                 (park-explainer! driver r* regs pos coll k) ; remember fallback
                 (park-explainer! driver r regs pos coll k))))
-          (reverse ?krs)))
+          ?krs))
 
 (defn alt-parser [& rs]
   (reduce (fn [acc r]
             (fn [driver regs pos coll k]
               (park-validator! driver acc regs pos coll k)  ; remember fallback
               (park-validator! driver r regs pos coll k)))
-          (reverse rs)))
+          rs))
 
-(defn alt*-parser [& krs]
-  (let [[kr & krs] (reverse krs)]
-    (reduce (fn [acc [tag r]]
-              (let [r (fmap-parser (fn [v] (miu/-tagged tag v)) r)]
-                (fn [driver regs pos coll k]
-                  (park-validator! driver acc regs pos coll k) ; remember fallback
-                  (park-validator! driver r regs pos coll k))))
-            (let [[tag r] kr]
-              (fmap-parser (fn [v] (miu/-tagged tag v)) r))
-            krs)))
+(defn alt*-parser [kr & krs]
+  (reduce (fn [acc [tag r]]
+            (let [r (fmap-parser (fn [v] (miu/-tagged tag v)) r)]
+              (fn [driver regs pos coll k]
+                (park-validator! driver acc regs pos coll k) ; remember fallback
+                (park-validator! driver r regs pos coll k))))
+          (let [[tag r] kr]
+            (fmap-parser (fn [v] (miu/-tagged tag v)) r))
+          krs))
 
 (defn alt-unparser [& unparsers]
   (fn [x]
@@ -260,9 +259,9 @@
   (reduce (fn [acc ?kr]
             (let [r (entry->regex acc), r* (entry->regex ?kr)]
               (fn [driver regs coll* pos coll k]
-                (park-transformer! driver r regs coll* pos coll k) ; remember fallback
-                (park-transformer! driver r* regs coll* pos coll k))))
-          (reverse ?krs)))
+                (park-transformer! driver r* regs coll* pos coll k) ; remember fallback
+                (park-transformer! driver r regs coll* pos coll k))))
+          ?krs))
 
 ;;;; ## Option
 

--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -129,7 +129,7 @@
 
 ;;;; ## Functor
 
-(defn fmap [f p]
+(defn fmap-parser [f p]
   (fn [driver regs pos coll k]
     (p driver regs pos coll (fn [v pos coll] (k (f v) pos coll)))))
 
@@ -234,12 +234,12 @@
 (defn alt*-parser [& krs]
   (let [[kr & krs] (reverse krs)]
     (reduce (fn [acc [tag r]]
-              (let [r (fmap (fn [v] (miu/-tagged tag v)) r)]
+              (let [r (fmap-parser (fn [v] (miu/-tagged tag v)) r)]
                 (fn [driver regs pos coll k]
                   (park-validator! driver acc regs pos coll k) ; remember fallback
                   (park-validator! driver r regs pos coll k))))
             (let [[tag r] kr]
-              (fmap (fn [v] (miu/-tagged tag v)) r))
+              (fmap-parser (fn [v] (miu/-tagged tag v)) r))
             krs)))
 
 (defn alt-unparser [& unparsers]
@@ -315,7 +315,7 @@
 
 (defn +-validator [p] (cat-validator p (*-validator p)))
 (defn +-explainer [p] (cat-explainer p (*-explainer p)))
-(defn +-parser [p] (fmap (fn [[v vs]] (cons v vs)) (cat-parser p (*-parser p))))
+(defn +-parser [p] (fmap-parser (fn [[v vs]] (cons v vs)) (cat-parser p (*-parser p))))
 
 (defn +-unparser [up]
   (let [up* (*-unparser up)]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1461,8 +1461,8 @@
           nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
           [] nil nil
           ["foo"] "foo" nil
-          [0] nil [{:path [], :in [0], :schema s, :value 0, :type ::m/input-remaining}
-                   {:path [0], :in [0], :schema string?, :value 0}]
+          [0] nil [{:path [0], :in [0], :schema string?, :value 0}
+                   {:path [], :in [0], :schema s, :value 0, :type ::m/input-remaining}]
           ["foo" 0] nil [{:path [], :in [1], :schema s, :value 0, :type ::m/input-remaining}]))
 
       (testing "pathological case (terminates)"

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1461,8 +1461,8 @@
           nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
           [] nil nil
           ["foo"] "foo" nil
-          [0] nil [{:path [0], :in [0], :schema string?, :value 0}
-                   {:path [], :in [0], :schema s, :value 0, :type ::m/input-remaining}]
+          [0] nil [{:path [], :in [0], :schema s, :value 0, :type ::m/input-remaining}
+                   {:path [0], :in [0], :schema string?, :value 0}]
           ["foo" 0] nil [{:path [], :in [1], :schema s, :value 0, :type ::m/input-remaining}]))
 
       (testing "pathological case (terminates)"


### PR DESCRIPTION
Simplifications to `regex.impl`:

* Streamline `:cat` and `:alt` "compilations"
* Improve naming