### PR TITLE
include decimal? in clojure specific predicate-schemas

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2238,7 +2238,7 @@
           #'qualified-keyword? #'symbol? #'simple-symbol? #'qualified-symbol? #'uuid? #'uri? #'inst? #'seqable?
           #'indexed? #'map? #'vector? #'list? #'seq? #'char? #'set? #'nil? #'false? #'true?
           #'zero? #'coll? [#'empty? -safe-empty?] #'associative? #'sequential? #'ifn? #'fn?
-          #?@(:clj [#'rational? #'rational? #'ratio? #'bytes?])]
+          #?@(:clj [#'rational? #'rational? #'ratio? #'bytes? #'decimal?])]
          (reduce -register-var {}))))
 
 (defn class-schemas []


### PR DESCRIPTION
In a [previous change](https://github.com/metosin/malli/commit/5deae59357b2eb3fb9890282e679bb2d7fa557e3#diff-c10cf1bd7f29baf493dfd1fb727c955f2bf09a256cdc7ff690343b5940f14940L2231), `decimal?` was accidentally removed the list of `predicate-schemas`.  Merging this PR will add it back. 

I wasn't sure where to add a test to ensure this doesn't get accidentally removed later. The test would like 

```clojure
#?(:clj (is (true? (m/validate decimal? 13.9M)))
```