### PR TITLE
Move core protocols to new ns

### DIFF
--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -1,5 +1,6 @@
 (ns malli.dot
   (:require [malli.core :as m]
+            [malli.protocols :as p]
             [malli.util :as mu]
             [malli.registry :as mr]
             [clojure.string :as str]))
@@ -43,7 +44,7 @@
       (m/walk
         schema
         (fn [schema _ _ _]
-          (when-let [to (if (m/-ref-schema? schema) (m/-ref schema))]
+          (when-let [to (if (m/-ref-schema? schema) (p/-ref schema))]
             (swap! links update from (fnil conj #{}) to)))))
     @links))
 

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -1,5 +1,6 @@
 (ns malli.json-schema
   (:require [malli.core :as m]
+            [malli.protocols :as p]
             [clojure.set :as set]))
 
 (defprotocol JsonSchema
@@ -9,7 +10,7 @@
 
 (defn -schema [schema {::keys [transform definitions] :as options}]
   (let [result (transform (m/deref schema) options)]
-    (if-let [ref (m/-ref schema)]
+    (if-let [ref (p/-ref schema)]
       (do (swap! definitions assoc ref result) (-ref ref))
       result)))
 
@@ -154,7 +155,7 @@
 
 (defmethod accept :=> [_ _ _ _] {})
 (defmethod accept :function [_ _ _ _] {})
-(defmethod accept :ref [_ schema _ _] (-ref (m/-ref schema)))
+(defmethod accept :ref [_ schema _ _] (-ref (p/-ref schema)))
 (defmethod accept :schema [_ schema _ options] (-schema schema options))
 (defmethod accept ::m/schema [_ schema _ options] (-schema schema options))
 

--- a/src/malli/protocols.cljc
+++ b/src/malli/protocols.cljc
@@ -1,0 +1,54 @@
+(ns malli.protocols
+  (:refer-clojure :exclude [-deref deref]))
+
+(defprotocol IntoSchema
+  (-type [this] "returns type of the schema")
+  (-type-properties [this] "returns schema type properties")
+  (-properties-schema [this options] "maybe returns :map schema describing schema properties")
+  (-children-schema [this options] "maybe returns sequence schema describing schema children")
+  (-into-schema [this properties children options] "creates a new schema instance"))
+
+(defprotocol Schema
+  (-validator [this] "returns a predicate function that checks if the schema is valid")
+  (-explainer [this path] "returns a function of `x in acc -> maybe errors` to explain the errors for invalid values")
+  (-parser [this] "return a function of `x -> parsed-x | ::m/invalid` to explain how schema is valid.")
+  (-unparser [this] "return the inverse (partial) function wrt. `-parser`; `parsed-x -> x | ::m/invalid`")
+  (-transformer [this transformer method options]
+    "returns a function to transform the value for the given schema and method.
+    Can also return nil instead of `identity` so that more no-op transforms can be elided.")
+  (-walk [this walker path options] "walks the schema and it's children, ::m/walk-entry-vals, ::m/walk-refs, ::m/walk-schema-refs options effect how walking is done.")
+  (-properties [this] "returns original schema properties")
+  (-options [this] "returns original options")
+  (-children [this] "returns schema children")
+  (-parent [this] "returns the IntoSchema instance")
+  (-form [this] "returns original form of the schema"))
+
+(defprotocol MapSchema
+  (-entries [this] "returns sequence of `key -val-schema` MapEntries"))
+
+(defprotocol LensSchema
+  (-keep [this] "returns truthy if schema contributes to value path")
+  (-get [this key default] "returns schema at key")
+  (-set [this key value] "returns a copy with key having new value"))
+
+(defprotocol RefSchema
+  (-ref [this] "returns the reference name")
+  (-deref [this] "returns the referenced schema"))
+
+(defprotocol RegexSchema
+  (-regex-op? [this] "is this a regex operator (e.g. :cat, :*...)")
+  (-regex-validator [this] "returns the raw internal regex validator implementation")
+  (-regex-explainer [this path] "returns the raw internal regex explainer implementation")
+  (-regex-unparser [this] "returns the raw internal regex unparser implementation")
+  (-regex-parser [this] "returns the raw internal regex parser implementation")
+  (-regex-transformer [this transformer method options] "returns the raw internal regex transformer implementation")
+  (-regex-min-max [this] "returns size of the sequence as [min max] vector. nil max means unbuond."))
+
+(defprotocol Walker
+  (-accept [this schema path options])
+  (-inner [this schema path options])
+  (-outer [this schema path children options]))
+
+(defprotocol Transformer
+  (-transformer-chain [this] "returns transformer chain as a vector of maps with :name, :encoders, :decoders and :options")
+  (-value-transformer [this schema method options] "returns an value transforming interceptor for the given schema and method"))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -2,6 +2,7 @@
   #?(:cljs (:refer-clojure :exclude [Inst Keyword UUID]))
   (:require #?@(:cljs [[goog.date.UtcDateTime]
                        [goog.date.Date]])
+            [malli.protocols :as p]
             [malli.core :as m])
   #?(:clj (:import (java.util Date UUID)
                    (java.time Instant ZoneId)
@@ -315,14 +316,14 @@
                                           :default default
                                           :key (if name (keyword (str key "/" name)))})
         ->eval (fn [x options] (if (map? x) (reduce-kv (fn [x k v] (assoc x k (m/eval v options))) x x) (m/eval x)))
-        ->chain (m/-comp m/-transformer-chain m/-into-transformer)
+        ->chain (m/-comp p/-transformer-chain m/-into-transformer)
         chain (->> ?transformers (keep identity) (mapcat #(if (map? %) [%] (->chain %))) (vec))
         chain' (->> chain (mapv #(let [name (some-> % :name name)]
                                    {:decode (->data (:decoders %) (:default-decoder %) name "decode")
                                     :encode (->data (:encoders %) (:default-encoder %) name "encode")})))]
     (if (seq chain)
       (reify
-        m/Transformer
+        p/Transformer
         (-transformer-chain [_] chain)
         (-value-transformer [_ schema method options]
           (reduce

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1,5 +1,6 @@
 (ns malli.core-test
   (:require [clojure.test :refer [deftest testing is are]]
+            [malli.protocols :as p]
             [malli.core :as m]
             [malli.edn :as edn]
             [malli.transform :as mt]
@@ -2096,7 +2097,7 @@
 
 (deftest -regex-min-max-size-test
   (are [s min-max]
-    (= min-max ((juxt :min :max) (m/-regex-min-max (m/schema s))))
+    (= min-max ((juxt :min :max) (p/-regex-min-max (m/schema s))))
 
     int? [1 1]
     [:cat] [0 0]
@@ -2121,7 +2122,7 @@
     [:schema {:registry {:named [:cat string? int?]}} [:repeat {:min 5 :max 15} :named]] [10 30])
 
   (is (thrown-with-msg? #?(:clj Exception, :cljs js/Error) #":malli.core/potentially-recursive-seqex"
-                        (m/-regex-min-max
+                        (p/-regex-min-max
                           (m/schema [:schema {:registry {::ints [:cat int? [:ref ::ints]]}}
                                      ::ints])))))
 

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -4,6 +4,7 @@
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check.generators :as gen]
             [malli.json-schema-test :as json-schema-test]
+            [malli.protocols :as p]
             [malli.generator :as mg]
             [malli.core :as m]
             [malli.util :as mu]))
@@ -243,8 +244,8 @@
 (deftest protocol-test
   (let [values #{1 2 3 5 8 13}
         schema (reify
-                 m/Schema
-                 (-parent [_] (reify m/IntoSchema (-type-properties [_])))
+                 p/Schema
+                 (-parent [_] (reify p/IntoSchema (-type-properties [_])))
                  (-properties [_])
                  mg/Generator
                  (-generator [_ _] (gen/elements values)))]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest testing is are]]
             [malli.core-test]
             [malli.json-schema :as json-schema]
+            [malli.protocols :as p]
             [malli.core :as m]
             [malli.util :as mu]))
 
@@ -81,12 +82,12 @@
        :cljs [])
    ;; protocols
    [(reify
-      m/Schema
+      p/Schema
       (-properties [_])
-      (-parent [_] (reify m/IntoSchema (-type [_]) (-type-properties [_])))
+      (-parent [_] (reify p/IntoSchema (-type [_]) (-type-properties [_])))
       (-form [_])
       (-validator [_] int?)
-      (-walk [t w p o] (m/-outer w t p nil o))
+      (-walk [t w p o] (p/-outer w t p nil o))
       json-schema/JsonSchema
       (-accept [_ _ _] {:type "custom"})) {:type "custom"}]
    ;; type-properties

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer [deftest testing is are]]
             [malli.core-test]
             [malli.swagger :as swagger]
+            [malli.protocols :as p]
             [malli.core :as m]
             [malli.util :as mu]))
 
