### PR TITLE
Perf part4

### DIFF
--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -159,6 +159,7 @@
   ;; 7.2µs (compact parsing)
   ;; 6.5µs (schema)
   ;; 5.8µs (protocols, registry, recur, parsed)
+  ;; 3.9µs (-parsed)
   (bench (mu/closed-schema schema))
   (profile (mu/closed-schema schema))
 

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -121,6 +121,18 @@
     (bench (m/schema ?schema))
     (profile (m/schema ?schema))))
 
+(def ref-schema (m/schema [:schema :int]))
+
+(comment
+
+  ;; 14ns -> 5ns
+  (bench (m/deref ref-schema))
+  (profile (m/deref ref-schema))
+
+  ;; 5µs -> 28ns
+  (bench (m/deref-all ref-schema))
+  (profile (m/deref-all ref-schema)))
+
 (comment
 
   ;;
@@ -147,7 +159,15 @@
   ;; 6.5µs (schema)
   ;; 5.8µs (protocols, registry, recur, parsed)
   (bench (mu/closed-schema schema))
-  (profile (mu/closed-schema schema)))
+  (profile (mu/closed-schema schema))
+
+  ;; 13µs
+  ;; 2.4µs (satisfies?)
+  (bench (mu/required-keys schema))
+
+  ;; 134µs
+  ;; 15µs (satisfies?)
+  (bench (mu/merge schema schema)))
 
 (comment
 
@@ -187,6 +207,8 @@
 
   (def schema (m/schema ?schema))
 
+  (def ref-schema (m/schema [:schema :int]))
+
   ;;
   ;; benchmarks (0.6.1 vs LATEST)
   ;;
@@ -211,4 +233,11 @@
   ; [], (mu/closed-schema schema), 10000 runs, 1046 msecs
   ; [], (mu/closed-schema schema), 10000 runs, 163 msecs (6x)
 
+  (simple-benchmark [] (m/deref ref-schema) 1000000)
+  ; [], (m/deref ref-schema), 1000000 runs, 53 msecs
+  ; [], (m/deref ref-schema), 1000000 runs, 53 msecs
+
+  (simple-benchmark [] (m/deref-all ref-schema) 1000000)
+  ; [], (m/deref-all ref-schema), 1000000 runs, 104 msecs
+  ; [], (m/deref-all ref-schema), 1000000 runs, 55 msecs
   )

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -252,6 +252,7 @@
   (simple-benchmark [] (mu/closed-schema schema) 10000)
   ; [], (mu/closed-schema schema), 10000 runs, 1046 msecs
   ; [], (mu/closed-schema schema), 10000 runs, 163 msecs (6x)
+  ; [], (mu/closed-schema schema), 10000 runs, 104 msecs (10x)
 
   (simple-benchmark [] (m/deref ref-schema) 1000000)
   ; [], (m/deref ref-schema), 1000000 runs, 53 msecs

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -113,7 +113,7 @@
   (bench (m/schema :int))
   (profile (m/schema :int))
 
-  ;; 44µs -> 31µs -> 18µs -> 11µs -> 9.4µs -> 9.0µs -> 8.5µs -> 7.0µs -> 6.4µs (registry) -> 5.7µs
+  ;; 44µs -> 31µs -> 18µs -> 11µs -> 9.4µs -> 9.0µs -> 8.5µs -> 7.0µs -> 6.4µs (registry) -> 5.7µs -> 3.4µs
   (bench (m/schema ?schema))
   (profile (m/schema ?schema))
 
@@ -244,6 +244,7 @@
   (simple-benchmark [] (m/schema ?schema) 10000)
   ; [], (m/schema ?schema), 10000 runs, 896 msecs
   ; [], (m/schema ?schema), 10000 runs, 156 msecs (6x)
+  ; [], (m/schema ?schema), 10000 runs, 94 msecs (9.5x)
 
   (simple-benchmark [] (m/walk schema (m/schema-walker identity)) 10000)
   ; [], (m/walk schema (m/schema-walker identity)), 10000 runs, 544 msecs

--- a/perf/malli/creation_perf_test.cljc
+++ b/perf/malli/creation_perf_test.cljc
@@ -76,6 +76,7 @@
   ;; 300ns (simple-schema)
   ;; 190ns (fast parse)
   ;; 1.1µs (mapv childs)
+  ;; 750ns (...)
   (bench (m/schema [:and :int :string]))
   (profile (m/schema [:and :int :string]))
 
@@ -160,6 +161,24 @@
   ;; 5.8µs (protocols, registry, recur, parsed)
   (bench (mu/closed-schema schema))
   (profile (mu/closed-schema schema))
