### PR TITLE
renamed named variants of :cat, :alt and :or

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Malli is in [alpha](README.md#alpha).
 * support for parsing and unparsing schemas: `m/parse`, `m/parser`, `m/unparse`, `m/unparser`, see [Parsing values](./README.md#parsing-values).
 * support for function schmas: `:=>` and `:function`, see [Function Schemas](./README.md#function-schemas).
 * support for [clj-kondo](https://github.com/clj-kondo/clj-kondo), see [Clj-kondo](./README.md#clj-kondo).
-* new schemas: `:any` (e.g. `any?`), `:not` (complement) and `:or*` (or with named branches)
+* new schemas: `:any` (e.g. `any?`), `:not` (complement) and `:or-named` (or with named branches)
 * `:qualified-keyword` support `:namespace` property
 
 * FIX: Schema vizualization is not working for `[:< ...]` like schemas, [#370](https://github.com/metosin/malli/issues/370)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Malli is in [alpha](README.md#alpha).
 * support for parsing and unparsing schemas: `m/parse`, `m/parser`, `m/unparse`, `m/unparser`, see [Parsing values](./README.md#parsing-values).
 * support for function schmas: `:=>` and `:function`, see [Function Schemas](./README.md#function-schemas).
 * support for [clj-kondo](https://github.com/clj-kondo/clj-kondo), see [Clj-kondo](./README.md#clj-kondo).
-* new schemas: `:any` (e.g. `any?`), `:not` (complement) and `:or-named` (or with named branches)
+* new schemas: `:any` (e.g. `any?`), `:not` (complement) and `:orn` (or with named branches)
 * `:qualified-keyword` support `:namespace` property
 
 * FIX: Schema vizualization is not working for `[:< ...]` like schemas, [#370](https://github.com/metosin/malli/issues/370)

--- a/README.md
+++ b/README.md
@@ -164,20 +164,20 @@ You can use `:sequential` for any homogeneous Clojure sequence, `:vector` for ve
 ```
 
 Malli also supports sequence regexes like [Seqexp](https://github.com/cgrand/seqexp) and Spec.
-The supported operators are `:cat` & `:cat*` for concatenation / sequencing
+The supported operators are `:cat` & `:cat-named` for concatenation / sequencing
 
 ```clj
 (m/validate [:cat string? int?] ["foo" 0]) ; => true
 
-(m/validate [:cat* [:s string?] [:n int?]] ["foo" 0]) ; => true
+(m/validate [:cat-named [:s string?] [:n int?]] ["foo" 0]) ; => true
 ```
 
-`:alt` & `:alt*` for alternatives
+`:alt` & `:alt-named` for alternatives
 
 ```clj
 (m/validate [:alt keyword? string?] ["foo"]) ; => true
 
-(m/validate [:alt* [:kw keyword?] [:s string?]] ["foo"]) ; => true
+(m/validate [:alt-named [:kw keyword?] [:s string?]] ["foo"]) ; => true
 ```
 
 and `:?`, `:*`, `:+` & `:repeat` for repetition:
@@ -200,11 +200,11 @@ and `:?`, `:*`, `:+` & `:repeat` for repetition:
 (m/validate [:repeat {:min 2, :max 4} int?] [1 2 3 4 5]) ; => false
 ```
 
-`:cat*` and `:alt*` allow naming the subsequences / alternatives
+`:cat-named` and `:alt-named` allow naming the subsequences / alternatives
 
 ```clj
 (m/explain
-  [:* [:cat* [:prop string?] [:val [:alt* [:s string?] [:b boolean?]]]]]
+  [:* [:cat-named [:prop string?] [:val [:alt-named [:s string?] [:b boolean?]]]]]
   ["-server" "foo" "-verbose" 11 "-user" "joe"])
 ;; => {:schema [:* [:map [:prop string?] [:val [:map [:s string?] [:b boolean?]]]]],
 ;;     :value ["-server" "foo" "-verbose" 11 "-user" "joe"],
@@ -1238,9 +1238,9 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
 
 ```clj
 (m/parse
-  [:* [:cat*
+  [:* [:cat-named
        [:prop string?]
-       [:val [:alt*
+       [:val [:alt-named
               [:s string?]
               [:b boolean?]]]]]
   ["-server" "foo" "-verbose" true "-user" "joe"])
@@ -1253,12 +1253,12 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
 
 ```clj
 (def Hiccup
-  [:schema {:registry {"hiccup" [:or*
-                                 [:node [:cat*
+  [:schema {:registry {"hiccup" [:or-named
+                                 [:node [:cat-named
                                          [:name keyword?]
                                          [:props [:? [:map-of keyword? any?]]]
                                          [:children [:* [:schema [:ref "hiccup"]]]]]]
-                                 [:primitive [:or*
+                                 [:primitive [:or-named
                                               [:nil nil?]
                                               [:boolean boolean?]
                                               [:number number?]
@@ -1816,7 +1816,7 @@ Functions can be described with `:=>`, which has two children: input schema (as 
 [:=> [:cat int? int?] pos-int?]
 
 ;; named varargs, e.g. (fn [x & xs] (* x (apply + xs)))
-[:=> [:cat* 
+[:=> [:cat-named 
       [:x int?]
       [:xs [:* int?]]]
       
@@ -2120,9 +2120,9 @@ Parsing:
     (parse ["-server" "foo" "-verbose" "-verbose" "-user" "joe"])))
 
 ;; 2.5µs
-(let [schema [:* [:cat*
+(let [schema [:* [:cat-named
                   [:prop string?]
-                  [:val [:alt*
+                  [:val [:alt-named
                          [:s string?]
                          [:b boolean?]]]]]
       parse (m/parser schema)]

--- a/README.md
+++ b/README.md
@@ -164,20 +164,20 @@ You can use `:sequential` for any homogeneous Clojure sequence, `:vector` for ve
 ```
 
 Malli also supports sequence regexes like [Seqexp](https://github.com/cgrand/seqexp) and Spec.
-The supported operators are `:cat` & `:cat-named` for concatenation / sequencing
+The supported operators are `:cat` & `:catn` for concatenation / sequencing
 
 ```clj
 (m/validate [:cat string? int?] ["foo" 0]) ; => true
 
-(m/validate [:cat-named [:s string?] [:n int?]] ["foo" 0]) ; => true
+(m/validate [:catn [:s string?] [:n int?]] ["foo" 0]) ; => true
 ```
 
-`:alt` & `:alt-named` for alternatives
+`:alt` & `:altn` for alternatives
 
 ```clj
 (m/validate [:alt keyword? string?] ["foo"]) ; => true
 
-(m/validate [:alt-named [:kw keyword?] [:s string?]] ["foo"]) ; => true
+(m/validate [:altn [:kw keyword?] [:s string?]] ["foo"]) ; => true
 ```
 
 and `:?`, `:*`, `:+` & `:repeat` for repetition:
@@ -200,11 +200,11 @@ and `:?`, `:*`, `:+` & `:repeat` for repetition:
 (m/validate [:repeat {:min 2, :max 4} int?] [1 2 3 4 5]) ; => false
 ```
 
-`:cat-named` and `:alt-named` allow naming the subsequences / alternatives
+`:catn` and `:altn` allow naming the subsequences / alternatives
 
 ```clj
 (m/explain
-  [:* [:cat-named [:prop string?] [:val [:alt-named [:s string?] [:b boolean?]]]]]
+  [:* [:catn [:prop string?] [:val [:altn [:s string?] [:b boolean?]]]]]
   ["-server" "foo" "-verbose" 11 "-user" "joe"])
 ;; => {:schema [:* [:map [:prop string?] [:val [:map [:s string?] [:b boolean?]]]]],
 ;;     :value ["-server" "foo" "-verbose" 11 "-user" "joe"],
@@ -1238,9 +1238,9 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
 
 ```clj
 (m/parse
-  [:* [:cat-named
+  [:* [:catn
        [:prop string?]
-       [:val [:alt-named
+       [:val [:altn
               [:s string?]
               [:b boolean?]]]]]
   ["-server" "foo" "-verbose" true "-user" "joe"])
@@ -1253,12 +1253,12 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
 
 ```clj
 (def Hiccup
-  [:schema {:registry {"hiccup" [:or-named
-                                 [:node [:cat-named
+  [:schema {:registry {"hiccup" [:orn
+                                 [:node [:catn
                                          [:name keyword?]
                                          [:props [:? [:map-of keyword? any?]]]
                                          [:children [:* [:schema [:ref "hiccup"]]]]]]
-                                 [:primitive [:or-named
+                                 [:primitive [:orn
                                               [:nil nil?]
                                               [:boolean boolean?]
                                               [:number number?]
@@ -1816,7 +1816,7 @@ Functions can be described with `:=>`, which has two children: input schema (as 
 [:=> [:cat int? int?] pos-int?]
 
 ;; named varargs, e.g. (fn [x & xs] (* x (apply + xs)))
-[:=> [:cat-named 
+[:=> [:catn 
       [:x int?]
       [:xs [:* int?]]]
       
@@ -2120,9 +2120,9 @@ Parsing:
     (parse ["-server" "foo" "-verbose" "-verbose" "-user" "joe"])))
 
 ;; 2.5µs
-(let [schema [:* [:cat-named
+(let [schema [:* [:catn
                   [:prop string?]
-                  [:val [:alt-named
+                  [:val [:altn
                          [:s string?]
                          [:b boolean?]]]]]
       parse (m/parser schema)]

--- a/perf/malli/perf_test.cljc
+++ b/perf/malli/perf_test.cljc
@@ -325,9 +325,9 @@
                                                 [:b (mh/fn boolean?)])]))
         valid-minimallist? (partial mc/valid? minimallist)
 
-        malli [:* [:cat-named
+        malli [:* [:catn
                    [:prop string?]
-                   [:val [:alt-named
+                   [:val [:altn
                           [:s string?]
                           [:b boolean?]]]]]
         valid-malli? (m/validator malli)]
@@ -355,9 +355,9 @@
       (parse ["-server" "foo" "-verbose" "-verbose" "-user" "joe"])))
 
   ;; 2.5µs
-  (let [schema [:* [:cat-named
+  (let [schema [:* [:catn
                     [:prop string?]
-                    [:val [:alt-named
+                    [:val [:altn
                            [:s string?]
                            [:b boolean?]]]]]
         parse (m/parser schema)]

--- a/perf/malli/perf_test.cljc
+++ b/perf/malli/perf_test.cljc
@@ -325,9 +325,9 @@
                                                 [:b (mh/fn boolean?)])]))
         valid-minimallist? (partial mc/valid? minimallist)
 
-        malli [:* [:cat*
+        malli [:* [:cat-named
                    [:prop string?]
-                   [:val [:alt*
+                   [:val [:alt-named
                           [:s string?]
                           [:b boolean?]]]]]
         valid-malli? (m/validator malli)]
@@ -355,9 +355,9 @@
       (parse ["-server" "foo" "-verbose" "-verbose" "-user" "joe"])))
 
   ;; 2.5µs
-  (let [schema [:* [:cat*
+  (let [schema [:* [:cat-named
                     [:prop string?]
-                    [:val [:alt*
+                    [:val [:alt-named
                            [:s string?]
                            [:b boolean?]]]]]
         parse (m/parser schema)]

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -103,7 +103,7 @@
 (defmethod accept :* [_ _ [child] _] {:op :rest, :spec (transform child)})
 (defmethod accept :repeat [_ _ [child] _] {:op :rest, :spec (transform child)})
 (defmethod accept :cat [_ _ children _] children)
-(defmethod accept :cat-named [_ _ children _] (mapv last children))
+(defmethod accept :catn [_ _ children _] (mapv last children))
 
 (defmethod accept :merge [_ schema _ options] (transform (m/deref schema) options))
 (defmethod accept :union [_ schema _ options] (transform (m/deref schema) options))

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -103,7 +103,7 @@
 (defmethod accept :* [_ _ [child] _] {:op :rest, :spec (transform child)})
 (defmethod accept :repeat [_ _ [child] _] {:op :rest, :spec (transform child)})
 (defmethod accept :cat [_ _ children _] children)
-(defmethod accept :cat* [_ _ children _] (mapv last children))
+(defmethod accept :cat-named [_ _ children _] (mapv last children))
 
 (defmethod accept :merge [_ schema _ options] (transform (m/deref schema) options))
 (defmethod accept :union [_ schema _ options] (transform (m/deref schema) options))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -453,17 +453,17 @@
           (-get [_ key default] (get children key default))
           (-set [this key value] (-set-assoc-children this key value)))))))
 
-(defn -or-named-schema []
+(defn -orn-schema []
   ^{:type ::into-schema}
   (reify IntoSchema
     (-into-schema [_ properties children options]
-      (-check-children! :or-named properties children {:min 1})
+      (-check-children! :orn properties children {:min 1})
       (let [{:keys [children entries forms]} (-parse-entries children {:naked-keys true} options)
-            form (-create-form :or-named properties forms)]
+            form (-create-form :orn properties forms)]
         ^{:type ::schema}
         (reify
           Schema
-          (-type [_] :or-named)
+          (-type [_] :orn)
           (-type-properties [_])
           (-validator [_]
             (let [validators (distinct (map (fn [[_ _ c]] (-validator c)) children))]
@@ -515,7 +515,7 @@
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
-          (-parent [_] (-or-named-schema))
+          (-parent [_] (-orn-schema))
           (-form [_] form)
 
           LensSchema
@@ -1282,7 +1282,7 @@
       (let [[input :as children] (map #(schema % options) children)
             form (-create-form :=> properties (map -form children))
             ->checker (if function-checker #(function-checker % options) (constantly nil))]
-        (when-not (#{:cat :cat-named} (-type input))
+        (when-not (#{:cat :catn} (-type input))
           (miu/-fail! ::invalid-input-schema {:input input}))
         ^{:type ::schema}
         (reify
@@ -1832,25 +1832,25 @@
                            :re-unparser (fn [_ children] (apply re/alt-unparser children))
                            :re-transformer (fn [_ children] (apply re/alt-transformer children))
                            :re-min-max (fn [_ children] (reduce -re-alt-min-max {:min miu/+max-size+, :max 0} children))})
-   :cat-named (-sequence-entry-schema {:type :cat-named, :child-bounds {}
-                                       :re-validator (fn [_ children] (apply re/cat-validator children))
-                                       :re-explainer (fn [_ children] (apply re/cat-explainer children))
-                                       :re-parser (fn [_ children] (apply re/cat*-parser children))
-                                       :re-unparser (fn [_ children] (apply re/cat*-unparser children))
-                                       :re-transformer (fn [_ children] (apply re/cat-transformer children))
-                                       :re-min-max (fn [_ children] (reduce (partial -re-min-max +) {:min 0, :max 0} (map last children)))})
-   :alt-named (-sequence-entry-schema {:type :alt-named, :child-bounds {:min 1}
-                                       :re-validator (fn [_ children] (apply re/alt-validator children))
-                                       :re-explainer (fn [_ children] (apply re/alt-explainer children))
-                                       :re-parser (fn [_ children] (apply re/alt*-parser children))
-                                       :re-unparser (fn [_ children] (apply re/alt*-unparser children))
-                                       :re-transformer (fn [_ children] (apply re/alt-transformer children))
-                                       :re-min-max (fn [_ children] (reduce -re-alt-min-max {:min miu/+max-size+, :max 0} (map last children)))})})
+   :catn (-sequence-entry-schema {:type :catn, :child-bounds {}
+                                  :re-validator (fn [_ children] (apply re/cat-validator children))
+                                  :re-explainer (fn [_ children] (apply re/cat-explainer children))
+                                  :re-parser (fn [_ children] (apply re/catn-parser children))
+                                  :re-unparser (fn [_ children] (apply re/catn-unparser children))
+                                  :re-transformer (fn [_ children] (apply re/cat-transformer children))
+                                  :re-min-max (fn [_ children] (reduce (partial -re-min-max +) {:min 0, :max 0} (map last children)))})
+   :altn (-sequence-entry-schema {:type :altn, :child-bounds {:min 1}
+                                  :re-validator (fn [_ children] (apply re/alt-validator children))
+                                  :re-explainer (fn [_ children] (apply re/alt-explainer children))
+                                  :re-parser (fn [_ children] (apply re/altn-parser children))
+                                  :re-unparser (fn [_ children] (apply re/altn-unparser children))
+                                  :re-transformer (fn [_ children] (apply re/alt-transformer children))
+                                  :re-min-max (fn [_ children] (reduce -re-alt-min-max {:min miu/+max-size+, :max 0} (map last children)))})})
 
 (defn base-schemas []
   {:and (-and-schema)
    :or (-or-schema)
-   :or-named (-or-named-schema)
+   :orn (-orn-schema)
    :not (-not-schema)
    :map (-map-schema)
    :map-of (-map-of-schema)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -453,17 +453,17 @@
           (-get [_ key default] (get children key default))
           (-set [this key value] (-set-assoc-children this key value)))))))
 
-(defn -or*-schema []
+(defn -or-named-schema []
   ^{:type ::into-schema}
   (reify IntoSchema
     (-into-schema [_ properties children options]
-      (-check-children! :or* properties children {:min 1})
+      (-check-children! :or-named properties children {:min 1})
       (let [{:keys [children entries forms]} (-parse-entries children {:naked-keys true} options)
-            form (-create-form :or* properties forms)]
+            form (-create-form :or-named properties forms)]
         ^{:type ::schema}
         (reify
           Schema
-          (-type [_] :or*)
+          (-type [_] :or-named)
           (-type-properties [_])
           (-validator [_]
             (let [validators (distinct (map (fn [[_ _ c]] (-validator c)) children))]
@@ -515,7 +515,7 @@
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
-          (-parent [_] (-or*-schema))
+          (-parent [_] (-or-named-schema))
           (-form [_] form)
 
           LensSchema
@@ -1282,7 +1282,7 @@
       (let [[input :as children] (map #(schema % options) children)
             form (-create-form :=> properties (map -form children))
             ->checker (if function-checker #(function-checker % options) (constantly nil))]
-        (when-not (#{:cat :cat*} (-type input))
+        (when-not (#{:cat :cat-named} (-type input))
           (miu/-fail! ::invalid-input-schema {:input input}))
         ^{:type ::schema}
         (reify
@@ -1832,25 +1832,25 @@
                            :re-unparser (fn [_ children] (apply re/alt-unparser children))
                            :re-transformer (fn [_ children] (apply re/alt-transformer children))
                            :re-min-max (fn [_ children] (reduce -re-alt-min-max {:min miu/+max-size+, :max 0} children))})
-   :cat* (-sequence-entry-schema {:type :cat*, :child-bounds {}
-                                  :re-validator (fn [_ children] (apply re/cat-validator children))
-                                  :re-explainer (fn [_ children] (apply re/cat-explainer children))
-                                  :re-parser (fn [_ children] (apply re/cat*-parser children))
-                                  :re-unparser (fn [_ children] (apply re/cat*-unparser children))
-                                  :re-transformer (fn [_ children] (apply re/cat-transformer children))
-                                  :re-min-max (fn [_ children] (reduce (partial -re-min-max +) {:min 0, :max 0} (map last children)))})
-   :alt* (-sequence-entry-schema {:type :alt*, :child-bounds {:min 1}
-                                  :re-validator (fn [_ children] (apply re/alt-validator children))
-                                  :re-explainer (fn [_ children] (apply re/alt-explainer children))
-                                  :re-parser (fn [_ children] (apply re/alt*-parser children))
-                                  :re-unparser (fn [_ children] (apply re/alt*-unparser children))
-                                  :re-transformer (fn [_ children] (apply re/alt-transformer children))
-                                  :re-min-max (fn [_ children] (reduce -re-alt-min-max {:min miu/+max-size+, :max 0} (map last children)))})})
+   :cat-named (-sequence-entry-schema {:type :cat-named, :child-bounds {}
+                                       :re-validator (fn [_ children] (apply re/cat-validator children))
+                                       :re-explainer (fn [_ children] (apply re/cat-explainer children))
+                                       :re-parser (fn [_ children] (apply re/cat*-parser children))
+                                       :re-unparser (fn [_ children] (apply re/cat*-unparser children))
+                                       :re-transformer (fn [_ children] (apply re/cat-transformer children))
+                                       :re-min-max (fn [_ children] (reduce (partial -re-min-max +) {:min 0, :max 0} (map last children)))})
+   :alt-named (-sequence-entry-schema {:type :alt-named, :child-bounds {:min 1}
+                                       :re-validator (fn [_ children] (apply re/alt-validator children))
+                                       :re-explainer (fn [_ children] (apply re/alt-explainer children))
+                                       :re-parser (fn [_ children] (apply re/alt*-parser children))
+                                       :re-unparser (fn [_ children] (apply re/alt*-unparser children))
+                                       :re-transformer (fn [_ children] (apply re/alt-transformer children))
+                                       :re-min-max (fn [_ children] (reduce -re-alt-min-max {:min miu/+max-size+, :max 0} (map last children)))})})
 
 (defn base-schemas []
   {:and (-and-schema)
    :or (-or-schema)
-   :or* (-or*-schema)
+   :or-named (-or-named-schema)
    :not (-not-schema)
    :map (-map-schema)
    :map-of (-map-of-schema)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -226,9 +226,9 @@
 (defmethod -schema-generator :select-keys [schema options] (generator (m/deref schema) options))
 
 (defmethod -schema-generator :cat [schema options] (-cat-gen schema options))
-(defmethod -schema-generator :cat* [schema options] (-cat-gen schema options))
+(defmethod -schema-generator :cat-named [schema options] (-cat-gen schema options))
 (defmethod -schema-generator :alt [schema options] (-alt-gen schema options))
-(defmethod -schema-generator :alt* [schema options] (-alt-gen schema options))
+(defmethod -schema-generator :alt-named [schema options] (-alt-gen schema options))
 
 (defmethod -schema-generator :? [schema options] (-?-gen schema options))
 (defmethod -schema-generator :* [schema options] (-*-gen schema options))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -226,9 +226,9 @@
 (defmethod -schema-generator :select-keys [schema options] (generator (m/deref schema) options))
 
 (defmethod -schema-generator :cat [schema options] (-cat-gen schema options))
-(defmethod -schema-generator :cat-named [schema options] (-cat-gen schema options))
+(defmethod -schema-generator :catn [schema options] (-cat-gen schema options))
 (defmethod -schema-generator :alt [schema options] (-alt-gen schema options))
-(defmethod -schema-generator :alt-named [schema options] (-alt-gen schema options))
+(defmethod -schema-generator :altn [schema options] (-alt-gen schema options))
 
 (defmethod -schema-generator :? [schema options] (-?-gen schema options))
 (defmethod -schema-generator :* [schema options] (-*-gen schema options))

--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -166,7 +166,7 @@
                     (reverse (cons r rs)))]
      (fn [driver regs pos coll k] (sp driver regs [] pos coll k)))))
 
-(defn cat*-parser
+(defn catn-parser
   ([] (fn [_ _ pos coll k] (k {} pos coll)))
   ([kr & krs]
    (let [sp (reduce (fn [acc [tag r]]
@@ -185,7 +185,7 @@
                    [] unparsers)
         :malli.core/invalid))))
 
-(defn cat*-unparser [& unparsers]
+(defn catn-unparser [& unparsers]
   (let [unparsers (into {} unparsers)]
     (fn [m]
       (if (and (map? m) (= (count m) (count unparsers)))
@@ -227,11 +227,11 @@
 (defn alt-parser [& rs]
   (reduce (fn [acc r]
             (fn [driver regs pos coll k]
-              (park-validator! driver acc regs pos coll k)  ; remember fallback
+              (park-validator! driver acc regs pos coll k) ; remember fallback
               (park-validator! driver r regs pos coll k)))
           rs))
 
-(defn alt*-parser [kr & krs]
+(defn altn-parser [kr & krs]
   (reduce (fn [acc [tag r]]
             (let [r (fmap-parser (fn [v] (miu/-tagged tag v)) r)]
               (fn [driver regs pos coll k]
@@ -246,7 +246,7 @@
     (reduce (fn [_ unparse] (miu/-map-valid reduced (unparse x)))
             :malli.core/invalid unparsers)))
 
-(defn alt*-unparser [& unparsers]
+(defn altn-unparser [& unparsers]
   (let [unparsers (into {} unparsers)]
     (fn [x]
       (if (miu/-tagged? x)
@@ -276,13 +276,13 @@
 (defn *-validator [p]
   (let [*p-epsilon (cat-validator)]
     (fn *p [driver regs pos coll k]
-      (park-validator! driver *p-epsilon regs pos coll k)   ; remember fallback
+      (park-validator! driver *p-epsilon regs pos coll k) ; remember fallback
       (p driver regs pos coll (fn [pos coll] (park-validator! driver *p regs pos coll k)))))) ; TCO
 
 (defn *-explainer [p]
   (let [*p-epsilon (cat-explainer)]
     (fn *p [driver regs pos coll k]
-      (park-explainer! driver *p-epsilon regs pos coll k)   ; remember fallback
+      (park-explainer! driver *p-epsilon regs pos coll k) ; remember fallback
       (p driver regs pos coll (fn [pos coll] (park-explainer! driver *p regs pos coll k)))))) ; TCO
 
 (defn *-parser [p]
@@ -396,7 +396,7 @@
                          driver
                          (fn [driver regs coll* pos coll k]
                            (optionals driver (conj (pop regs) (inc (peek regs))) (conj coll* v) pos coll k))
-                         regs coll* pos coll k))))          ; TCO
+                         regs coll* pos coll k)))) ; TCO
                 (k coll* pos coll)))]
       (fn [driver regs pos coll k] (compulsories driver (conj regs 0) [] pos coll k)))))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -178,7 +178,7 @@
 
   (testing "composite schemas"
     (let [schema (m/schema [:and int? [:or pos-int? neg-int?]])
-          schema* (m/schema [:and int? [:or-named [:pos pos-int?] [:neg neg-int?]]])]
+          schema* (m/schema [:and int? [:orn [:pos pos-int?] [:neg neg-int?]]])]
 
       (doseq [schema [schema schema*]]
         (is (true? (m/validate schema 1)))
@@ -189,7 +189,7 @@
 
       (is (= pos-int? (m/validator [:and pos-int? pos-int? pos-int?])))
       (is (= pos-int? (m/validator [:or pos-int? pos-int? pos-int?])))
-      (is (= pos-int? (m/validator [:or-named [:a pos-int?] [:b pos-int?] [:c pos-int?]])))
+      (is (= pos-int? (m/validator [:orn [:a pos-int?] [:b pos-int?] [:c pos-int?]])))
 
       (is (nil? (m/explain schema 1)))
       (is (results= {:schema schema,
@@ -235,13 +235,13 @@
              (mu/to-map-syntax schema)))
       (is (= {:type :and
               :children [{:type 'int?}
-                         {:type :or-named
+                         {:type :orn
                           :children [[:pos nil {:type 'pos-int?}]
                                      [:neg nil {:type 'neg-int?}]]}]}
              (mu/to-map-syntax schema*)))
 
       (is (= [:and 'int? [:or 'pos-int? 'neg-int?]] (m/form schema)))
-      (is (= [:and 'int? [:or-named [:pos 'pos-int?] [:neg 'neg-int?]]] (m/form schema*))))
+      (is (= [:and 'int? [:orn [:pos 'pos-int?] [:neg 'neg-int?]]] (m/form schema*))))
 
     (testing "transforming :or"
       (testing "first valid transformed branch is used"
@@ -250,7 +250,7 @@
                          int?
                          [:map [:y keyword?]]
                          keyword?]
-                        [:or-named
+                        [:orn
                          [:äxy [:map [:x keyword?]]]
                          [:n int?]
                          [:yxy [:map [:y keyword?]]]
@@ -274,7 +274,7 @@
                          [:map
                           [:y keyword?]
                           [:enter boolean?]]]
-                        [:or-named {:decode/string {:enter (fn [m] (update m :enter #(or % true)))
+                        [:orn {:decode/string {:enter (fn [m] (update m :enter #(or % true)))
                                                :leave (fn [m] (update m :leave #(or % true)))}}
                          [:äxy [:map
                                 [:x keyword?]
@@ -1299,7 +1299,7 @@
              (mu/to-map-syntax [:tuple int? int?])))))
 
   (testing "seqex schemas"
-    (doseq [typ [:cat :cat-named]]
+    (doseq [typ [:cat :catn]]
       (testing typ
         (testing "empty"
           (let [s [typ]]
@@ -1328,9 +1328,9 @@
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
               nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
-              [] nil [{:path [(case typ :cat-named :s 0)], :in [0], :schema string?, :value nil, :type ::m/end-of-input}]
+              [] nil [{:path [(case typ :catn :s 0)], :in [0], :schema string?, :value nil, :type ::m/end-of-input}]
               ["foo"] {:s "foo"} nil
-              [0] nil [{:path [(case typ :cat-named :s 0)], :in [0], :schema string?, :value 0}]
+              [0] nil [{:path [(case typ :catn :s 0)], :in [0], :schema string?, :value 0}]
               ["foo" "bar"] nil [{:path [], :in [1], :schema s, :value "bar", :type ::m/input-remaining}])))
 
         (testing "pair"
@@ -1345,11 +1345,11 @@
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
               nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
-              [] nil [{:path [(case typ :cat-named :s 0)], :in [0], :schema string?, :value nil, :type ::m/end-of-input}]
-              ["foo"] nil [{:path [(case typ :cat-named :n 1)], :in [1], :schema int?, :value nil, :type ::m/end-of-input}]
+              [] nil [{:path [(case typ :catn :s 0)], :in [0], :schema string?, :value nil, :type ::m/end-of-input}]
+              ["foo"] nil [{:path [(case typ :catn :n 1)], :in [1], :schema int?, :value nil, :type ::m/end-of-input}]
               ["foo" 0] {:s "foo", :n 0} nil
-              ["foo" "bar"] nil [{:path [(case typ :cat-named :n 1)], :in [1], :schema int?, :value "bar"}]
-              [1 2] nil [{:path [(case typ :cat-named :s 0)], :in [0], :schema string?, :value 1}]
+              ["foo" "bar"] nil [{:path [(case typ :catn :n 1)], :in [1], :schema int?, :value "bar"}]
+              [1 2] nil [{:path [(case typ :catn :s 0)], :in [0], :schema string?, :value 1}]
               ["foo" 0 1] nil [{:path [], :in [2], :schema s, :value 1, :type ::m/input-remaining}])))
 
         (testing "triplet"
@@ -1365,16 +1365,16 @@
               0 nil [{:path [], :in [], :schema s, :value 0, :type ::m/invalid-type}]
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
               nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
-              [] nil [{:path [(case typ :cat-named :s 0)], :in [0], :schema string?, :value nil, :type ::m/end-of-input}]
-              ["foo"] nil [{:path [(case typ :cat-named :n 1)], :in [1], :schema int?, :value nil, :type ::m/end-of-input}]
-              ["foo" 0] nil [{:path [(case typ :cat-named :k 2)], :in [2], :schema keyword?, :value nil, :type ::m/end-of-input}]
+              [] nil [{:path [(case typ :catn :s 0)], :in [0], :schema string?, :value nil, :type ::m/end-of-input}]
+              ["foo"] nil [{:path [(case typ :catn :n 1)], :in [1], :schema int?, :value nil, :type ::m/end-of-input}]
+              ["foo" 0] nil [{:path [(case typ :catn :k 2)], :in [2], :schema keyword?, :value nil, :type ::m/end-of-input}]
               ["foo" 0 :bar] {:s "foo", :n 0, :k :bar} nil
-              ["foo" 0 "bar"] nil [{:path [(case typ :cat-named :k 2)], :in [2], :schema keyword?, :value "bar"}]
+              ["foo" 0 "bar"] nil [{:path [(case typ :catn :k 2)], :in [2], :schema keyword?, :value "bar"}]
               ["foo" 0 :bar 0] nil [{:path [], :in [3], :schema s, :value 0, :type ::m/input-remaining}])))
 
         (testing "* backtracks"
           (let [s [:cat [:* pos?] [:= 4]]
-                s* [:cat-named [:pos [:* pos?]] [:four [:= 4]]]
+                s* [:catn [:pos [:* pos?]] [:four [:= 4]]]
                 v [4 4 4 4]]
             (is (m/validate s v))
 
@@ -1383,7 +1383,7 @@
             (is (= v (m/unparse s [[4 4 4] 4])))
             (is (= v (m/unparse s* {:pos [4 4 4], :four 4})))))))
 
-    (doseq [typ [:alt :alt-named]]
+    (doseq [typ [:alt :altn]]
       (testing typ
         (testing "empty"
           (is (thrown? #?(:clj Exception, :cljs js/Error) (m/validator [typ]))))
@@ -1402,7 +1402,7 @@
               "foo" nil [{:path [], :in [], :schema s, :value "foo", :type ::m/invalid-type}]
               nil nil [{:path [], :in [], :schema s, :value nil, :type ::m/invalid-type}]
               ["foo"] ["foo" (miu/-tagged :s "foo")] nil
-              [0] nil [{:path [(case typ :alt-named :s 0)], :in [0], :schema string?, :value 0}]
+              [0] nil [{:path [(case typ :altn :s 0)], :in [0], :schema string?, :value 0}]
               ["foo" 0] nil [{:path [], :in [1], :schema s, :value 0, :type ::m/input-remaining}])))
 
         (testing "pair"
@@ -2011,14 +2011,14 @@
     [:cat int?] [1 1]
     [:cat int? [:cat]] [1 1]
     [:cat int? [:cat string? int?]] [3 3]
-    [:cat-named] [0 0]
-    [:cat-named [:n int?]] [1 1]
-    [:cat-named [:n int?] [:named [:cat]]] [1 1]
-    [:cat-named [:n int?] [:named [:cat string? int?]]] [3 3]
+    [:catn] [0 0]
+    [:catn [:n int?]] [1 1]
+    [:catn [:n int?] [:named [:cat]]] [1 1]
+    [:catn [:n int?] [:named [:cat string? int?]]] [3 3]
     [:alt int?] [1 1]
     [:alt int? [:cat]] [0 1]
-    [:alt-named [:n int?]] [1 1]
-    [:alt-named [:n int?] [:empty [:cat]]] [0 1]
+    [:altn [:n int?]] [1 1]
+    [:altn [:n int?] [:empty [:cat]]] [0 1]
     [:* int?] [0 nil]
     [:? int?] [0 1]
     [:+ [:cat string? int?]] [2 nil]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -138,7 +138,7 @@
 (defspec cat*-test 100
   (for-all [[s coll] (->> (gen/vector (gen/tuple gen/keyword seqex-child))
                           (gen/such-that (fn [coll] (or (empty? coll) (apply distinct? (map first coll)))))
-                          (schema+coll-gen :cat*))]
+                          (schema+coll-gen :cat-named))]
     (m/validate s coll)))
 
 (defspec alt-test 100
@@ -148,7 +148,7 @@
 (defspec alt*-test 100
   (for-all [[s coll] (->> (gen/not-empty (gen/vector (gen/tuple gen/keyword seqex-child)))
                           (gen/such-that (fn [coll] (or (empty? coll) (apply distinct? (map first coll)))))
-                          (schema+coll-gen :alt*))]
+                          (schema+coll-gen :alt-named))]
     (m/validate s coll)))
 
 (defspec ?*+-test 100

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -138,7 +138,7 @@
 (defspec cat*-test 100
   (for-all [[s coll] (->> (gen/vector (gen/tuple gen/keyword seqex-child))
                           (gen/such-that (fn [coll] (or (empty? coll) (apply distinct? (map first coll)))))
-                          (schema+coll-gen :cat-named))]
+                          (schema+coll-gen :catn))]
     (m/validate s coll)))
 
 (defspec alt-test 100
@@ -148,7 +148,7 @@
 (defspec alt*-test 100
   (for-all [[s coll] (->> (gen/not-empty (gen/vector (gen/tuple gen/keyword seqex-child)))
                           (gen/such-that (fn [coll] (or (empty? coll) (apply distinct? (map first coll)))))
-                          (schema+coll-gen :alt-named))]
+                          (schema+coll-gen :altn))]
     (m/validate s coll)))
 
 (defspec ?*+-test 100

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -269,22 +269,22 @@
         [:cat int? keyword?] ["1" "kikka"] [1 :kikka]
         [:cat int? keyword?] ["kikka" "kukka"] ["kikka" "kukka"]
 
-        [:cat-named] [] []
-        [:cat-named] "1" "1"
-        [:cat-named] nil nil
-        [:cat-named [:n int?]] ["1"] [1]
-        [:cat-named [:n int?] [:k keyword?]] ["1" "kikka"] [1 :kikka]
-        [:cat-named [:n int?] [:k keyword?]] ["kikka" "kukka"] ["kikka" "kukka"]
+        [:catn] [] []
+        [:catn] "1" "1"
+        [:catn] nil nil
+        [:catn [:n int?]] ["1"] [1]
+        [:catn [:n int?] [:k keyword?]] ["1" "kikka"] [1 :kikka]
+        [:catn [:n int?] [:k keyword?]] ["kikka" "kukka"] ["kikka" "kukka"]
 
         [:alt int?] ["1"] [1]
         [:alt int? keyword?] ["1"] [1]
         [:alt keyword? int?] ["1"] [:1]
         [:alt int? keyword?] ["kikka"] [:kikka]
 
-        [:alt-named [:n int?]] ["1"] [1]
-        [:alt-named [:n int?] [:k keyword?]] ["1"] [1]
-        [:alt-named [:k keyword?] [:n int?]] ["1"] [:1]
-        [:alt-named [:n int?] [:k keyword?]] ["kikka"] [:kikka]
+        [:altn [:n int?]] ["1"] [1]
+        [:altn [:n int?] [:k keyword?]] ["1"] [1]
+        [:altn [:k keyword?] [:n int?]] ["1"] [:1]
+        [:altn [:n int?] [:k keyword?]] ["kikka"] [:kikka]
 
         [:? int?] [] []
         [:? int?] "1" "1"

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -269,22 +269,22 @@
         [:cat int? keyword?] ["1" "kikka"] [1 :kikka]
         [:cat int? keyword?] ["kikka" "kukka"] ["kikka" "kukka"]
 
-        [:cat*] [] []
-        [:cat*] "1" "1"
-        [:cat*] nil nil
-        [:cat* [:n int?]] ["1"] [1]
-        [:cat* [:n int?] [:k keyword?]] ["1" "kikka"] [1 :kikka]
-        [:cat* [:n int?] [:k keyword?]] ["kikka" "kukka"] ["kikka" "kukka"]
+        [:cat-named] [] []
+        [:cat-named] "1" "1"
+        [:cat-named] nil nil
+        [:cat-named [:n int?]] ["1"] [1]
+        [:cat-named [:n int?] [:k keyword?]] ["1" "kikka"] [1 :kikka]
+        [:cat-named [:n int?] [:k keyword?]] ["kikka" "kukka"] ["kikka" "kukka"]
 
         [:alt int?] ["1"] [1]
         [:alt int? keyword?] ["1"] [1]
         [:alt keyword? int?] ["1"] [:1]
         [:alt int? keyword?] ["kikka"] [:kikka]
 
-        [:alt* [:n int?]] ["1"] [1]
-        [:alt* [:n int?] [:k keyword?]] ["1"] [1]
-        [:alt* [:k keyword?] [:n int?]] ["1"] [:1]
-        [:alt* [:n int?] [:k keyword?]] ["kikka"] [:kikka]
+        [:alt-named [:n int?]] ["1"] [1]
+        [:alt-named [:n int?] [:k keyword?]] ["1"] [1]
+        [:alt-named [:k keyword?] [:n int?]] ["1"] [:1]
+        [:alt-named [:n int?] [:k keyword?]] ["kikka"] [:kikka]
 
         [:? int?] [] []
         [:? int?] "1" "1"


### PR DESCRIPTION
* `:cat*`, `:alt*`, `:or*` => `:cat-named`, `:alt-named`, `:or-named`