### PR TITLE
Fix mu/update for when key doesn't exist in schema

### DIFF
--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -285,7 +285,7 @@
 (defn update
   "Like [[clojure.core/update]], but for LensSchema instances."
   [schema key f & args]
-  (m/-set (m/schema schema) key (apply f (get schema key (m/schema :map (m/options schema))) args)))
+  (m/-set (m/schema schema) key (apply f (get schema key) args)))
 
 (defn get-in
   "Like [[clojure.core/get-in]], but for LensSchemas."

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -405,7 +405,13 @@
                    [:map {:title "map"}
                     [:a int?]
                     [:b string?]
-                    [:c string?]]))))
+                    [:c string?]]))
+    (is (mu/equals (mu/update schema :d #(or % boolean?))
+                   [:map {:title "map"}
+                    [:a int?]
+                    [:b {:optional true} int?]
+                    [:c string?]
+                    [:d boolean?]]))))
 
 (deftest assoc-in-test
   (is (mu/equals (mu/assoc-in (m/schema [:vector int?]) [0] string?) [:vector string?]))


### PR DESCRIPTION
Passing an empty map schema by default doesn't really make sense here. Probably a copy & paste leftover from `update-in`? :-)