+
+  ;; 3.8µs
+  ;; 3.4µs (satisfies?)
+  ;; 2.2µs (-set-entries)
+  ;; 830ns (-update-parsed)
+  (bench (mu/assoc schema :y :string))
+  (profile (mu/assoc schema :y :string))
+
+  ;; 4.2µs
+  ;; 3.8µs (satisfies?)
+  ;; 820ns (-update-parsed)
+  (bench (mu/assoc schema :w :string))
+  (profile (mu/assoc schema :w :string))
+
+  ;; 205ns
+  ;; 195ns
+  (bench (mu/get schema :y))
+  (profile (mu/get schema :y))
 
   ;; 13µs
   ;; 2.4µs (satisfies?)

--- a/perf/malli/perf_test.cljc
+++ b/perf/malli/perf_test.cljc
@@ -17,7 +17,7 @@
 
   (let [valid {:x true, :y 1, :z "kikka"}]
 
-    ;; 18ns
+    ;; 28ns
     (let [valid? (fn [m]
                    (and (if-let [v (:x m)] (boolean? v) false)
                         (if-let [v (:y m)] (int? v) true)
@@ -26,7 +26,7 @@
       (cc/quick-bench
         (valid? valid)))
 
-    ;; 37ns
+    ;; 30ns
     (let [valid? (m/validator [:map
                                [:x boolean?]
                                [:y {:optional true} int?]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -256,7 +256,7 @@
               (aset -entries i e)
               (aset -forms i f)
               (unchecked-inc-int i)))
-          (-schema [e] (schema (cond-> e lazy-refs (-lazy options)) options))
+          (-schema [e] (schema (cond-> e (and (-reference? e) lazy-refs) (-lazy options)) options))
           (-parse-ref-entry [e]
             (let [s (-schema e)
                   c [e nil s]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -365,7 +365,7 @@
 
 (defn -into-transformer [x]
   (cond
-    (satisfies? Transformer x) x
+    (#?(:clj instance?, :cljs implements?) malli.core.Transformer x) x
     (fn? x) (-into-transformer (x))
     :else (-fail! ::invalid-transformer {:value x})))
 
@@ -1895,7 +1895,7 @@
    (entries ?schema nil))
   ([?schema options]
    (if-let [schema (schema ?schema options)]
-     (if (satisfies? MapSchema schema)
+     (if (#?(:clj instance?, :cljs implements?) malli.core.MapSchema schema)
        (-entries schema)))))
 
 (defn deref

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -6,7 +6,7 @@
 
 (defn -lift [?schema]
   (let [schema (m/schema ?schema)]
-    (if (and (satisfies? m/RefSchema schema) (-> schema m/deref m/type (= ::m/schema)))
+    (if (and (m/-ref-schema? schema) (-> schema m/deref m/type (= ::m/schema)))
       ?schema [:schema {:registry {::schema ?schema}} ?schema])))
 
 (defn -collect [schema]
@@ -43,7 +43,7 @@
       (m/walk
         schema
         (fn [schema _ _ _]
-          (when-let [to (if (satisfies? m/RefSchema schema) (m/-ref schema))]
+          (when-let [to (if (m/-ref-schema? schema) (m/-ref schema))]
             (swap! links update from (fnil conj #{}) to)))))
     @links))
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -362,6 +362,11 @@
         [:ref {:registry {::a int?, ::b string?}} ::a] 0 "invalid" ::throws
         [:ref {:registry {::a int?, ::b string?}} ::a] 1 ::b ::throws
 
+        [:function [:=> :cat :int] [:=> [:cat :int] :int]] 0 [:=> [:cat :int] :int] ::throws
+        [:function [:=> :cat :int] [:=> [:cat :int] :int]] 3 [:=> [:cat :int :int] :int] ::throws
+        [:function [:=> :cat :int] [:=> [:cat :int] :int]] 1 [:=> [:cat :int :int] :int] [:function [:=> :cat :int] [:=> [:cat :int :int] :int]]
+        [:function [:=> :cat :int] [:=> [:cat :int] :int]] 2 [:=> [:cat :int :int] :int] [:function [:=> :cat :int] [:=> [:cat :int] :int] [:=> [:cat :int :int] :int]]
+
         [:schema string?] 0 int? [:schema 'int?]
         [:schema string?] 0 "invalid" ::throws
         [:schema string?] 1 int? ::throws))))


### PR DESCRIPTION
* faster `m/deref` & `m/deref-all`
* remove all `satisfies?` calls for perf reasons.
* entry schemas can reuse parse results in transformations
* fixed `:function` lenses
* faster entry parsing