### PR TITLE
type-hints for :map-of inferring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,23 @@ Malli is in [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* `:map-of` provider understands `:maybe` and optional keys
+* `:map-of` inferring can be forced with `:malli.provider/hint :map-of` meta-data:
+
+```clj
+(require '[malli.provider :as mp])
+
+(mp/provide
+  [^{::mp/hint :map-of}
+   {:a {:b 1, :c 2}
+    :b {:b 2, :c 1}
+    :c {:b 3}
+    :d nil}])
+;[:map-of
+; keyword?
+; [:maybe [:map
+;          [:b int?]
+;          [:c {:optional true} int?]]]]
+```
 
 ## 0.7.2 (2021-12-12)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* `:map-of` provider understands `:maybe` and optional keys
+
 ## 0.7.2 (2021-12-12)
 
 * FIX Function with Sequential return value cannot define as function schema [#585](https://github.com/metosin/malli/issues/585)

--- a/README.md
+++ b/README.md
@@ -1463,6 +1463,49 @@ For order of magnitude better performance, use `mp/provider` instead:
   (p/bench (provider [1 2 3])))
 ```
 
+Inferring `:map-of` required 3 identical key & value schemas:
+
+```clj
+(mp/provide
+  [{:a [1]
+    :b [1 2]}])
+;[:map 
+; [:a [:vector int?]] 
+; [:b [:vector int?]]]
+
+(mp/provide
+  [{:a [1]
+    :b [1 2]
+    :c [1 2 3]}])
+; [:map-of keyword? [:vector int?]]
+```
+
+This can be configured via `::mp/map-of-threshold` options:
+
+```clj
+(mp/provide
+  [{:a [1]
+    :b [1 2]}]
+  {::mp/map-of-threshold 2})
+; [:map-of keyword? [:vector int?]]
+```
+
+Sample-data can be type-hinted with `::mp/hint`:
+
+```clj
+(mp/provide
+  [^{::mp/hint :map-of}
+   {:a {:b 1, :c 2}
+    :b {:b 2, :c 1}
+    :c {:b 3}
+    :d nil}])
+;[:map-of
+; keyword?
+; [:maybe [:map
+;          [:b int?]
+;          [:c {:optional true} int?]]]]
+```
+
 ## Parsing values
 
 Schemas can be used to parse values using `m/parse` and `m/parser`:

--- a/src/malli/provider.cljc
+++ b/src/malli/provider.cljc
@@ -33,7 +33,7 @@
               (#{:set :vector :sequential} type) (update-in [:types type :values] (fnil (infer-seq infer) {}) x))
             (cond-> hint (update-in [:types type :hints] (fnil conj #{}) hint)))))))
 
-(defn -map-schema [{tc :count :as stats} schema {::keys [infer map-of-threshold] :or {map-of-threshold 8} :as options}]
+(defn -map-schema [{tc :count :as stats} schema {::keys [infer map-of-threshold] :or {map-of-threshold 3} :as options}]
   (let [entries (map (fn [[key vstats]] {:key key, :vs (schema vstats options), :vc (:count vstats)}) (:keys stats))
         kschema* (delay (schema (reduce infer {} (map :key entries)) options))
         ?kschema* (delay (let [kschemas (map (fn [{:keys [key]}] (schema (infer {} key) options)) entries)]
@@ -78,7 +78,7 @@
 (defn provider
   "Returns a inferring function of `values -> schema`. Supports the following options:
 
-  - `:malli.provider/map-of-threshold, how many identical value schemas need for :map-of"
+  - `:malli.provider/map-of-threshold (default 3), how many identical value schemas need for :map-of"
   ([] (provider nil))
   ([options] (let [infer (-inferrer options)]
                (fn [xs] (-> (reduce infer {} xs) (-schema (assoc options ::infer infer)))))))

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -23,6 +23,26 @@
    [[:maybe [:map [:x int?]]] [{:x 1} nil]]
    [[:maybe [:or [:map [:x int?]] string?]] [{:x 1} nil "1"]]
 
+   ;; :maybe and optional keys with :map-of
+   [[:map-of keyword? [:maybe [:map [:b int?] [:c {:optional true} int?]]]]
+    [{:a {:b 1, :c 2}
+      :b {:b 2, :c 1}
+      :c {:b 3}
+      :d nil}]]
+   [[:map [:a [:map
+               [:b int?]
+               [:c int?]]]
+     [:b [:map
+          [:b int?]
+          [:c int?]]]
+     [:c [:map
+          [:b int?]]]
+     [:d string?]]
+    [{:a {:b 1, :c 2}
+           :b {:b 2, :c 1}
+           :c {:b 3}
+           :d "whatever"}]]
+
    [[:map
      ["kikka" [:map [:name string?]]]
      ["kakka" [:map [:name string?]]]]

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -51,27 +51,22 @@
 
    ;; too few samples for :map-of
    [[:map
-     ["kikka" [:map [:name string?]]]
-     ["kakka" [:map [:name string?]]]]
-    [{"kikka" {:name "kikka"}
-      "kakka" {:name "kakka"}}]]
+     ["1" [:map [:name string?]]]
+     ["2" [:map [:name string?]]]]
+    [{"1" {:name "1"}
+      "2" {:name "2"}}]]
 
    ;; explicit sample count for :map-of
    [[:map-of string? [:map [:name string?]]]
-    [{"kikka" {:name "kikka"}
-      "kukka" {:name "kukka"}}]
+    [{"1" {:name "1"}
+      "2" {:name "2"}}]
     {::mp/map-of-threshold 2}]
 
    ;; implicit sample count for :map-of
    [[:map-of string? [:map [:name string?]]]
     [{"1" {:name "1"}
       "2" {:name "2"}
-      "3" {:name "3"}
-      "4" {:name "4"}
-      "5" {:name "5"}
-      "6" {:name "6"}
-      "7" {:name "7"}
-      "8" {:name "8"}}]]
+      "3" {:name "3"}}]]
 
    [[:map
      [:id string?]

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -23,39 +23,55 @@
    [[:maybe [:map [:x int?]]] [{:x 1} nil]]
    [[:maybe [:or [:map [:x int?]] string?]] [{:x 1} nil "1"]]
 
-   ;; :maybe and optional keys with :map-of
-   [[:map-of keyword? [:maybe [:map [:b int?] [:c {:optional true} int?]]]]
-    [{:a {:b 1, :c 2}
-      :b {:b 2, :c 1}
-      :c {:b 3}
-      :d nil}]]
-   [[:map [:a [:map
-               [:b int?]
-               [:c int?]]]
+   ;; normal maps without type-hint
+   [[:map
+     [:a [:map
+          [:b int?]
+          [:c int?]]]
      [:b [:map
           [:b int?]
           [:c int?]]]
      [:c [:map
           [:b int?]]]
-     [:d string?]]
+     [:d :nil]]
     [{:a {:b 1, :c 2}
-           :b {:b 2, :c 1}
-           :c {:b 3}
-           :d "whatever"}]]
+      :b {:b 2, :c 1}
+      :c {:b 3}
+      :d nil}]]
 
+   ;; :map-of type-hint
+   [[:map-of keyword? [:maybe [:map
+                               [:b int?]
+                               [:c {:optional true} int?]]]]
+    [^{::mp/hint :map-of}
+     {:a {:b 1, :c 2}
+      :b {:b 2, :c 1}
+      :c {:b 3}
+      :d nil}]]
+
+   ;; too few samples for :map-of
    [[:map
      ["kikka" [:map [:name string?]]]
      ["kakka" [:map [:name string?]]]]
     [{"kikka" {:name "kikka"}
       "kakka" {:name "kakka"}}]]
+
+   ;; explicit sample count for :map-of
    [[:map-of string? [:map [:name string?]]]
     [{"kikka" {:name "kikka"}
       "kukka" {:name "kukka"}}]
     {::mp/map-of-threshold 2}]
+
+   ;; implicit sample count for :map-of
    [[:map-of string? [:map [:name string?]]]
-    [{"kikka" {:name "kikka"}
-      "kukka" {:name "kukka"}
-      "kakka" {:name "kakka"}}]]
+    [{"1" {:name "1"}
+      "2" {:name "2"}
+      "3" {:name "3"}
+      "4" {:name "4"}
+      "5" {:name "5"}
+      "6" {:name "6"}
+      "7" {:name "7"}
+      "8" {:name "8"}}]]
 
    [[:map
      [:id string?]


### PR DESCRIPTION
### Original Idea

```clj
(require '[malli.provider :as mp])

(mp/provide
  [{:a {:b 1, :c 2}
    :b {:b 2, :c 1}
    :c {:b 3}
    :d nil}])
;[:map-of 
; keyword? 
; [:maybe 
;  [:map [:b int?]
;   [:c {:optional true} int?]]]]
```

... was bad as it reads data too easily into `:map-of`. After thinking how to make the guessing robust, decided just to enable meta-data based hinting allowing the user to be in control of things:

### Implementation

```clj
(require '[malli.provider :as mp])

;; without typehints
(mp/provide
  [{:a {:b 1, :c 2}
    :b {:b 2, :c 1}
    :c {:b 3}
    :d nil}])
;[:map
; [:a [:map 
;      [:b int?] 
;      [:c int?]]] 
; [:b [:map 
;      [:b int?] 
;      [:c int?]]] 
; [:c [:map 
;      [:b int?]]] 
; [:d :nil]]

;; with typehints
(mp/provide
  [^{::mp/hint :map-of}
   {:a {:b 1, :c 2}
    :b {:b 2, :c 1}
    :c {:b 3}
    :d nil}])
;[:map-of
; keyword?
; [:maybe [:map
;          [:b int?]
;          [:c {:optional true} int?]]]]
```