### PR TITLE
Transform longs bigger than js/Number.MAX_SAFE_INTEGER

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -1,6 +1,7 @@
 (ns malli.transform
   #?(:cljs (:refer-clojure :exclude [Inst Keyword UUID]))
   (:require #?@(:cljs [[goog.date.UtcDateTime]
+                       [goog.math.Long]
                        [goog.date.Date]])
             [malli.core :as m])
   #?(:clj (:import (java.util Date UUID)
@@ -61,8 +62,8 @@
          :cljs (let [x' (if (re-find #"\D" (subs x 1)) ##NaN (js/parseInt x 10))]
                  (cond
                    (js/isNaN x') x
-                   (> x' js/Number.MAX_SAFE_INTEGER) x
-                   (< x' js/Number.MIN_SAFE_INTEGER) x
+                   (> x' js/Number.MAX_SAFE_INTEGER) (goog.math.Long/fromString x 10)
+                   (< x' js/Number.MIN_SAFE_INTEGER) (goog.math.Long/fromString x 10)
                    :else x')))
       (catch #?(:clj Exception, :cljs js/Error) _ x))
     x))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -3,7 +3,8 @@
             [malli.core :as m]
             [malli.transform :as mt]
             [malli.core-test]
-            [clojure.string :as str]))
+            [clojure.string :as str]
+            #?(:cljs [goog.math.Long])))
 
 (deftest ->interceptor-test
   (are [?interceptor expected]
@@ -29,10 +30,10 @@
   (is (= 1 (mt/-string->long 1)))
   (is (= 9007199254740991 (mt/-string->long "9007199254740991")))
   (is (= -9007199254740991 (mt/-string->long "-9007199254740991")))
-  ;; Unfortunately, the number in the CLJ branch here isn't representable in JS 'integers'.
-  (is (= #?(:clj 9007199254740993 :cljs "9007199254740993")
+  ;; Numbers in JS bigger than (2^53)-1 cannot be safely represented. CLJS uses goog.math.Long
+  (is (= #?(:clj 9007199254740993 :cljs (goog.math.Long/fromString "9007199254740993"))
          (mt/-string->long "9007199254740993")))
-  (is (= #?(:clj -9007199254740993 :cljs "-9007199254740993")
+  (is (= #?(:clj -9007199254740993 :cljs (goog.math.Long/fromString "-9007199254740993"))
          (mt/-string->long "-9007199254740993")))
   (is (= "abba" (mt/-string->long "abba"))))
 


### PR DESCRIPTION
In cljs these are goog.math.Longs, malli transforms should do the same instead of leaving them as strings.