### PR TITLE
Add ifn? schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in [alpha](README.md#alpha).
 
+## 0.5.0 (2021-04-13)
+
+* Add `ifn?` predicate, [#416](https://github.com/metosin/malli/pull/416)
+
 ## 0.4.0 (2021-03-31)
 
 * `:nil` schema, [#401](https://github.com/metosin/malli/pull/401)

--- a/README.md
+++ b/README.md
@@ -331,6 +331,22 @@ Using regular expressions:
 ; => false
 ```
 
+`ifn?` accepts any value that implements Clojure(Script)'s IFn:
+
+```clj
+(m/validate ifn? :keyword)
+; => true
+
+(m/validate ifn? [])
+; => true
+
+(m/validate ifn? {})
+; => true
+
+(s/validate ifn? 123)
+; => false
+```
+
 ## Serializable Functions
 
 Enabling serializable function schemas requires [sci](https://github.com/borkdude/sci) as external dependency. If

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -53,6 +53,7 @@
 (defmethod accept 'sequential? [_ _ _ _] :sequential)
 (defmethod accept 'ratio? [_ _ _ _] :int) ;;??
 (defmethod accept 'bytes? [_ _ _ _] :char-sequence) ;;??
+(defmethod accept 'ifn? [_ _ _ _] :ifn)
 
 (defmethod accept :> [_ _ _ _] :number) ;;??
 (defmethod accept :>= [_ _ _ _] :number) ;;??

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1752,7 +1752,8 @@
         #'boolean? #'string? #'ident? #'simple-ident? #'qualified-ident? #'keyword? #'simple-keyword?
         #'qualified-keyword? #'symbol? #'simple-symbol? #'qualified-symbol? #'uuid? #'uri? #?(:clj #'decimal?)
         #'inst? #'seqable? #'indexed? #'map? #'vector? #'list? #'seq? #'char? #'set? #'nil? #'false? #'true?
-        #'zero? #?(:clj #'rational?) #'coll? #'empty? #'associative? #'sequential? #?(:clj #'ratio?) #?(:clj #'bytes?)]
+        #'zero? #?(:clj #'rational?) #'coll? #'empty? #'associative? #'sequential? #?(:clj #'ratio?) #?(:clj #'bytes?)
+        #'ifn?]
        (reduce -register-var {})))
 
 (defn class-schemas []

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -72,6 +72,7 @@
    #?@(:clj ['bytes? {:error/message {:en "should be bytes"}}])
    :re {:error/message {:en "should match regex"}}
    :=> {:error/message {:en "invalid function"}}
+   'ifn? {:error/message {:en "should be an ifn"}}
    :enum {:error/fn {:en (fn [{:keys [schema]} _]
                            (str "should be "
                                 (if (= 1 (count (m/children schema)))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -223,6 +223,7 @@
 
 (defmethod -schema-generator :=> [schema options] (-=>-gen schema options))
 (defmethod -schema-generator :function [schema options] (-function-gen schema options))
+(defmethod -schema-generator 'ifn? [_ _] gen/keyword)
 (defmethod -schema-generator :ref [schema options] (-ref-gen schema options))
 (defmethod -schema-generator :schema [schema options] (generator (m/deref schema) options))
 (defmethod -schema-generator ::m/schema [schema options] (generator (m/deref schema) options))

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -29,6 +29,12 @@
              [:=> [:cat :int] [:int {:min 0}]]
              [:=> [:cat :int :int [:* :int]] :int]])
 
+(defn siren
+  [f coll]
+  (into {} (map (juxt f identity) coll)))
+
+(m/=> siren [:=> [:cat ifn? coll?] map?])
+
 (deftest clj-kondo-integration-test
 
   (is (= {:op :keys,
@@ -48,7 +54,9 @@
                             :ret :int},
                          :varargs {:args [:int :int {:op :rest, :spec :int}],
                                    :ret :int,
-                                   :min-arity 2}}}}}
+                                   :min-arity 2}}}
+              'siren
+              {:arities {2 {:args [:ifn :coll], :ret :map}}}}}
             (-> 'malli.clj-kondo-test
                 (clj-kondo/collect)
                 (clj-kondo/linter-config)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -698,6 +698,16 @@
 
         (is (= form (m/form schema))))))
 
+  (testing "ifn schemas"
+    (let [schema (m/schema ifn?)]
+      (is (true? (m/validate schema (fn []))))
+      (is (true? (m/validate schema (constantly 1))))
+      (is (true? (m/validate schema :keyword)))
+      (is (true? (m/validate schema #?(:clj (reify clojure.lang.IFn
+                                              (invoke [_] "Invoked!"))
+                                       :cljs (reify IFn
+                                              (-invoke [_] "Invoked!"))))))))
+
   (testing "fn schemas"
     (doseq [fn ['(fn [x] (and (int? x) (< 10 x 18)))
                 "(fn [x] (and (int? x) (< 10 x 18)))"]]

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -423,6 +423,10 @@
              (m/explain 123)
              (me/humanize)))))
 
+(deftest ifn-test
+  (is (= ["should be an ifn"]
+         (me/humanize (m/explain ifn? 123)))))
+
 (deftest multi-error-test
   (let [schema [:multi {:dispatch :type}
                 ["plus" [:map [:value int?]]]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -73,6 +73,7 @@
 
    [[:=> :cat int?] {} :fn]
    [[:function [:=> :cat int?]] {} :fn]
+   [ifn? {}]
 
    [integer? {:type "integer"}]
    #?@(:clj [[ratio? {:type "number"}]

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -710,6 +710,7 @@
                       [[:enum P1 "S" "M" "L"] "s" "S"]
                       [[:re P1 ".*"] "kikka" "KIKKA"]
                       [[:fn P1 'string?] "kikka" "KIKKA"]
+                      [[ifn? P1] "kikka" "KIKKA"]
                       [[:maybe P1 keyword?] "kikka" :KIKKA]
                       [[:vector PS keyword?] ["kikka"] [:KIKKA]]
                       [[:sequential PS keyword?] ["kikka"] [:KIKKA]]


### PR DESCRIPTION
As per a thread over on the [Clojurians' Slack group](https://clojurians.slack.com/archives/CLDK6MFMK/p1618309722405800), I've teed up a first draft at adding support for `ifn?` in Malli schemas.

``` clj
(m/validate ifn? :kw)
(m/validate ifn? (fn [] :ok!))
```

This is my first time contributing so apologies for any faux pas. I think I've covered all of the bases with transformers, generators, JSON schema, humanized errors, and clj-kondo, but would really appreciate some testing and pointers from the more familiar Malli contributors.

Thank you for sharing this awesome library, and all of the Metosin suite. It's truly awesome stuff!