### PR TITLE
Manually destructure simple-schema props

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -375,7 +375,11 @@
       (-into-schema [parent properties children options]
         (if (fn? ?props)
           (-into-schema (-simple-schema (?props properties children)) properties children options)
-          (let [{:keys [type pred property-pred min max], :or {min 0, max 0}} ?props]
+          (let [type (if ?props (?props :type))
+                pred (if ?props (?props :pred))
+                property-pred (if ?props (?props :property-pred))
+                min (if ?props (?props :min 0) 0)
+                max (if ?props (?props :max 0) 0)]
             (reset! props* ?props)
             (-check-children! type properties children {:min min, :max max})
             (let [pvalidator (if property-pred (property-pred properties))


### PR DESCRIPTION
Shaves about 30 ns

Part of #513 

```clojure
(let [s (mr/-schema m/default-registry :int)
      props [nil {} {:min 3}]]
  (dotimes [_ 10]
    (doseq [props props]
      (m/-into-schema s props nil nil)))
  (doseq [props props]
    (cc/quick-bench (m/-into-schema s props nil nil))))

;;; Before
;; Evaluation count : 5654382 in 6 samples of 942397 calls.
;;              Execution time mean : 104.946290 ns
;;     Execution time std-deviation : 0.498020 ns
;;    Execution time lower quantile : 104.532546 ns ( 2.5%)
;;    Execution time upper quantile : 105.786444 ns (97.5%)
;;                    Overhead used : 1.288302 ns
;; Evaluation count : 3441606 in 6 samples of 573601 calls.
;;              Execution time mean : 174.105307 ns
;;     Execution time std-deviation : 1.909646 ns
;;    Execution time lower quantile : 172.299707 ns ( 2.5%)
;;    Execution time upper quantile : 177.069101 ns (97.5%)
;;                    Overhead used : 1.288302 ns
;; Evaluation count : 3261972 in 6 samples of 543662 calls.
;;              Execution time mean : 182.995677 ns
;;     Execution time std-deviation : 0.300868 ns
;;    Execution time lower quantile : 182.556708 ns ( 2.5%)
;;    Execution time upper quantile : 183.334195 ns (97.5%)
;;                    Overhead used : 1.288302 ns

;;; After
;; Evaluation count : 8045124 in 6 samples of 1340854 calls.
;;              Execution time mean : 76.953182 ns
;;     Execution time std-deviation : 0.596017 ns
;;    Execution time lower quantile : 76.168239 ns ( 2.5%)
;;    Execution time upper quantile : 77.486997 ns (97.5%)
;;                    Overhead used : 1.263533 ns
;; Evaluation count : 4225704 in 6 samples of 704284 calls.
;;              Execution time mean : 140.237636 ns
;;     Execution time std-deviation : 0.211503 ns
;;    Execution time lower quantile : 139.991150 ns ( 2.5%)
;;    Execution time upper quantile : 140.481190 ns (97.5%)
;;                    Overhead used : 1.263533 ns
;; Evaluation count : 3803154 in 6 samples of 633859 calls.
;;              Execution time mean : 149.382653 ns
;;     Execution time std-deviation : 0.087152 ns
;;    Execution time lower quantile : 149.286079 ns ( 2.5%)
;;    Execution time upper quantile : 149.500607 ns (97.5%)
;;                    Overhead used : 1.263533 ns
```