### PR TITLE
Min version required for PlantUML

### DIFF
--- a/README.md
+++ b/README.md
@@ -2086,6 +2086,8 @@ Visualized with [Graphviz](https://graphviz.org/):
 
 ### PlantUML
 
+Added in version 0.6.
+
 Transforming Schemas into [PlantUML](https://plantuml.com/):
 
 ```clj


### PR DESCRIPTION
I was on 0.5.1 and then had a class path error when calling `(require '[malli.plantuml :as plantuml])`. Then, I figured out it was added in 0.6.