### PR TITLE
Faster map schema validator

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -651,7 +651,8 @@
                                         (fn [[key {:keys [optional]} value]]
                                           (let [valid? (-validator value)
                                                 default (boolean optional)]
-                                            (fn [m] (if-let [map-entry (find m key)] (valid? (val map-entry)) default))))
+                                            #?(:clj (fn [^clojure.lang.Associative m] (if-let [map-entry (.entryAt m key)] (valid? (val map-entry)) default))
+                                               :cljs (fn [m] (if-let [map-entry (find m key)] (valid? (val map-entry)) default)))))
                                         children)
                                       closed (into [(fn [m]
                                                       (reduce


### PR DESCRIPTION
Replace find with .entryAt in clj map validator

Since the map validator always checks for `map?` first, we have a guarantee the object is `IPersistentMap` which is an `Associative`, thus has an `.entryAt` method.
Calling it instead of using `find` is significantly faster.

The accompanying gist specifies the methods used to test the change and the results
https://gist.github.com/bsless/c50ee40f9734d6fe59e6dc36930d78c0

Closes #455