### PR TITLE
fix non-accumulating errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Malli is in [alpha](README.md#alpha).
 ### Public API
 
 * Add `ifn?` predicate, [#416](https://github.com/metosin/malli/pull/416)
+* Accumulate errors correctly with `m/-explain` with `:function` and `:=>` Schemas
 
 ### Extender API
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1322,7 +1322,8 @@
                 (if (not (fn? x))
                   (conj acc (miu/-error path in this x))
                   (if-let [res (checker x)]
-                    (conj acc (assoc (miu/-error path in this x) :check res)))))
+                    (conj acc (assoc (miu/-error path in this x) :check res))
+                    acc)))
               (let [validator (-validator this)]
                 (fn explain [x in acc]
                   (if-not (validator x) (conj acc (miu/-error path in this x)) acc)))))
@@ -1376,7 +1377,8 @@
                 (if (not (fn? x))
                   (conj acc (miu/-error path in this x))
                   (if-let [res (checker x)]
-                    (conj acc (assoc (miu/-error path in this x) :check res)))))
+                    (conj acc (assoc (miu/-error path in this x) :check res))
+                    acc)))
               (let [validator (-validator this)]
                 (fn explain [x in acc]
                   (if-not (validator x) (conj acc (miu/-error path in this x)) acc)))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -703,10 +703,10 @@
       (is (true? (m/validate schema (fn []))))
       (is (true? (m/validate schema (constantly 1))))
       (is (true? (m/validate schema :keyword)))
-      (is (true? (m/validate schema #?(:clj (reify clojure.lang.IFn
-                                              (invoke [_] "Invoked!"))
+      (is (true? (m/validate schema #?(:clj  (reify clojure.lang.IFn
+                                               (invoke [_] "Invoked!"))
                                        :cljs (reify IFn
-                                              (-invoke [_] "Invoked!"))))))))
+                                               (-invoke [_] "Invoked!"))))))))
 
   (testing "fn schemas"
     (doseq [fn ['(fn [x] (and (int? x) (< 10 x 18)))
@@ -2183,6 +2183,16 @@
                                  :schema schema2
                                  :value invalid-f}]}
                       (m/explain schema2 invalid-f))))
+
+      (testing "non-accumulating errors"
+        (let [schema (m/schema
+                       [:tuple :int [:function [:=> [:cat :int] :int]]]
+                       {::m/function-checker malli.generator/function-checker})
+              f (fn [_] 1)]
+          (is (results= {:schema schema,
+                         :value ["1" f],
+                         :errors [{:path [0], :in [0], :schema :int, :value "1"}]}
+                        (m/explain schema ["1" f])))))
 
       (is (= valid-f (m/decode schema1 valid-f mt/string-transformer)))
 


### PR DESCRIPTION
```clj
(testing "non-accumulating errors"
  (let [schema (m/schema
                 [:tuple :int [:function [:=> [:cat :int] :int]]]
                 {::m/function-checker malli.generator/function-checker})
        f (fn [_] 1)]
    (is (results= {:schema schema,
                   :value ["1" f],
                   :errors [{:path [0], :in [0], :schema :int, :value "1"}]}
                  (m/explain schema ["1" f])))))
```