### PR TITLE
allow swapping the default registry without tears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,11 +129,35 @@ New optimized map-syntax to super-fast schema creation, see [README](README.md#m
 
 Will fully replace the old map-syntax at some point.
 
+## Swappable default registry
+
+No need to play with Compiler options or JVM properties to swap the default registry (only if you want to get DCE on CLJS with small set of schemas). Can be disabled with new `malli.registry/mode=strict` option.
+
+```clj
+(require '[malli.core :as m]
+         '[malli.util :as mu]
+         '[malli.registry :as mr]
+         '[malli.generator :as mg])
+
+;; look ma, just works
+(mr/set-default-registry!
+  (mr/composite-registry
+    (m/default-schemas)
+    (mu/schemas)))
+
+(mg/generate
+  [:merge
+   [:map [:x :int]]
+   [:map [:y :int]]])
+; => {:x 0, :y 92}
+```
+
 ### Public API
 
 * **BREAKING**: `m/explain` `:errors` are plain maps, not `Error` records.
 * **BREAKING**: `malli.provider/schema` is moved into extender API: `malli.provider/-schema`
 * **BREAKING**: strings generate alphanumeric chars by default
+* configure default registry in less invasive manner, [#488](https://github.com/metosin/malli/issues/488)
 * `nil` is a valid default with `mt/default-value-transformer` [#576](https://github.com/metosin/malli/issues/576)
 * fixed `:schema` explain path, [#573](https://github.com/metosin/malli/issues/573)
 * fixed `:enum` explain path, [#553](https://github.com/metosin/malli/issues/553)

--- a/README.md
+++ b/README.md
@@ -1990,8 +1990,6 @@ With this, you can register just what you need and rest are DCE'd. The previous 
 
 Malli supports multiple type of registries.
 
-Since 0.7.0, one can set up the default re
-
 ### Immutable registry
 
 Just just a `Map`.

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2360,12 +2360,13 @@
   (merge (predicate-schemas) (class-schemas) (comparator-schemas) (type-schemas) (sequence-schemas) (base-schemas)))
 
 (def default-registry
-  (mr/registry (cond (identical? mr/type "default") (mr/fast-registry (default-schemas))
-                     (identical? mr/type "custom") (mr/custom-default-registry)
-                     :else (-fail! ::invalid-registry.type {:type mr/type}))))
+  (let [strict (identical? mr/mode "strict")
+        registry (mr/fast-registry (if (identical? mr/type "custom") {} (default-schemas)))]
+    (when-not strict (mr/set-default-registry! registry))
+    (mr/registry (if strict registry (mr/custom-default-registry)))))
 
 ;;
-;; function schemas (alpha, subject to change)
+;; function schemas
 ;;
 
 (defonce ^:private -function-schemas* (atom {}))

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -42,13 +42,13 @@
 (defn set-default-registry! [?registry]
   (if-not (identical? mode "strict")
     (reset! registry* (registry ?registry))
-    (throw (ex-info "can't set default registry, invalid mode" {:mode mode, :type type})))
+    (throw (ex-info "can't set default registry, invalid mode" {:mode mode, :type type}))))
 
-  (defn ^:no-doc custom-default-registry []
-    (reify
-      Registry
-      (-schema [_ type] (-schema @registry* type))
-      (-schemas [_] (-schemas @registry*)))))
+(defn ^:no-doc custom-default-registry []
+  (reify
+    Registry
+    (-schema [_ type] (-schema @registry* type))
+    (-schemas [_] (-schemas @registry*))))
 
 (defn composite-registry [& ?registries]
   (let [registries (mapv registry ?registries)]


### PR DESCRIPTION
```clj
(require '[malli.core :as m]
         '[malli.util :as mu]
         '[malli.registry :as mr]
         '[malli.generator :as mg])

;; look ma, just works
(mr/set-default-registry!
  (mr/composite-registry
    (m/default-schemas)
    (mu/schemas)))

(mg/generate
  [:merge
   [:map [:x :int]]
   [:map [:y :int]]])
; => {:x 0, :y 92}
```