### PR TITLE
refine clj-kondo's sequential spec

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -114,15 +114,9 @@
 (defmethod accept :schema [_ schema _ options] (transform (m/deref schema) options))
 (defmethod accept ::m/schema [_ schema _ options] (transform (m/deref schema) options))
 
-(defn rest-transform [child]
-  (cond
-    (vector? child) :any
-    (map? child) :any
-    :else (transform child)))
-
-(defmethod accept :+ [_ _ [child] _] {:op :rest, :spec (rest-transform child)})
-(defmethod accept :* [_ _ [child] _] {:op :rest, :spec (rest-transform child)})
-(defmethod accept :repeat [_ _ [child] _] {:op :rest, :spec (rest-transform child)})
+(defmethod accept :+ [_ _ [child] _] {:op :rest, :spec child})
+(defmethod accept :* [_ _ [child] _] {:op :rest, :spec child})
+(defmethod accept :repeat [_ _ [child] _] {:op :rest, :spec child})
 (defmethod accept :cat [_ _ children _] children)
 (defmethod accept :catn [_ _ children _] (mapv last children))
 

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -114,9 +114,15 @@
 (defmethod accept :schema [_ schema _ options] (transform (m/deref schema) options))
 (defmethod accept ::m/schema [_ schema _ options] (transform (m/deref schema) options))
 
-(defmethod accept :+ [_ _ [child] _] {:op :rest, :spec (transform child)})
-(defmethod accept :* [_ _ [child] _] {:op :rest, :spec (transform child)})
-(defmethod accept :repeat [_ _ [child] _] {:op :rest, :spec (transform child)})
+(defn rest-transform [child]
+  (cond
+    (vector? child) :any
+    (map? child) :any
+    :else (transform child)))
+
+(defmethod accept :+ [_ _ [child] _] {:op :rest, :spec (rest-transform child)})
+(defmethod accept :* [_ _ [child] _] {:op :rest, :spec (rest-transform child)})
+(defmethod accept :repeat [_ _ [child] _] {:op :rest, :spec (rest-transform child)})
 (defmethod accept :cat [_ _ children _] children)
 (defmethod accept :catn [_ _ children _] (mapv last children))
 

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -1,5 +1,5 @@
 (ns malli.clj-kondo-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [malli.clj-kondo :as clj-kondo]
             [malli.core :as m]
             [malli.util :as mu]))
@@ -65,4 +65,11 @@
             (-> 'malli.clj-kondo-test
                 (clj-kondo/collect)
                 (clj-kondo/linter-config)
-                (get-in [:linters :type-mismatch :namespaces]))))))
+                (get-in [:linters :type-mismatch :namespaces])))))
+  (testing "sequential elements"
+    (is (= {:op :rest :spec :int}
+           (clj-kondo/transform [:repeat :int])))
+    (is (= {:op :rest :spec :any}
+           (clj-kondo/transform [:repeat [:map [:price :int]]])))
+    (is (= {:op :rest :spec :any}
+           (clj-kondo/transform [:repeat [:tuple :int]])))))

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -69,7 +69,7 @@
   (testing "sequential elements"
     (is (= {:op :rest :spec :int}
            (clj-kondo/transform [:repeat :int])))
-    (is (= {:op :rest :spec :any}
+    (is (= {:op :rest :spec {:op :keys :req {:price :int}}}
            (clj-kondo/transform [:repeat [:map [:price :int]]])))
-    (is (= {:op :rest :spec :any}
+    (is (= {:op :rest :spec [:int]}
            (clj-kondo/transform [:repeat [:tuple :int]])))))


### PR DESCRIPTION
related with : https://github.com/metosin/malli/issues/585

Now, `malli.clj-kondo` and also `malli.dev` will cause error when we wrote the sequential spec have map / tuple spec.

e.g.
 
```clojure
(def Item [:map [:name :string] [:price :int]])
(def ItemList [:+ Item])
(clj-kondo/transform ItemList) ;; will cause error
```

so that, I propose the temporary fix and also, some tests to fix them.