### PR TITLE
Do not ignore double properties at generation

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -215,12 +215,8 @@
 (defmethod -schema-generator :double [schema options]
   (gen/double* (merge (let [props (m/properties schema
                                                 options)]
-                        {:infinite? (or (:gen/infinite? props)
-                                        (:infinite? props)
-                                        false)
-                         :NaN?      (or (:gen/NaN? props)
-                                        (:NaN? props)
-                                        false)})
+                        {:infinite? (get props :gen/infinite? false)
+                         :NaN?      (get props :gen/NaN? false)})
                       (-min-max schema options))))
 (defmethod -schema-generator :boolean [_ _] gen/boolean)
 (defmethod -schema-generator :keyword [_ _] gen/keyword)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -32,8 +32,6 @@
       (miu/-fail! ::invalid-property {:key :gen/min, :value gen-min, :min min}))
     (when (and max gen-max (> gen-max max))
       (miu/-fail! ::invalid-property {:key :gen/max, :value gen-min, :max min}))
-           :min (or gen-min min)
-           :max (or gen-max max)
     {:min (or gen-min min)
      :max (or gen-max max)}))
 
@@ -214,9 +212,16 @@
 (defmethod -schema-generator :nil [_ _] (gen/return nil))
 (defmethod -schema-generator :string [schema options] (-string-gen schema options))
 (defmethod -schema-generator :int [schema options] (gen/large-integer* (-min-max schema options)))
-(defmethod -schema-generator :double [schema options] (gen/double* (merge {:infinite? false, :NaN? false}
-                                                                          (m/properties schema options)
-                                                                          (-min-max schema options))))
+(defmethod -schema-generator :double [schema options]
+  (gen/double* (merge (let [props (m/properties schema
+                                                options)]
+                        {:infinite? (or (:gen/infinite? props)
+                                        (:infinite? props)
+                                        false)
+                         :NaN?      (or (:gen/NaN? props)
+                                        (:NaN? props)
+                                        false)})
+                      (-min-max schema options))))
 (defmethod -schema-generator :boolean [_ _] gen/boolean)
 (defmethod -schema-generator :keyword [_ _] gen/keyword)
 (defmethod -schema-generator :symbol [_ _] gen/symbol)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -32,6 +32,8 @@
       (miu/-fail! ::invalid-property {:key :gen/min, :value gen-min, :min min}))
     (when (and max gen-max (> gen-max max))
       (miu/-fail! ::invalid-property {:key :gen/max, :value gen-min, :max min}))
+           :min (or gen-min min)
+           :max (or gen-max max)
     {:min (or gen-min min)
      :max (or gen-max max)}))
 
@@ -212,7 +214,9 @@
 (defmethod -schema-generator :nil [_ _] (gen/return nil))
 (defmethod -schema-generator :string [schema options] (-string-gen schema options))
 (defmethod -schema-generator :int [schema options] (gen/large-integer* (-min-max schema options)))
-(defmethod -schema-generator :double [schema options] (gen/double* (merge (-min-max schema options) {:infinite? false, :NaN? false})))
+(defmethod -schema-generator :double [schema options] (gen/double* (merge {:infinite? false, :NaN? false}
+                                                                          (m/properties schema options)
+                                                                          (-min-max schema options))))
 (defmethod -schema-generator :boolean [_ _] gen/boolean)
 (defmethod -schema-generator :keyword [_ _] gen/keyword)
 (defmethod -schema-generator :symbol [_ _] gen/symbol)

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -57,15 +57,11 @@
                                            {:size 1000})))]
       (is (test-presence infinity?
                          {:gen/infinite? true}))
-      (is (test-presence infinity?
-                         {:infinite? true}))
       (is (test-presence NaN?
                          {:gen/NaN? true}))
-      (is (test-presence NaN?
-                         {:NaN? true}))
       (is (test-presence special?
-                         {:infinite? true
-                          :NaN?      true}))
+                         {:gen/infinite? true
+                          :gen/NaN?      true}))
       (is (not (test-presence special?
                               nil)))))
 

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -40,6 +40,17 @@
                     :qualified-symbol]]
       (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
 
+  (testing "double properties"
+    (is (pos? (count (filter (fn [x]
+                               (or (#?(:clj Double/isNaN
+                                       :cljs js/isNaN)
+                                    x)
+                                   (#{##Inf ##-Inf} x)))
+                             (mg/sample [:double
+                                         {:infinite? true
+                                          :NaN?      true}]
+                                        {:size 1000}))))))
+
   (testing "map entries"
     (is (= {:korppu "koira"
             :piilomaan "pikku aasi"


### PR DESCRIPTION
Previous to this commit, properties of `:double` such as `:NaN?` were
discarded for generation meaning the user could not apply such
parameters.