### PR TITLE
Humanized errors can be looked from parent schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Malli is in [alpha](README.md#alpha).
 (-> [:map
      [:foo {:error/message "entry-failure"} :int]]
     (m/explain {:foo "1"})
-    (me/humanize {:resolve me/resolve-root-error-message-and-path}))
+    (me/humanize {:resolve me/resolve-root-error}))
 ; => {:foo ["entry-failure"]}
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* humanized errors for `:boolean`
+* **BREAKING**: humanized message duplicates are removed, e.g. `{:foo ["fail" "fail"]}` => `{:foo ["fail"]}`  
+* humanized errors can be read from parent schemas (also from map entries), fixes [#86](https://github.com/metosin/malli/issues/86):
+
+```clj
+(-> [:map
+     [:foo {:error/message "entry-failure"} :int]]
+    (m/explain {:foo "1"})
+    (me/humanize {:resolve me/resolve-root-error-message-and-path}))
+; => {:foo ["entry-failure"]}
+```
+
 ## 0.5.1 (2021-05-02)
 
 ### Public API

--- a/README.md
+++ b/README.md
@@ -535,11 +535,11 @@ Errors can be targeted using `:error/path` property:
 ; {:password2 ["passwords don't match"]}
 ```
 
-By default, only erronous schema properties are used:
+By default, only direct erronous schema properties are used:
 
 ```clj
 (-> [:map
-     [:foo {:error/message "entry-failure"} :int]]
+     [:foo {:error/message "entry-failure"} :int]] ;; here, :int fails, no error props
     (m/explain {:foo "1"})
     (me/humanize))
 ; => {:foo ["should be an integer"]}

