### PR TITLE
fix :uuid does not produce humanized error, fixes #511

### DIFF
--- a/src/malli/error.cljc
+++ b/src/malli/error.cljc
@@ -103,6 +103,7 @@
                                  (and min max) (str "should be between " min " and " max " characters")
                                  min (str "should be at least " min " characters")
                                  max (str "should be at most " max " characters"))))}}
+   :uuid {:error/message {:en "should be a uuid"}}
    :> {:error/fn {:en (fn [{:keys [schema value]} _]
                         (if (number? value)
                           (str "should be larger than " (first (m/children schema)))


### PR DESCRIPTION
Fixes issue #511 

`:uuid` schema now produces same error as `uuid?`
```
(me/humanize (m/explain :uuid "foo"))
=> ["should be a uuid"]
```