### PR TITLE
Even faster

### DIFF
--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -54,6 +54,7 @@
   ;; 3.6µs
   ;; 3.0µs (map childs)
   ;; 3.2µs (mapv childs)
+  ;; 2.5µs (...)
   (bench (m/validate [:or :int :string] 42))
   (profile (m/validate [:or :int :string] 42))
 
@@ -65,6 +66,7 @@
   ;; 300ns (simple-schema)
   ;; 180ns (fast parse)
   ;; 1.1µs (mapv childs)
+  ;; 750ns (...)
   (bench (m/schema [:or :int :string]))
   (profile (m/schema [:or :int :string]))
 
@@ -106,13 +108,18 @@
   ;; schema creation
   ;;
 
-  ;; 480ns -> 400ns -> 340ns -> 280ns
+  ;; 480ns -> 400ns -> 340ns -> 280ns -> 240ns -> 170ns (registry) -> 160ns (recur)
   (bench (m/schema :int))
   (profile (m/schema :int))
 
-  ;; 44µs -> 31µs -> 18µs -> 11µs -> 9.4µs -> 9.0µs -> 8.5µs
+  ;; 44µs -> 31µs -> 18µs -> 11µs -> 9.4µs -> 9.0µs -> 8.5µs -> 7.0µs -> 6.4µs (registry) -> 5.7µs
   (bench (m/schema ?schema))
-  (profile (m/schema ?schema)))
+  (profile (m/schema ?schema))
+
+  ;; does not work with direct linking
+  (with-redefs [m/-check-children? (constantly false)]
+    (bench (m/schema ?schema))
+    (profile (m/schema ?schema))))
 
 (comment
 
@@ -127,6 +134,7 @@
 
   ;; 26µs
   ;; 1.3µs (-set-children, -set-properties)
+  ;; 1.2µs (protocols, registry, recur)
   (bench (m/walk schema (m/schema-walker identity)))
   (profile (m/walk schema (m/schema-walker identity)))
 
@@ -137,6 +145,7 @@
   ;; 7.5µs (ever faster parsing)
   ;; 7.2µs (compact parsing)
   ;; 6.5µs (schema)
+  ;; 5.8µs (protocols, registry, recur, parsed)
   (bench (mu/closed-schema schema))
   (profile (mu/closed-schema schema)))
 

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -168,3 +168,47 @@
 (comment
   (prof/serve-files 8080)
   (prof/clear-results))
+
+(comment
+  "clojurescript perf tests"
+
+  ; shadow-cljs browser-repl
+
+  (require '[malli.core :as m])
+  (require '[malli.util :as mu])
+
+  (def ?schema
+    [:map
+     [:x boolean?]
+     [:y {:optional true} int?]
+     [:z [:map
+          [:x boolean?]
+          [:y {:optional true} int?]]]])
+
+  (def schema (m/schema ?schema))
+
+  ;;
+  ;; benchmarks (0.6.1 vs LATEST)
+  ;;
+
+  (simple-benchmark [] (m/schema :int) 100000)
+  ; [], (m/schema :int), 100000 runs, 181 msecs
+  ; [], (m/schema :int), 100000 runs, 55 msecs (3x)
+
+  (simple-benchmark [] (m/schema [:or :int :string]) 100000)
+  ; [], (m/schema [:or :int :string]), 100000 runs, 654 msecs
+  ; [], (m/schema [:or :int :string]), 100000 runs, 185 msecs (4x)
+
+  (simple-benchmark [] (m/schema ?schema) 10000)
+  ; [], (m/schema ?schema), 10000 runs, 896 msecs
+  ; [], (m/schema ?schema), 10000 runs, 156 msecs (6x)
+
+  (simple-benchmark [] (m/walk schema (m/schema-walker identity)) 10000)
+  ; [], (m/walk schema (m/schema-walker identity)), 10000 runs, 544 msecs
+  ; [], (m/walk schema (m/schema-walker identity)), 10000 runs, 41 msecs (13x)
+
+  (simple-benchmark [] (mu/closed-schema schema) 10000)
+  ; [], (mu/closed-schema schema), 10000 runs, 1046 msecs
+  ; [], (mu/closed-schema schema), 10000 runs, 163 msecs (6x)
+
+  )

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -10,7 +10,7 @@
   (-schemas [this] "returns all schemas from a registry"))
 
 (defn fast-registry [m]
-  (let [fm #?(:clj (doto (HashMap.) (.putAll ^Map m)), :cljs m)]
+  (let [fm #?(:clj (doto (HashMap. 1024 0.25) (.putAll ^Map m)), :cljs m)]
     (reify
       Registry
       (-schema [_ type] (.get fm type))
@@ -24,7 +24,7 @@
 
 (defn registry [?registry]
   (cond (nil? ?registry) nil
-        #?@(:clj [(instance? malli.registry.Registry ?registry) ?registry])
+        (#?(:clj instance?, :cljs implements?) malli.registry.Registry ?registry) ?registry
         (map? ?registry) (simple-registry ?registry)
         (satisfies? Registry ?registry) ?registry))
 

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -369,7 +369,7 @@
     (-properties-schema [_ _])
     (-children-schema [_ _])
     (-into-schema [parent properties children options]
-      (m/-check-children! type properties children {:min min, :max max})
+      (m/-check-children! type properties children min max)
       (let [[children forms schema] (fn properties (vec children) options)
             walkable-childs (if childs (subvec children 0 childs) children)
             form (m/-create-form type properties forms)]


### PR DESCRIPTION
Small improvements

* fast -check-children!
* optionally don't check children
* **BREAKING**: rremove `Schemas`, use `instance?` and `implements?` instead
* schema recur
* transducers
* parse record
* delayed forms
* fast (clj) registry