### PR TITLE
Fix m/=> macro failing to detect the namespace in cljs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ classes
 /demosci
 /target
 .clj-kondo
+.DS_Store
+.lsp/*

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,3 @@ classes
 /demosci
 /target
 .clj-kondo
-.DS_Store
-.lsp/*

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,5 +1,6 @@
 (ns malli.core
   (:refer-clojure :exclude [eval type -deref deref -lookup -key])
+  #?(:cljs (:require-macros malli.core))
   (:require [malli.sci :as ms]
             [malli.impl.util :as miu]
             [malli.impl.regex :as re]
@@ -1965,7 +1966,8 @@
           :ns ns
           :name name}))
 
-(defmacro => [name value]
-  (let [name' `'~(symbol (str name))]
-    `(let [ns# (symbol (str *ns*))]
-       (-register-function-schema! ns# ~name' ~value))))
+#?(:clj
+   (defmacro => [name value]
+     (let [name' `'~(symbol (str name))
+           ns'   `'~(symbol (str *ns*))]
+       `(-register-function-schema! ~ns' ~name' ~value))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2236,3 +2236,12 @@
 
     (is (m/validate [List :int] '(1 2)))
     (is (not (m/validate [List :int] [1 2])))))
+
+(deftest function-schema-registry-test
+  (let [prior-function-schemas (m/function-schemas)
+        new-function-schemas   (m/=> function-schema-registry-test-fn [:=> :cat :nil])
+        this-ns-schemas        (get new-function-schemas 'malli.core-test)
+        fn-schema              (get this-ns-schemas 'function-schema-registry-test-fn)]
+    (is (= (inc (count prior-function-schemas)) (count new-function-schemas)))
+    (is (map? this-ns-schemas))
+    (is (map? fn-schema))))


### PR DESCRIPTION
In ClojureScript, the `m/=>` macro would incorrectly register a function schema at a blank namespace symbol (as `*ns*` returns nil in non-bootstrapped cljs).

`(malli.core/function-schemas)` results in something like:
```clojure
;; The key is the invisible result of (symbol "")
{ {add-five
   {:schema #object[malli.core.t_malli$core59734]
    :meta   nil
    :ns     test-ns.core
    :name   add-five}}}
```
instead of
```clojure
{test-ns.core
 {add-five
  {:schema #object[malli.core.t_malli$core59734]
   :meta   nil
   :ns     test-ns.core
   :name   add-five}}}
```