### PR TITLE
Robust Humanize Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,16 +56,17 @@ Malli is in [alpha](README.md#alpha).
 * **BREAKING**: `malli.json-schema/unlift-keys` is removed in favor of `malli.core/-unlift-keys`
 * **BREAKING**: `malli.json-schema/unlift` is removed in favor of `get`
 * **BREAKING**: `malli.provider/stats` is removed (was already deprecated)
-* **BREAKING**: humanized message duplicates are removed, e.g. `{:foo ["fail" "fail"]}` => `{:foo ["fail"]}`
 * **BREAKING**: `malli.util/update` doesn't the properties of the key it updates, fixes [#412](https://github.com/metosin/malli/issues/412)
+* **BREAKING**: New rules for humanized errors, see [#502](https://github.com/metosin/malli/pull/502), fixes [#80](https://github.com/metosin/malli/issues/80), [#428](https://github.com/metosin/malli/issues/428) and [#499](https://github.com/metosin/malli/issues/499).
 
+* `:map-of` supports `:min` and `:max` properties
+* Collection Schemas emit correct JSON Schema min & max declarations
 * new `malli.plantuml` namespace for [PlantUML generation](README.md#plantuml)
 * new `malli.instrument` and `malli.dev` for instrumenting function Vars (e.g. `defn`s), see [the guide](docs/function-schemas.md).
 * new `malli.generator/check` and `malli.generator/check!` for generative testing of functions and `defn`s.
 * new `malli.core/parent`
-* humanized errors for `:boolean`
+* humanized errors for `:boolean` & `:malli.core/tuple-limit`
 * predicate schema for `fn?`
-* fix crash in humanize for maps [#333](https://github.com/metosin/malli/pull/333)
 * `malli.util/transform-entries` passes in options [#340]/(https://github.com/metosin/malli/pull/340)  
 * humanized errors can be read from parent schemas (also from map entries), fixes [#86](https://github.com/metosin/malli/issues/86):
 

--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -144,7 +144,7 @@
 
 (defn -assoc-in [a v [p & ps] e]
   (let [v' (-get v p)
-        a' (or a (if (sequential? v) [] (empty v)))]
+        a' (or a (cond (sequential? v) [], (record? v) {}, :else (empty v)))]
     (cond
       ;; error present, let's not go deeper
       (and p (-error? a')) a

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -584,3 +584,8 @@
       ;; sequences
       [:and [:sequential :int] (f "1") (f "2")] [1 "2"] => [nil ["should be an integer"]]
       [:and [:sequential :int] (f "1") (f "2")] [1 2] => ["1" "2"])))
+
+(deftest multi-humanize-test-428
+  (is (= {:user {:type ["invalid dispatch value"]}}
+         (-> (m/explain [:map [:user [:multi {:dispatch :type}]]] {:user nil})
+             (me/humanize)))))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -546,6 +546,8 @@
                 :f [1 2 3 4]})
              (me/humanize)))))
 
+(defrecord Horror [])
+
 (deftest robust-humanize-form
   (let [f (fn [s] [:fn {:error/message s} (constantly false)])
         => ::irrelevant]
@@ -566,6 +568,10 @@
       [:map [:x [:and [:map [:y :any]] seq? (f "kosh")]]] {:x {}} => {:x {:y ["missing required key"]
                                                                           :malli/error ["should be a seq" "kosh"]}}
       [:map [:x [:and [:map [:y :any]] seq?]]] {:x {:y 123}} => {:x ["should be a seq"]}
+
+      ;; records
+      [:map [:x [:and [:map [:y :any]] seq?]]] (map->Horror {:x (map->Horror {})}) => {:x {:y ["missing required key"]
+                                                                                           :malli/error ["should be a seq"]}}
 
       ;; don't derive error form from value in case of top-level error
       [:map [:x [:and seq? [:map [:y :any]]]]] 123 => ["invalid type"]

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -143,8 +143,8 @@
                (m/explain {:x 1, :extra "key"})
                (me/humanize)))))
 
-  (testing "multiple errors on same key are presented just once"
-    (is (= {:x ["missing required key"]}
+  (testing "multiple errors on same key are preserved"
+    (is (= {:x ["missing required key" "missing required key"]}
            (me/humanize
              {:value {},
               :errors [{:in [:x], :schema [:map [:x int?]], :type ::m/missing-key}
@@ -153,12 +153,12 @@
   (testing "maps can have top level errors and key errors"
     (is (= {:person {:malli/error ["should be a seq"],
                      :name ["missing required key"]}}
-           (-> [:map [:person [:and seq? [:map [:name string?]]]]]
+           (-> [:map [:person [:and [:map [:name string?]] seq?]]]
                (m/explain {:person {}})
                (me/humanize)))))
 
   (testing "maps have errors inside"
-    (is (= {:person {:malli/error ["should be a seq"]}}
+    (is (= {:person ["should be a seq"]}
            (-> [:map [:person seq?]]
                (m/explain {:person {}})
                (me/humanize))))))
@@ -257,33 +257,33 @@
                                :password2 "faarao"})
                    (me/humanize)))))))
 
-  (testing "on collections, first error wins"
+  (testing "on collections"
     (let [schema [:and
                   [:vector int?]
-                  [:fn {:error/message "first should be positive"}
-                   '(fn [[x]] (pos? x))]
-                  [:fn {:error/message "first should be positive (masked)"}
-                   '(fn [[x]] (pos? x))]]]
-      (is (= ["first should be positive"]
-             (-> schema
-                 (m/explain [-2 1])
-                 (me/humanize))))
-      (is (= [nil ["should be an int"]]
-             (-> schema
-                 (m/explain [-2 "1"])
-                 (me/humanize))))
-      (is (= ["invalid type"]
-             (-> schema
-                 (m/explain '(-2 "1"))
-                 (me/humanize))))))
+                  [:fn {:error/message "error1"} '(fn [[x]] (pos? x))]
+                  [:fn {:error/message "error2"} '(fn [[x]] (pos? x))]]]
+      (testing "value errors are reported over extra top-level errpors"
+        (is (= [nil ["should be an int"]]
+               (-> schema
+                   (m/explain [-2 "1"])
+                   (me/humanize)))))
+      (testing "without value errors, all top-level errors are collected"
+        (is (= ["error1" "error2"]
+               (-> schema
+                   (m/explain [-2 1])
+                   (me/humanize))))
+        (is (= ["invalid type" "error1" "error2"]
+               (-> schema
+                   (m/explain '(-2 "1"))
+                   (me/humanize)))))))
 
-  (testing "on non-collections, first error wins"
+  (testing "on non-collections, all errors are collectd"
     (let [schema [:and
                   [:fn {:error/message "should be >= 1"} '(fn [x] (or (not (int? x)) (>= x 1)))]
                   int?
                   [:fn {:error/message "should be >= 2"} '(fn [x] (or (not (int? x)) (>= x 2)))]]]
 
-      (is (= ["should be >= 1"]
+      (is (= ["should be >= 1" "should be >= 2"]
              (-> schema
                  (m/explain 0)
                  (me/humanize))))
@@ -509,7 +509,7 @@
              (m/explain {:foo "1"})
              (me/humanize {:resolve me/resolve-root-error}))))
 
-  (is (= {:malli/error ["map-failure"]}
+  (is (= ["map-failure"]
          (-> [:map {:error/message "map-failure"}
               [:foo {:error/message "entry-failure"} :int]]
              (m/explain {:foo "1"})
@@ -538,10 +538,49 @@
               [:e [:vector {:min 2, :max 5} int?]]
               [:f [:vector {:min 5, :max 5} int?]]]
              (m/explain
-              {:a ["123"]
-               :b [1]
-               :c [1 2 3 4 5 6]
-               :d [1]
-               :e [1.2]
-               :f [1 2 3 4]})
+               {:a ["123"]
+                :b [1]
+                :c [1 2 3 4 5 6]
+                :d [1]
+                :e [1.2]
+                :f [1 2 3 4]})
              (me/humanize)))))
+
+(deftest robust-humanize-form
+  (let [f (fn [s] [:fn {:error/message s} (constantly false)])
+        => ::irrelevant]
+    (are [schema value _ expected]
+      (is (= expected (-> (m/explain schema value) (me/humanize))))
+
+      ;; simple cases
+      :any :any => nil
+      [:and :any :any] :any => nil
+      [:and (f "1") :any] :any => ["1"]
+      [:and (f "1") (f "1") :any] :any => ["1" "1"]
+      [:and (f "1") (f "2")] {:a :map} => ["1" "2"]
+
+      ;; accumulate into maps if error shape is already a map
+      [:map [:x [:and [:map [:y :any]] seq?]]] 123 => ["invalid type"]
+      [:map [:x [:and [:map [:y :any]] seq?]]] {} => {:x ["missing required key"]}
+      [:map [:x [:and [:map [:y :any]] seq?]]] {:x 123} => {:x ["invalid type" "should be a seq"]}
+      [:map [:x [:and [:map [:y :any]] seq? (f "kosh")]]] {:x {}} => {:x {:y ["missing required key"]
+                                                                          :malli/error ["should be a seq" "kosh"]}}
+      [:map [:x [:and [:map [:y :any]] seq?]]] {:x {:y 123}} => {:x ["should be a seq"]}
+
+      ;; don't derive error form from value in case of top-level error
+      [:map [:x [:and seq? [:map [:y :any]]]]] 123 => ["invalid type"]
+      [:map [:x [:and seq? [:map [:y :any]]]]] {} => {:x ["missing required key"]}
+      [:map [:x [:and seq? [:map [:y :any]]]]] {:x 123} => {:x ["should be a seq" "invalid type"]}
+      [:map [:x [:and seq? [:map [:y :any]]]]] {:x {}} => {:x ["should be a seq"]}
+
+      ;; tuple sizes
+      [:map [:x [:tuple :int :int :int]]] {} => {:x ["missing required key"]}
+      [:map [:x [:tuple :int :int :int]]] {:x []} => {:x ["invalid tuple size 0, expected 3"]}
+      [:map [:x [:tuple :int :int :int]]] {:x [1 "2" 3]} => {:x [nil ["should be an integer"]]}
+      [:map [:x [:tuple :int :int :int]]] {:x [1 "2" "3"]} => {:x [nil ["should be an integer"] ["should be an integer"]]}
+      [:map [:x [:tuple :int [:and :int (f "fails")] :int]]] {:x [1 "2" "3"]} => {:x [nil ["should be an integer" "fails"] ["should be an integer"]]}
+      [:map [:x [:tuple :int :int :int]]] {:x [1 2 3]} => nil
+
+      ;; sequences
+      [:and [:sequential :int] (f "1") (f "2")] [1 "2"] => [nil ["should be an integer"]]
+      [:and [:sequential :int] (f "1") (f "2")] [1 2] => ["1" "2"])))


### PR DESCRIPTION
Simplified humanization with proper tests. Fixes #80, #428 & #499.

```clj
(deftest robust-humanize-form
  (let [f (fn [s] [:fn {:error/message s} (constantly false)])
        => ::irrelevant]
    (are [schema value _ expected]
      (is (= expected (-> (m/explain schema value) (me/humanize))))

      ;; simple cases
      :any :any => nil
      [:and :any :any] :any => nil
      [:and (f "1") :any] :any => ["1"]
      [:and (f "1") (f "1") :any] :any => ["1" "1"]
      [:and (f "1") (f "2")] {:a :map} => ["1" "2"]

      ;; accumulate into maps if error shape is already a map
      [:map [:x [:and [:map [:y :any]] seq?]]] 123 => ["invalid type"]
      [:map [:x [:and [:map [:y :any]] seq?]]] {} => {:x ["missing required key"]}
      [:map [:x [:and [:map [:y :any]] seq?]]] {:x 123} => {:x ["invalid type" "should be a seq"]}
      [:map [:x [:and [:map [:y :any]] seq? (f "kosh")]]] {:x {}} => {:x {:y ["missing required key"]
                                                                          :malli/error ["should be a seq" "kosh"]}}
      [:map [:x [:and [:map [:y :any]] seq?]]] {:x {:y 123}} => {:x ["should be a seq"]}

      ;; don't derive error form from value in case of top-level error
      [:map [:x [:and seq? [:map [:y :any]]]]] 123 => ["invalid type"]
      [:map [:x [:and seq? [:map [:y :any]]]]] {} => {:x ["missing required key"]}
      [:map [:x [:and seq? [:map [:y :any]]]]] {:x 123} => {:x ["should be a seq" "invalid type"]}
      [:map [:x [:and seq? [:map [:y :any]]]]] {:x {}} => {:x ["should be a seq"]}

      ;; tuple sizes
      [:map [:x [:tuple :int :int :int]]] {} => {:x ["missing required key"]}
      [:map [:x [:tuple :int :int :int]]] {:x []} => {:x ["invalid tuple size 0, expected 3"]}
      [:map [:x [:tuple :int :int :int]]] {:x [1 "2" 3]} => {:x [nil ["should be an integer"]]}
      [:map [:x [:tuple :int :int :int]]] {:x [1 "2" "3"]} => {:x [nil ["should be an integer"] ["should be an integer"]]}
      [:map [:x [:tuple :int [:and :int (f "fails")] :int]]] {:x [1 "2" "3"]} => {:x [nil ["should be an integer" "fails"] ["should be an integer"]]}
      [:map [:x [:tuple :int :int :int]]] {:x [1 2 3]} => nil

      ;; sequences
      [:and [:sequential :int] (f "1") (f "2")] [1 "2"] => [nil ["should be an integer"]]
      [:and [:sequential :int] (f "1") (f "2")] [1 2] => ["1" "2"])))
```