@@ -82,12 +83,12 @@
        :cljs [])
    ;; protocols
    [(reify
-      m/Schema
+      p/Schema
       (-properties [_])
-      (-parent [_] (reify m/IntoSchema (-type [_]) (-type-properties [_])))
+      (-parent [_] (reify p/IntoSchema (-type [_]) (-type-properties [_])))
       (-form [_])
       (-validator [_] int?)
-      (-walk [t w p o] (m/-outer w t p nil o))
+      (-walk [t w p o] (p/-outer w t p nil o))
       swagger/SwaggerSchema
       (-accept [_ _ _] {:type "custom"})) {:type "custom"}]
    ;; type-properties

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -1,5 +1,6 @@
 (ns malli.transform-test
   (:require [clojure.test :refer [deftest testing is are]]
+            [malli.protocols :as p]
             [malli.core :as m]
             [malli.transform :as mt]
             [malli.core-test]
@@ -379,7 +380,7 @@
                                   {:opts {:random :opts}})]
 
     (testing "transformer chain has 4 transformers"
-      (is (= 3 (count (m/-transformer-chain strict-json-transformer)))))
+      (is (= 3 (count (p/-transformer-chain strict-json-transformer)))))
 
     (testing "decode"
       (is (= :kikka (m/decode keyword? "kikka" strict-json-transformer)))


### PR DESCRIPTION
Open questions:
What to do with instance check predicates? Some are in protocols ns, some in core.

Possible solution:
Move regex protocol extension back to core.

Prerequisite for #545 and many more(?)