### PR TITLE
delayed gen

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -74,10 +74,10 @@
                   (gen/vector gen/any 0 0)))))
 
 (defn -or-gen [schema options]
-  (-delay (gen/one-of (keep #(some->> (-maybe-recur % options) (generator %)) (m/children schema options)))))
+  (gen/one-of (keep #(some->> (-maybe-recur % options) (generator %)) (m/children schema options))))
 
 (defn -multi-gen [schema options]
-  (-delay (gen/one-of (keep #(some->> (-maybe-recur (last %) options) (generator (last %))) (m/entries schema options)))))
+  (gen/one-of (keep #(some->> (-maybe-recur (last %) options) (generator (last %))) (m/entries schema options))))
 
 (defn -map-gen [schema options]
   (let [entries (m/entries schema)
@@ -150,11 +150,10 @@
        (gen/fmap #(apply concat %))))
 
 (defn -alt-gen [schema options]
-  (-delay
-    (gen/one-of (keep (fn [e]
-                        (let [child (entry->schema e)]
-                          (some->> (-maybe-recur child options) (-regex-generator child))))
-                      (m/children schema options)))))
+  (gen/one-of (keep (fn [e]
+                      (let [child (entry->schema e)]
+                        (some->> (-maybe-recur child options) (-regex-generator child))))
+                    (m/children schema options))))
 
 (defn -?-gen [schema options]
   (let [child (m/-get schema 0 nil)]
@@ -224,7 +223,7 @@
 
 (defmethod -schema-generator :=> [schema options] (-=>-gen schema options))
 (defmethod -schema-generator :function [schema options] (-function-gen schema options))
-(defmethod -schema-generator :ref [schema options] (generator (m/deref schema) options))
+(defmethod -schema-generator :ref [schema options] (-delay (generator (m/deref schema) options)))
 (defmethod -schema-generator :schema [schema options] (generator (m/deref schema) options))
 (defmethod -schema-generator ::m/schema [schema options] (generator (m/deref schema) options))
 

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -243,10 +243,6 @@
                              ::A] {:size 1, :seed 1})]
     (is (-> sample flatten count (> 1)))))
 
-(deftest -delay-test
-  (is (= 12 (mg/generate (gen/return 12))))
-  (is (= 12 (mg/generate (mg/-delay (gen/return 12))))))
-
 (deftest slow-recursive-test
   (let [schema [:schema {:registry {::A [:tuple [:= :A]]
                                     ::B [:tuple [:= :B]]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -242,3 +242,27 @@
                                                   [:vector {:gen/min 2, :gen/max 2} [:ref ::A]]]}}
                              ::A] {:size 1, :seed 1})]
     (is (-> sample flatten count (> 1)))))
+
+(deftest -delay-test
+  (is (= 12 (mg/generate (gen/return 12))))
+  (is (= 12 (mg/generate (mg/-delay (gen/return 12))))))
+
+(deftest slow-recursive-test
+  (let [schema [:schema {:registry {::A [:tuple [:= :A]]
+                                    ::B [:tuple [:= :B]]
+                                    ::C [:tuple [:= :C]]
+                                    ::D [:tuple [:= :D]]
+                                    ::E [:tuple [:= :E] [:ref ::item]]
+                                    ::F [:tuple [:= :F] [:ref ::item]]
+                                    ::G [:tuple [:= :G] [:ref ::item]]
+                                    ::item [:multi {:dispatch first}
+                                            [:A ::A]
+                                            [:B ::B]
+                                            [:C ::C]
+                                            [:D ::D]
+                                            [:E ::E]
+                                            [:F ::F]
+                                            [:G ::G]]}}
+                ::E]
+        valid? (m/validator schema)]
+    (is (every? valid? (mg/sample schema {:size 10000})))))


### PR DESCRIPTION
lazy gen for potentially recursive generators.

```clj
(time
  (let [schema [:schema {:registry {::A [:tuple [:= :A]]
                                    ::B [:tuple [:= :B]]
                                    ::C [:tuple [:= :C]]
                                    ::D [:tuple [:= :D]]
                                    ::E [:tuple [:= :E] [:ref ::item]]
                                    ::F [:tuple [:= :F] [:ref ::item]]
                                    ::G [:tuple [:= :G] [:ref ::item]]
                                    ::item [:multi {:dispatch first}
                                            [:A ::A]
                                            [:B ::B]
                                            [:C ::C]
                                            [:D ::D]
                                            [:E ::E]
                                            [:F ::F]
                                            [:G ::G]]}}
                ::E]
        valid? (m/validator schema)]
    (is (every? valid? (mg/sample schema {:size 10000})))))
; => "Elapsed time: 230 msecs"
```

Fixes #408 