### PR TITLE
Fix #427

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -50,7 +50,7 @@
   (let [{:keys [min max]} (-min-max schema options)
         [continue options] (-recur schema options)
         child (-> schema m/children first)
-        gen (if continue (generator child options))]
+        gen (when continue (generator child options))]
     (gen/fmap f (cond
                   (not gen) (gen/vector gen/any 0 0)
                   (and min (= min max)) (gen/vector gen min)
@@ -63,8 +63,7 @@
   (let [{:keys [min max]} (-min-max schema options)
         [continue options] (-recur schema options)
         child (-> schema m/children first)
-        gen (if-not (and (= :ref (m/type child)) continue (<= (or min 0) 0))
-              (generator child options))]
+        gen (when continue (generator child options))]
     (gen/fmap f (if gen
                   (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100})
                   (gen/vector gen/any 0 0)))))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -59,7 +59,7 @@
                   max (gen/vector gen 0 max)
                   :else (gen/vector gen)))))
 
-(defn- -coll-distict-gen [schema f options]
+(defn- -coll-distinct-gen [schema f options]
   (let [{:keys [min max]} (-min-max schema options)
         [continue options] (-recur schema options)
         child (-> schema m/children first)
@@ -199,7 +199,7 @@
 (defmethod -schema-generator :multi [schema options] (-multi-gen schema options))
 (defmethod -schema-generator :vector [schema options] (-coll-gen schema identity options))
 (defmethod -schema-generator :sequential [schema options] (-coll-gen schema identity options))
-(defmethod -schema-generator :set [schema options] (-coll-distict-gen schema set options))
+(defmethod -schema-generator :set [schema options] (-coll-distinct-gen schema set options))
 (defmethod -schema-generator :enum [schema options] (gen/elements (m/children schema options)))
 
 (defmethod -schema-generator :maybe [schema options]

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -168,7 +168,7 @@
      @state)))
 
 (defn distinct-by
-  "Returns a sequence of distict (f x) values)"
+  "Returns a sequence of distinct (f x) values)"
   [f coll]
   (let [seen (atom #{})]
     (filter (fn [x] (let [v (f x)] (if-not (@seen v) (swap! seen conj v)))) coll)))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -267,3 +267,10 @@
                 ::E]
         valid? (m/validator schema)]
     (is (every? valid? (mg/sample schema {:size 10000})))))
+
+(deftest recursive-distinct-col-test
+  (is (not (every? empty?
+                   (mg/sample [:set
+                               {:registry {::foo :int}}
+                               [:ref ::foo]]
+                              {:size 1000})))))


### PR DESCRIPTION
Attention, second commit introduces a small breaking change (fix typo in function name) and can be discarded if it is intolerable. Important commit is the first one which fixes #427.