### PR TITLE
more customization on -collection-schema

### DIFF
--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2223,3 +2223,16 @@
 
       (is (= {:FOO-BAR "bar"} (m/encode schema {:foo-bar "bar"} transformer)))
       (is (= {:FOO-BAR "baz"} (m/encode schema {:foo-bar "baz"} transformer))))))
+
+(deftest custom-collection-test
+  (let [List (m/-collection-schema
+               (fn [properties [child]]
+                 {:type :list
+                  :pred list?
+                  :empty '()
+                  :type-properties {:error/message "should be a list"
+                                    :gen/schema [:vector properties child]
+                                    :gen/fmap #(or (list* %) '())}}))]
+
+    (is (m/validate [List :int] '(1 2)))
+    (is (not (m/validate [List :int] [1 2])))))


### PR DESCRIPTION
* allow setting :type-properties and content-dependent creation callback for `m/-collection-schema`

```clj
(def List
  (m/-collection-schema
    (fn [properties [child]]
      {:type 'List
       :pred list?
       :empty '()
       :type-properties {:error/message "should be a list"
                         :gen/schema [:vector properties child]
                         :gen/fmap #(or (list* %) '())}})))

(m/validate [List :int] '(1 2))
; => true

(-> (m/explain [List :boolean] [1 2 3])
    (me/humanize))
; => ["should be a list"]

(mg/sample [List {:gen/min 4, :gen/max 10} :int])
;((-1 0 -1 -1 -1 -1 -1 0)
; (-1 -1 -1 0 -1)
; (0 0 1 -2 -1)
; (-1 0 -1 1 -1 0 -4 -1)
; (-2 0 0 -2 1 0)
; (-2 7 2 3 2 -1)
; (-7 -3 -1 7 -1)
; (0 -12 0 8)
; (-5 25 0 -2 -5 1 -1 -25 -10 1)
; (53 221 0 15 1 -42))

(m/form [List :int])
; => [List :int]

(mu/assoc [List :int] 0 :boolean)
; => [List :boolean]
```