### PR TITLE
Implement -map-transformer with -comp

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -298,14 +298,15 @@
                :output output}
               max (assoc :max max)))))
 
+#?(:clj
+   (defn -entry-transformer [[k t]]
+     (fn [^Associative x]
+       (if-let [e ^MapEntry (.entryAt x k)]
+         (.assoc x k (t (.val e)))
+         x))))
+
 (defn -map-transformer [ts]
-  #?(:clj  (let [tl (LinkedList. ^Collection (mapv (fn [[k v]] (MapEntry/create k v)) ts))]
-             (fn [x] (let [i (.iterator ^Iterable tl)]
-                       (loop [x ^Associative x]
-                         (if (.hasNext i)
-                           (let [e ^MapEntry (.next i), k (.key e)]
-                             (recur (if-let [xe (.entryAt x k)] (.assoc x k ((.val e) (.val xe))) x)))
-                           x)))))
+  #?(:clj (apply -comp (map -entry-transformer ts))
      :cljs (fn [x] (reduce-kv
                      (fn reduce-child-transformers [m k t]
                        (if-let [entry (find m k)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -298,20 +298,15 @@
                :output output}
               max (assoc :max max)))))
 
-#?(:clj
-   (defn -entry-transformer [[k t]]
-     (fn [^Associative x]
-       (if-let [e ^MapEntry (.entryAt x k)]
-         (.assoc x k (t (.val e)))
-         x))))
-
 (defn -map-transformer [ts]
-  #?(:clj (apply -comp (map -entry-transformer ts))
-     :cljs (fn [x] (reduce-kv
-                     (fn reduce-child-transformers [m k t]
-                       (if-let [entry (find m k)]
-                         (assoc m k (t (val entry)))
-                         m)) x ts))))
+  #?(:clj  (apply -comp (map (fn child-transformer [[k t]]
+                               (fn [^Associative x]
+                                 (if-let [e ^MapEntry (.entryAt x k)]
+                                   (.assoc x k (t (.val e))) x))) (rseq ts)))
+     :cljs (fn [x] (reduce (fn child-transformer [m [k t]]
+                             (if-let [entry (find m k)]
+                               (assoc m k (t (val entry)))
+                               m)) x ts))))
 
 (defn -tuple-transformer [ts]
   #?(:clj  (let [tl (LinkedList. ^Collection (mapv (fn [[k v]] (MapEntry/create k v)) ts))]
@@ -754,10 +749,9 @@
            (-unparser [_] (->parser -unparser))
            (-transformer [this transformer method options]
              (let [this-transformer (-value-transformer transformer this method options)
-                   ->children (some->> entries
-                                       (keep (fn [[k s]]
-                                               (when-some [t (-transformer s transformer method options)] [k t])))
-                                       (into {}))
+                   ->children (reduce (fn [acc [k s]]
+                                        (let [t (-transformer s transformer method options)]
+                                          (cond-> acc t (conj [k t])))) [] entries)
                    apply->children (when (seq ->children) (-map-transformer ->children))
                    apply->children (-guard map? apply->children)]
                (-intercepting this-transformer apply->children)))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -597,18 +597,12 @@
       (reset! state nil)
       (m/decode schema {:x 1, :y "2"} transformer)
       (is (= [[:decode :enter :map {:x 1, :y "2"}]
-              #?@(:clj
-                  [[:decode :enter ::m/val "2"]
-                   [:decode :enter 'string? "2"]
-                   [:decode :leave 'string? "2"]
-                   [:decode :leave ::m/val "2"]])
               [:decode :enter ::m/val 1]
               [:decode :leave ::m/val 1]
-              #?@(:cljs
-                  [[:decode :enter ::m/val "2"]
-                   [:decode :enter 'string? "2"]
-                   [:decode :leave 'string? "2"]
-                   [:decode :leave ::m/val "2"]])
+              [:decode :enter ::m/val "2"]
+              [:decode :enter 'string? "2"]
+              [:decode :leave 'string? "2"]
+              [:decode :leave ::m/val "2"]
               [:decode :leave :map {:x 1, :y "2"}]]
              @state)))
 
@@ -616,18 +610,12 @@
       (reset! state nil)
       (m/encode schema {:x 1, :y "2"} transformer)
       (is (= [[:encode :enter :map {:x 1, :y "2"}]
-              #?@(:clj
-                  [[:encode :enter ::m/val "2"]
-                   [:encode :enter 'string? "2"]
-                   [:encode :leave 'string? "2"]
-                   [:encode :leave ::m/val "2"]])
               [:encode :enter ::m/val 1]
               [:encode :leave ::m/val 1]
-              #?@(:cljs
-                  [[:encode :enter ::m/val "2"]
-                   [:encode :enter 'string? "2"]
-                   [:encode :leave 'string? "2"]
-                   [:encode :leave ::m/val "2"]])
+              [:encode :enter ::m/val "2"]
+              [:encode :enter 'string? "2"]
+              [:encode :leave 'string? "2"]
+              [:encode :leave ::m/val "2"]
               [:encode :leave :map {:x 1, :y "2"}]]
              @state)))))
 

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -597,12 +597,18 @@
       (reset! state nil)
       (m/decode schema {:x 1, :y "2"} transformer)
       (is (= [[:decode :enter :map {:x 1, :y "2"}]
+              #?@(:clj
+                  [[:decode :enter ::m/val "2"]
+                   [:decode :enter 'string? "2"]
+                   [:decode :leave 'string? "2"]
+                   [:decode :leave ::m/val "2"]])
               [:decode :enter ::m/val 1]
               [:decode :leave ::m/val 1]
-              [:decode :enter ::m/val "2"]
-              [:decode :enter 'string? "2"]
-              [:decode :leave 'string? "2"]
-              [:decode :leave ::m/val "2"]
+              #?@(:cljs
+                  [[:decode :enter ::m/val "2"]
+                   [:decode :enter 'string? "2"]
+                   [:decode :leave 'string? "2"]
+                   [:decode :leave ::m/val "2"]])
               [:decode :leave :map {:x 1, :y "2"}]]
              @state)))
 
@@ -610,12 +616,18 @@
       (reset! state nil)
       (m/encode schema {:x 1, :y "2"} transformer)
       (is (= [[:encode :enter :map {:x 1, :y "2"}]
+              #?@(:clj
+                  [[:encode :enter ::m/val "2"]
+                   [:encode :enter 'string? "2"]
+                   [:encode :leave 'string? "2"]
+                   [:encode :leave ::m/val "2"]])
               [:encode :enter ::m/val 1]
               [:encode :leave ::m/val 1]
-              [:encode :enter ::m/val "2"]
-              [:encode :enter 'string? "2"]
-              [:encode :leave 'string? "2"]
-              [:encode :leave ::m/val "2"]
+              #?@(:cljs
+                  [[:encode :enter ::m/val "2"]
+                   [:encode :enter 'string? "2"]
+                   [:encode :leave 'string? "2"]
+                   [:encode :leave ::m/val "2"]])
               [:encode :leave :map {:x 1, :y "2"}]]
              @state)))))
 


### PR DESCRIPTION
The clj implementation reverses the order of transformers, this makes
the transformer trace test fail without accounting for the change in order