### PR TITLE
fast collection transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Malli is in [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* Much faster validators (loop unrolling & using spesific functions) with `:or`, `:and`, `:orn` and `:map`, thanks to [Ben Sless](https://github.com/bsless):
+* Much faster validators on CLJ (loop unrolling & programming against interfaces) with `:or`, `:and`, `:orn` and `:map`, thanks to [Ben Sless](https://github.com/bsless):
 
 ```clj
 ;; 164ns -> 36ns
@@ -27,6 +27,28 @@ Malli is in [alpha](README.md#alpha).
 (let [valid? (m/validator [:map [:a :any] [:b :any] [:c :any] [:d :any] [:e :any]])
       value {:a 1, :b 2, :c 3, :d 4, :e 5}]
   (cc/quick-bench (valid? value)))
+```
+
+* Much faster collection transformers on CLJ (loop unrolling & programming against interfaces):
+
+```clj
+(let [decode (m/decoder
+               [:map
+                [:id :string]
+                [:type :keyword]
+                [:address
+                 [:map
+                  [:street :string]
+                  [:lonlat [:tuple :double :double]]]]]
+               (mt/json-transformer))
+      json {:id "pulla"
+            :type "food"
+            :address {:street "hämeenkatu 14"
+                      :lonlat [61 23.7644223]}}]
+                      
+  ;; 920ns => 160ns
+  (cc/quick-bench
+    (decode json)))
 ```
 
 ### Public API

--- a/perf/malli/perf_test.cljc
+++ b/perf/malli/perf_test.cljc
@@ -151,10 +151,10 @@
 
 (defn transform-test []
   (let [json {:id "Metosin"
-              :tags #{"clj" "cljs"}
+              :tags ["clj" "cljs"]
               :address {:street "Hämeenkatu 14"
                         :zip 33800
-                        :lonlat [61.4983866 23.7644223]}}]
+                        :lonlat [61 23.7644223]}}]
 
     (let [json->place #(st/coerce ::place % st/json-transformer)]
       (clojure.pprint/pprint (json->place json))
@@ -165,7 +165,7 @@
     (let [json->place (m/decoder Place transform/json-transformer)]
       (clojure.pprint/pprint (json->place json))
 
-      ;; 1µs
+      ;; 1µs -> 400ns
       (cc/quick-bench (json->place json)))))
 
 (defn transform-test2 []


### PR DESCRIPTION
much faster collection transformers for CLJ:

```clj
(let [schema [:map
              [:id :string]
              [:type :keyword]
              [:address
               [:map
                [:street :string]
                [:lonlat [:tuple :double :double]]]]]
      decode (m/decoder schema (mt/json-transformer))
      json {:id "pulla"
            :type "herkku"
            :address {:street "hämeenkatu 14"
                      :lonlat [61 23.7644223]}}]
  ;; 920ns => 160ns
  (cc/quick-bench
    (decode json)))
```