### PR TITLE
IntoSchema knows type and schemas for properties and children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Malli is in [alpha](README.md#alpha).
 
 * **BREAKING**: `-type` is moved from `Schema` to `IntoSchema`.
 * **BREAKING**: `-type-properties` is moved from `Schema` to `IntoSchema`.
+* new Protocol methods in `IntoSchema` Protocol
+  * `(-properties-schema [this] "maybe returns :map schema describing schema properties")`
+  * `(-children-schema [this] "maybe returns sequence schema describing schema children")`
 
 ## 0.4.0 (2021-03-31)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in [alpha](README.md#alpha).
 
+## UNRELEASED
+
+### Extender API
+
+* **BREAKING**: `-type` is moved from `Schema` to `IntoSchema`.
+
 ## 0.4.0 (2021-03-31)
 
 * `:nil` schema, [#401](https://github.com/metosin/malli/pull/401)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Malli is in [alpha](README.md#alpha).
 ### Extender API
 
 * **BREAKING**: `-type` is moved from `Schema` to `IntoSchema`.
+* **BREAKING**: `-type-properties` is moved from `Schema` to `IntoSchema`.
 
 ## 0.4.0 (2021-03-31)
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -105,8 +105,8 @@
   (-value-transformer [this schema method options] "returns an value transforming interceptor for the given schema and method"))
 
 #?(:clj (defmethod print-method SchemaError [v ^java.io.Writer w] (.write w (str "#Error" (->> v (filter val) (into {}))))))
-#?(:clj (defmethod print-method ::into-schema [v ^java.io.Writer w] (.write w (str "#IntoSchema{:class " v "}"))))
-#?(:clj (defmethod print-method ::schema [v ^java.io.Writer w] (.write w (pr-str (-form v)))))
+#?(:clj (defmethod print-method ::into-schema [v ^java.io.Writer w] (.write w (str "#IntoSchema{:type " (pr-str (-type ^IntoSchema v)) "}"))))
+#?(:clj (defmethod print-method ::schema [v ^java.io.Writer w] (.write w (pr-str (-form ^Schema v)))))
 
 ;;
 ;; impl

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -24,6 +24,8 @@
 (defprotocol IntoSchema
   (-type [this] "returns type of the schema")
   (-type-properties [this] "returns schema type properties")
+  (-properties-schema [this] "maybe returns :map schema describing schema properties")
+  (-children-schema [this] "maybe returns sequence schema describing schema children")
   (-into-schema [this properties children options] "creates a new schema instance"))
 
 (defprotocol Schema
@@ -316,6 +318,8 @@
     (reify IntoSchema
       (-type [_] (:type @props*))
       (-type-properties [_] (:type-properties @props*))
+      (-properties-schema [_])
+      (-children-schema [_])
       (-into-schema [parent properties children options]
         (if (fn? ?props)
           (-into-schema (-simple-schema (?props properties children)) properties children options)
@@ -366,6 +370,8 @@
   (reify IntoSchema
     (-type [_] :and)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! :and properties children {:min 1})
       (let [children (mapv #(schema % options) children)
@@ -403,6 +409,8 @@
   (reify IntoSchema
     (-type [_] :or)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! :or properties children {:min 1})
       (let [children (mapv #(schema % options) children)
@@ -461,6 +469,8 @@
   (reify IntoSchema
     (-type [_] :orn)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! :orn properties children {:min 1})
       (let [{:keys [children entries forms]} (-parse-entries children {:naked-keys true} options)
@@ -531,6 +541,8 @@
   (reify IntoSchema
     (-type [_] :not)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! :not properties children {:min 1 :max 1})
       (let [[schema :as children] (map #(schema % options) children)
@@ -568,6 +580,8 @@
    (reify IntoSchema
      (-type [_] ::val)
      (-type-properties [_])
+     (-properties-schema [_])
+     (-children-schema [_])
      (-into-schema [parent properties children options]
        (-check-children! ::val properties children {:min 1, :max 1})
        (let [[schema :as children] (map #(schema % options) children)
@@ -713,6 +727,8 @@
   (reify IntoSchema
     (-type [_] :map-of)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! :map-of properties children {:min 2 :max 2})
       (let [[key-schema value-schema :as children] (mapv #(schema % options) children)
@@ -858,6 +874,8 @@
   (reify IntoSchema
     (-type [_] :tuple)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (let [children (mapv #(schema % options) children)
             size (count children)
@@ -960,6 +978,8 @@
   (reify IntoSchema
     (-type [_] :re)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties [child :as children] options]
       (-check-children! :re properties children {:min 1, :max 1})
       (let [children (vec children)
@@ -1043,6 +1063,8 @@
   (reify IntoSchema
     (-type [_] :maybe)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! :maybe properties children {:min 1, :max 1})
       (let [[schema :as children] (map #(schema % options) children)
@@ -1086,6 +1108,8 @@
    (reify IntoSchema
      (-type [_] :multi)
      (-type-properties [_] (:type-properties opts))
+     (-properties-schema [_])
+     (-children-schema [_])
      (-into-schema [parent properties children options]
        (let [type (or (:type opts) :multi)
              opts' (merge opts (select-keys properties [:lazy-refs]))
@@ -1213,6 +1237,8 @@
     (reify IntoSchema
       (-type [_] type)
       (-type-properties [_])
+      (-properties-schema [_])
+      (-children-schema [_])
       (-into-schema [parent properties children options]
         (-check-children! type properties children {:min 1, :max 1})
         (let [[child :as children] (map #(schema % options) children)
@@ -1323,6 +1349,8 @@
   (reify IntoSchema
     (-type [_] :function)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children {::keys [function-checker] :as options}]
       (-check-children! :function properties children {:min 1})
       (let [children (map #(schema % options) children)
@@ -1387,6 +1415,8 @@
   (reify IntoSchema
     (-type [_] type)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! type properties children child-bounds)
       (let [children (mapv #(schema % options) children)
@@ -1430,6 +1460,8 @@
   (reify IntoSchema
     (-type [_] type)
     (-type-properties [_])
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (-check-children! type properties children child-bounds)
       (let [{:keys [children entries forms]} (-parse-entries children opts options)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -305,7 +305,7 @@
                                    explain-output (assoc ::explain-output explain-output)
                                    (ex-message result) (-> (update :result ex-message)
                                                            (dissoc :result-data)))))))))]
-     (condp = (m/-type schema)
+     (condp = (m/type schema)
        :=> (check schema)
        :function (let [checkers (map #(function-checker % options) (m/-children schema))]
                    (fn [x] (->> checkers (keep #(% x)) (seq))))

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -365,10 +365,11 @@
      (clojure.core/update children 0 #(m/form % options))
      (apply f (conj children options))]))
 
-(defn -util-schema [{:keys [type min max childs type-properties fn] :as opts}]
+(defn -util-schema [{:keys [type min max childs type-properties fn]}]
   ^{:type ::m/into-schema}
   (reify m/IntoSchema
     (-type [_] type)
+    (-type-properties [_] type-properties)
     (-into-schema [parent properties children options]
       (m/-check-children! type properties children {:min min, :max max})
       (let [[children forms schema] (fn properties (vec children) options)
@@ -377,7 +378,6 @@
         ^{:type ::m/schema}
         (reify
           m/Schema
-          (-type-properties [_] type-properties)
           (-validator [_] (m/-validator schema))
           (-explainer [_ path] (m/-explainer schema path))
           (-transformer [this transformer method options]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -370,6 +370,8 @@
   (reify m/IntoSchema
     (-type [_] type)
     (-type-properties [_] type-properties)
+    (-properties-schema [_])
+    (-children-schema [_])
     (-into-schema [parent properties children options]
       (m/-check-children! type properties children {:min min, :max max})
       (let [[children forms schema] (fn properties (vec children) options)

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -368,7 +368,8 @@
 (defn -util-schema [{:keys [type min max childs type-properties fn] :as opts}]
   ^{:type ::m/into-schema}
   (reify m/IntoSchema
-    (-into-schema [_ properties children options]
+    (-type [_] type)
+    (-into-schema [parent properties children options]
       (m/-check-children! type properties children {:min min, :max max})
       (let [[children forms schema] (fn properties (vec children) options)
             walkable-childs (if childs (subvec children 0 childs) children)
@@ -376,7 +377,6 @@
         ^{:type ::m/schema}
         (reify
           m/Schema
-          (-type [_] type)
           (-type-properties [_] type-properties)
           (-validator [_] (m/-validator schema))
           (-explainer [_ path] (m/-explainer schema path))
@@ -388,7 +388,7 @@
           (-properties [_] properties)
           (-options [_] options)
           (-children [_] children)
-          (-parent [_] (-util-schema opts))
+          (-parent [_] parent)
           (-form [_] form)
           m/LensSchema
           (-keep [_])

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -206,7 +206,7 @@
   (let [values #{1 2 3 5 8 13}
         schema (reify
                  m/Schema
-                 (-type-properties [_])
+                 (-parent [_] (reify m/IntoSchema (-type-properties [_])))
                  (-properties [_])
                  mg/Generator
                  (-generator [_ _] (gen/elements values)))]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -82,9 +82,8 @@
    [(reify
       m/Schema
       (-properties [_])
-      (-parent [_] (reify m/IntoSchema (-type [_])))
+      (-parent [_] (reify m/IntoSchema (-type [_]) (-type-properties [_])))
       (-form [_])
-      (-type-properties [_])
       (-validator [_] int?)
       (-walk [t w p o] (m/-outer w t p nil o))
       json-schema/JsonSchema

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -82,7 +82,7 @@
    [(reify
       m/Schema
       (-properties [_])
-      (-type [_])
+      (-parent [_] (reify m/IntoSchema (-type [_])))
       (-form [_])
       (-type-properties [_])
       (-validator [_] int?)

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -84,7 +84,7 @@
    [(reify
       m/Schema
       (-properties [_])
-      (-type [_])
+      (-parent [_] (reify m/IntoSchema (-type [_])))
       (-form [_])
       (-type-properties [_])
       (-validator [_] int?)

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -84,9 +84,8 @@
    [(reify
       m/Schema
       (-properties [_])
-      (-parent [_] (reify m/IntoSchema (-type [_])))
+      (-parent [_] (reify m/IntoSchema (-type [_]) (-type-properties [_])))
       (-form [_])
-      (-type-properties [_])
       (-validator [_] int?)
       (-walk [t w p o] (m/-outer w t p nil o))
       swagger/SwaggerSchema


### PR DESCRIPTION
Related to #269 & #270. Move methods from `Schema` to `IntoSchema` so that we can describe Malli schemas with Malli.

```clj
(defprotocol IntoSchema
  (-type [this] "returns type of the schema")
  (-type-properties [this] "returns schema type properties")
  (-properties-schema [this] "maybe returns :map schema describing schema properties")
  (-children-schema [this] "maybe returns sequence schema describing schema children")
  (-into-schema [this properties children options] "creates a new schema instance"))
```

the print-method now shows the `:type`:

```clj
(m/-enum-schema)
; => #IntoSchema{:type :enum}

(m/schema [*1 "A" "B"])
; => [:enum "A" "B"]

(type *1)
; => :malli.core/schema
```