--- a/README.md
+++ b/README.md
@@ -535,6 +535,26 @@ Errors can be targeted using `:error/path` property:
 ; {:password2 ["passwords don't match"]}
 ```
 
+By default, only erronous schema properties are used:
+
+```clj
+(-> [:map
+     [:foo {:error/message "entry-failure"} :int]]
+    (m/explain {:foo "1"})
+    (me/humanize))
+; => {:foo ["should be an integer"]}
+```
+
+Looking up humanized errors from parent schemas with custom `:resolve`:
+
+```clj
+(-> [:map
+     [:foo {:error/message "entry-failure"} :int]]
+    (m/explain {:foo "1"})
+    (me/humanize {:resolve me/resolve-root-error-message-and-path}))
+; => {:foo ["entry-failure"]}
+```
+
 ## Spell Checking
 
 For closed schemas, key spelling can be checked with:

--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ Looking up humanized errors from parent schemas with custom `:resolve`:
 (-> [:map
      [:foo {:error/message "entry-failure"} :int]]
     (m/explain {:foo "1"})
-    (me/humanize {:resolve me/resolve-root-error-message-and-path}))
+    (me/humanize {:resolve me/resolve-root-error}))
 ; => {:foo ["entry-failure"]}
 ```
 

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -208,7 +208,7 @@
   ([{:keys [schema type] :as error}
     {:keys [errors unknown locale default-locale]
      :or {errors default-errors
-          unknown-error true
+          unknown true
           default-locale :en} :as options}]
    (or (-message error (m/properties schema) locale options)
        (-message error (m/type-properties schema) locale options)

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -114,10 +114,10 @@
 (defn- -maybe-localized [x locale]
   (if (map? x) (get x locale) x))
 
-(defn- -message [error x locale options]
+(defn- -message [error props locale options]
   (let [options (or options (m/options (:schema error)))]
-    (if x (or (if-let [fn (-maybe-localized (:error/fn x) locale)] ((m/eval fn options) error options))
-              (-maybe-localized (:error/message x) locale)))))
+    (if props (or (if-let [fn (-maybe-localized (:error/fn props) locale)] ((m/eval fn options) error options))
+                  (-maybe-localized (:error/message props) locale)))))
 
 (defn- -ensure [x k]
   (if (sequential? x)

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -283,6 +283,10 @@
                    $))))))))
 
 (defn humanize
+  "Humanized a explanation. Accepts the following optitons:
+
+  - `:wrap`, a function of `error -> message`, defaulting ot `:message`
+  - `:resolve`, a function of `explanation error options -> path message`"
   ([explanation]
    (humanize explanation nil))
   ([{:keys [value errors] :as explanation} {:keys [wrap resolve]

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -221,10 +221,10 @@
        (and unknown (-message error (errors ::unknown) locale options))
        (and unknown (-message error (errors ::unknown) default-locale options)))))
 
-(defn direct-error-message-and-path [_ error options]
+(defn resolve-direct-error [_ error options]
   [(error-path error options) (error-message error options)])
 
-(defn resolve-root-error-message-and-path [{:keys [schema]} {:keys [path] :as error} options]
+(defn resolve-root-error [{:keys [schema]} {:keys [path] :as error} options]
   (let [options (assoc options :unknown false)]
     (loop [p path, l nil, mp p, m (error-message error options)]
       (let [[p' m'] (or (when-let [m' (error-message {:schema (mu/get-in schema p)} options)] [p m'])
@@ -291,7 +291,7 @@
    (humanize explanation nil))
   ([{:keys [value errors] :as explanation} {:keys [wrap resolve]
                                             :or {wrap :message
-                                                 resolve direct-error-message-and-path}
+                                                 resolve resolve-direct-error}
                                             :as options}]
    (if errors
      (if (coll? value)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2239,9 +2239,9 @@
 
 (deftest function-schema-registry-test
   (let [prior-function-schemas (m/function-schemas)
-        new-function-schemas   (m/=> function-schema-registry-test-fn [:=> :cat :nil])
-        this-ns-schemas        (get new-function-schemas 'malli.core-test)
-        fn-schema              (get this-ns-schemas 'function-schema-registry-test-fn)]
+        new-function-schemas (m/=> function-schema-registry-test-fn [:=> :cat :nil])
+        this-ns-schemas (get new-function-schemas 'malli.core-test)
+        fn-schema (get this-ns-schemas 'function-schema-registry-test-fn)]
     (is (= (inc (count prior-function-schemas)) (count new-function-schemas)))
     (is (map? this-ns-schemas))
     (is (map? fn-schema))))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -488,19 +488,19 @@
          (-> [:map
               [:foo :int]]
              (m/explain {:foo "1"})
-             (me/humanize {:resolve me/resolve-root-error-message-and-path}))))
+             (me/humanize {:resolve me/resolve-root-error}))))
 
   (is (= {:foo ["entry-failure"]}
          (-> [:map
               [:foo {:error/message "entry-failure"} :int]]
              (m/explain {:foo "1"})
-             (me/humanize {:resolve me/resolve-root-error-message-and-path}))))
+             (me/humanize {:resolve me/resolve-root-error}))))
 
   (is (= {:malli/error ["map-failure"]}
          (-> [:map {:error/message "map-failure"}
               [:foo {:error/message "entry-failure"} :int]]
              (m/explain {:foo "1"})
-             (me/humanize {:resolve me/resolve-root-error-message-and-path}))))
+             (me/humanize {:resolve me/resolve-root-error}))))
 
   (testing "entry sees child schema via :error/fn"
     (is (= {:foo ["failure"]}
@@ -508,13 +508,13 @@
                 [:foo {:error/fn (fn [{:keys [schema]} _]
                                    (-> schema m/properties :reason))} [:int {:reason "failure"}]]]
                (m/explain {:foo "1"})
-               (me/humanize {:resolve me/resolve-root-error-message-and-path}))))))
+               (me/humanize {:resolve me/resolve-root-error}))))))
 
 
 (-> [:map
      [:foo {:error/message "entry-failure"} :int]]
     (m/explain {:foo "1"})
-    (me/humanize {:resolve me/resolve-root-error-message-and-path}))
+    (me/humanize {:resolve me/resolve-root-error}))
 ; => {:foo ["entry-failure"]}
 
 (-> [:map

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -509,16 +509,3 @@
                                    (-> schema m/properties :reason))} [:int {:reason "failure"}]]]
                (m/explain {:foo "1"})
                (me/humanize {:resolve me/resolve-root-error}))))))
-
-
-(-> [:map
-     [:foo {:error/message "entry-failure"} :int]]
-    (m/explain {:foo "1"})
-    (me/humanize {:resolve me/resolve-root-error}))
-; => {:foo ["entry-failure"]}
-
-(-> [:map
-     [:foo {:error/message "entry-failure"} :int]]
-    (m/explain {:foo "1"})
-    (me/humanize))
-; => {:foo ["should be an integer"]}


### PR DESCRIPTION
using a custom `:resolve` impl with `me/humanize`:

```clj
(-> [:map
     [:foo {:error/message "entry-failure"} :int]]
    (m/explain {:foo "1"})
    (me/humanize {:resolve me/resolve-root-error}))
; => {:foo ["entry-failure"]}
```