### PR TITLE
Faster schema transformations

### DIFF
--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -51,10 +51,13 @@
   ;;
 
   ;; 5.2µs
+  ;; 3.6µs
   (bench (m/validate [:or :int :string] 42))
   (profile (m/validate [:or :int :string] 42))
 
   ;; 3.0µs
+  ;; 500ns (delayed mapv childs)
+  ;; 1.7µs
   (bench (m/schema [:or :int :string]))
   (profile (m/schema [:or :int :string]))
 

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -86,11 +86,11 @@
   ;; schema creation
   ;;
 
-  ;; 480ns
+  ;; 480ns -> 400ns
   (bench (m/schema :int))
   (profile (m/schema :int))
 
-  ;; 44µs
+  ;; 44µs -> 31µs
   (bench (m/schema ?schema))
   (profile (m/schema ?schema)))
 
@@ -112,6 +112,7 @@
 
   ;; 51µs
   ;; 44µs (-set-children, -set-properties)
+  ;; 29µs (lot's of stuff)
   (bench (mu/closed-schema schema))
   (profile (mu/closed-schema schema)))
 

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -123,5 +123,14 @@
     (bench (m/-create-form t p c))))
 
 (comment
+  (let [s (m/schema :int)]
+    ;; 440ns
+    ;; 341ns (-create-form)
+    ;; 150ns (delayed form)
+    ;;  30ns (don't -check-children)
+    (bench (m/-val-schema s nil))
+    (profile (m/-val-schema s nil))))
+
+(comment
   (prof/serve-files 8080)
   (prof/clear-results))

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -116,5 +116,12 @@
   (profile (mu/closed-schema schema)))
 
 (comment
+
+  (let [t ::or, p {:a 1}, c (mapv m/schema [:int :int])]
+    ;; 480ns
+    ;; 221ns (faster impl)
+    (bench (m/-create-form t p c))))
+
+(comment
   (prof/serve-files 8080)
   (prof/clear-results))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -135,11 +135,11 @@
     (-fail! ::child-error (merge {:type type, :properties properties, :children children} opts))))
 
 (defn -create-form [type properties children]
-  (cond
-    (and (seq properties) (seq children)) (into [type properties] children)
-    (seq properties) [type properties]
-    (seq children) (into [type] children)
-    :else type))
+  (let [has-children (seq children), has-properties (seq properties)]
+    (cond (and has-properties has-children) (reduce conj [type properties] children)
+          has-properties [type properties]
+          has-children (reduce conj [type] children)
+          :else type)))
 
 (defn -pointer [id schema options] (-into-schema (-schema-schema {:id id}) nil [schema] options))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -470,7 +470,7 @@
     (-children-schema [_ _])
     (-into-schema [parent properties children options]
       (-check-children! :or properties children {:min 1})
-      (let [children (map #(schema % options) children)
+      (let [children (mapv #(schema % options) children)
             form (delay (-create-form :or properties (map -form children)))
             ->parser (fn [f] (let [parsers (mapv f children)]
                                #(reduce (fn [_ parser] (miu/-map-valid reduced (parser %))) ::invalid parsers)))]
@@ -1633,12 +1633,11 @@
      (into-schema? ?schema) (-into-schema ?schema nil nil options)
      (vector? ?schema) (let [t (nth ?schema 0)
                              n (count ?schema)
-                             ?p (when (> n 1) (nth ?schema 1))]
-                         (if-let [p (when (or (nil? ?p) (map? ?p)) ?p)]
-                           (let [c (when (< 2 n) (subvec ?schema 2 n))]
-                             (into-schema (-schema t options) p c options))
-                           (let [c (when (< 1 n) (subvec ?schema 1 n))]
-                             (into-schema (-schema t options) nil c options))))
+                             ?p (when (> n 1) (nth ?schema 1))
+                             s (-schema t options)]
+                         (if (or (nil? ?p) (map? ?p))
+                           (into-schema s ?p (when (< 2 n) (subvec ?schema 2 n)) options)
+                           (into-schema s nil (when (< 1 n) (subvec ?schema 1 n)) options)))
      :else (if-let [?schema' (and (-reference? ?schema) (-lookup ?schema options))]
              (-pointer ?schema (schema ?schema' options) options)
              (-> ?schema (-schema options) (schema options))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -186,6 +186,10 @@
   (if (-equals children (-children schema))
     schema (-into-schema (-parent schema) (-properties schema) children (-options schema))))
 
+(defn -set-properties [schema properties]
+  (if (-equals properties (-properties schema))
+    schema (-into-schema (-parent schema) properties (-children schema) (-options schema))))
+
 (defn -update-options [schema f]
   (-into-schema (-parent schema) (-properties schema) (-children schema) (f (-options schema))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -131,7 +131,7 @@
   (reduce-kv #(if (= (name prefix) (namespace %2)) (assoc %1 (keyword (name %2)) %3) %1) {} m))
 
 (defn -check-children! [type properties children opts]
-  (let [size (count children), min (:min opts 0), max (:max opts size)]
+  (let [size (count children), min (or (:min opts) 0), max (or (:max opts) size)]
     (when (or (< size min) (> size max))
       (-fail! ::child-error {:type type, :properties properties, :children children, :min min, :max max}))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -131,8 +131,8 @@
   (reduce-kv #(if (= (name prefix) (namespace %2)) (assoc %1 (keyword (name %2)) %3) %1) {} m))
 
 (defn -check-children! [type properties children opts]
-  (let [size (count children), min (or (:min opts) 0), max (or (:max opts) size)]
-    (when (or (< size min) (> size max))
+  (let [size (count children), min (:min opts), max (:max opts)]
+    (when (or (and min (< size min)) (and max (> size max)))
       (-fail! ::child-error {:type type, :properties properties, :children children, :min min, :max max}))))
 
 (defn -create-form [type properties children]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -261,10 +261,7 @@
 (defn -registry
   {:arglists '([] [{:keys [registry]}])}
   ([] default-registry)
-  ([opts]
-   (or (when opts
-         (mr/registry (opts :registry)))
-       default-registry)))
+  ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
 (defn- -lookup [?schema options]
   (let [registry (-registry options)]

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -14,19 +14,11 @@
     (-schema [_ type] (schemas type))
     (-schemas [_] schemas)))
 
-(defn registry
-  [?registry]
-  #?(:clj
-     (when ?registry
-       (if (instance? malli.registry.Registry ?registry)
-         ?registry
-         (if (map? ?registry)
-           (simple-registry ?registry)
-           (when (satisfies? Registry ?registry)
-             ?registry))))
-     :cljs
-     (cond (satisfies? Registry ?registry) ?registry
-           (map? ?registry) (simple-registry ?registry))))
+(defn registry [?registry]
+  (cond (nil? ?registry) nil
+        #?@(:clj [(instance? malli.registry.Registry ?registry) ?registry])
+        (map? ?registry) (simple-registry ?registry)
+        (satisfies? Registry ?registry) ?registry))
 
 ;;
 ;; custom

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -116,11 +116,7 @@
   "Returns a Schema instance with updated properties."
   [?schema f & args]
   (let [schema (m/schema ?schema)]
-    (m/into-schema
-      (m/-parent schema)
-      (not-empty (apply f (m/-properties schema) args))
-      (m/-children schema)
-      (m/-options schema))))
+    (m/-set-properties schema (not-empty (apply f (m/-properties schema) args)))))
 
 (defn closed-schema
   "Closes recursively all :map schemas by adding `{:closed true}`


### PR DESCRIPTION
## what

* cherry picked & clojurescriptized #521
* faster `m/-check-children`
* 2x faster `m/-create-form`
* `m/-set-children` only sets if children have changed
* `m/-set-properties` only sets if properties have changed
* 10x faster `m/-val-schema`

## findings

### clojure

* turning sequences into vectors (`vec`,  `mapv`, `into []` is slow)

```clj
(defn -nth0 [x]
  (if (vector? x)
    (nth x 0)
    (first x)))

(let [l '(1 2 3 4)
      v (vec l)]

  (cc/quick-bench (vec l))    ;; -> 150ns

  (cc/quick-bench (nth l 0))  ;; -> 108ns
  (cc/quick-bench (nth v 0))  ;; -> 5ns

  (cc/quick-bench (first l))  ;; -> 5ns
  (cc/quick-bench (first v))  ;; -> 52ns

  (cc/quick-bench (-nth0 l))  ;; -> 32ns
  (cc/quick-bench (-nth0 v))) ;; -> 41ns
```

### composite schemas

composite schemas like `:and`,  `:or` and `:tuple` would benefit a lot from:

1. `mapv` childs (fast access on `-get` etc) + `delay` the result -> 

```clj
; 1.7µs => 500ns
(bench (m/schema [:or :int :string])) 
```

2. map the child and use `loop` in `-get`


### misc

* `m/-check-children` should be optional (via configuration var? *assert*?)
* re-parsing map entries is the big win, bets on that (#522)

