### PR TITLE
Support :enum in clj-kondo

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -78,7 +78,20 @@
 (defmethod accept :vector [_ _ _ _] :vector)
 (defmethod accept :sequential [_ _ _ _] :sequential)
 (defmethod accept :set [_ _ _ _] :set)
-(defmethod accept :enum [_ _ _ _])
+(defmethod accept :enum [_ _ children _]
+  (let [types (->> children (map type) (set))]
+    (if (< 1 (count types))
+      :any
+      (let [child (first children)]
+        (cond
+          (string? child) :string
+          (keyword? child) :keyword
+          (integer? child) :int
+          (char? child) :char
+          (number? child) :number
+          (symbol? child) :symbol
+          :else :any)))))
+
 (defmethod accept :maybe [_ _ [child] _] (if (keyword? child) (keyword "nilable" (name child)) child))
 (defmethod accept :tuple [_ _ children _] children)
 (defmethod accept :re [_ _ _ _] :regex)

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -18,6 +18,9 @@
      [:nested [:merge
                [:map [:id ::id]]
                [:map [:price ::price]]]]
+     [:string-type-enum  [:maybe [:enum "b" "c"]]]
+     [:keyword-type-enum [:enum :a :b]]
+     [:any-type-enum [:enum :a "b" "c"]]
      [:z [:vector [:map-of int? int?]]]]
     {:registry (merge (m/default-schemas) (mu/schemas))}))
 
@@ -43,6 +46,9 @@
                 :description :nilable/string,
                 :select-keys {:op :keys, :req {:x :int}},
                 :nested {:op :keys, :req {:id :string, :price :double}},
+                :string-type-enum :nilable/string
+                :keyword-type-enum :keyword
+                :any-type-enum :any
                 :z :vector}}
          (clj-kondo/transform Schema)))
 


### PR DESCRIPTION
Currently `:enum` is not supported in the clj-kondo generation (it produces `nil` in the kondo config). This adds support for `:enum`:
* If `:enum` has multiple types for its values (i.e. `[:enum "a" 1]`) then use `:any`
* If `:enum` has a single type use the corresponding clj-kondo type or use `:any` if there is no corresponding type.

Let me know if you need more info!