### PR TITLE
Correct example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2220,7 +2220,7 @@ Validation:
 (let [spec (s/and int? (s/or :pos-int pos-int? :neg-int neg-int?))
       valid? (partial s/valid? spec)]
   (cc/quick-bench
-    (valid? spec 0)))
+    (valid? 0)))
 
 ;; 5ns
 (let [valid? (m/validator [:and int? [:or pos-int? neg-int?]])]


### PR DESCRIPTION
The partial function is now used correctly in the example. The example will fail as the `s/valid?` only expects 2 arguments.

Another option is to remove the partial application of `s/valid?`
```clojure
valid? (partial s/valid? spec)
```

I don't know if this change has any effect on the mentioned benchmarks. I'm guessing the partial application is not faster.