### PR TITLE
support for value-decoders in inferring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* schema inferring supports value decoding via options
+
+```clj
+(mp/provide
+ [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
+  {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
+ {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}})
+; => [:map [:id :uuid]]
+```
+
 ## 0.7.3 (2021-12-15)
 
 * `:map-of` inferring can be forced with `:malli.provider/hint :map-of` meta-data:

--- a/README.md
+++ b/README.md
@@ -1533,6 +1533,27 @@ Sample-data can be type-hinted with `::mp/hint`:
 ; [:tuple some? string? boolean?]
 ```
 
+### decoding in value inffering
+
+By default, no decoding is applied for (leaf) values:
+
+```clj
+(mp/provide
+ [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
+  {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}])
+; => [:map [:id string?]]
+```
+
+Adding custom decoding via `::mp/value-decoders` option:
+
+```clj
+(mp/provide
+ [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
+  {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
+ {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}})
+; => [:map [:id :uuid]]
+```
+
 ## Parsing values
 
 Schemas can be used to parse values using `m/parse` and `m/parser`:

--- a/README.md
+++ b/README.md
@@ -1533,7 +1533,7 @@ Sample-data can be type-hinted with `::mp/hint`:
 ; [:tuple some? string? boolean?]
 ```
 
-### decoding in value inffering
+### value decoding in inferring
 
 By default, no decoding is applied for (leaf) values:
 

--- a/src/malli/provider.cljc
+++ b/src/malli/provider.cljc
@@ -64,11 +64,11 @@
 
 (defn -schema
   ([stats] (-schema stats nil))
-  ([{:keys [types] :as stats} {::keys [value-providers] :as options}]
+  ([{:keys [types] :as stats} {::keys [value-decoders] :as options}]
    (cond (= 1 (count (keys types))) (let [type (-> types keys first)]
                                       (case type
                                         :nil :nil
-                                        :value (let [t (type types), vs (-value-schema t), vp (get value-providers vs)]
+                                        :value (let [t (type types), vs (-value-schema t), vp (get value-decoders vs)]
                                                  (cond->> vs vp (-decoded t vp)))
                                         (:set :vector :sequential) (-sequential-schema stats type -schema options)
                                         :map (-map-schema (type types) -schema options)))
@@ -88,7 +88,8 @@
   "Returns a inferring function of `values -> schema`. Supports the following options:
 
   - `:malli.provider/map-of-threshold (default 3), how many identical value schemas need for :map-of
-  - `:malli.provider/tuple-threshold (default 3), how many identical value schemas need for :tuple"
+  - `:malli.provider/tuple-threshold (default 3), how many identical value schemas need for :tuple
+  - `:malli.provider/value-decoders, function of `type -> target-type -> value -> decoded-value`"
   ([] (provider nil))
   ([options] (let [infer (-inferrer options)]
                (fn [xs] (-> (reduce infer {} xs) (-schema (assoc options ::infer infer)))))))

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -1,7 +1,8 @@
 (ns malli.provider-test
   (:require [clojure.test :refer [deftest testing is]]
             [malli.provider :as mp]
-            [malli.core :as m])
+            [malli.core :as m]
+            [malli.transform :as mt])
   #?(:clj (:import (java.util UUID Date))))
 
 (def expectations
@@ -105,6 +106,15 @@
    [[:vector some?]
     [^{::mp/hint :tuple} [1 "kikka" true]
      [2 "kukka" true "invalid tuple"]]]
+
+   ;; value-providers
+   [[:map [:id string?]]
+    [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
+     {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]]
+   [[:map [:id :uuid]]
+    [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
+     {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
+    {::mp/value-providers {'string? {:uuid mt/-string->uuid}}}]
 
    [[:map
      [:id string?]

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -107,19 +107,19 @@
     [^{::mp/hint :tuple} [1 "kikka" true]
      [2 "kukka" true "invalid tuple"]]]
 
-   ;; value-providers
+   ;; value-decoders
    [[:map [:id string?]]
     [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
      {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]]
    [[:map [:id :uuid]]
     [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
      {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
-    {::mp/value-providers {'string? {:uuid mt/-string->uuid}}}]
+    {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}}]
    [[:map-of :uuid [:map [:id :uuid]]]
     [{"0423191a-5fee-11ec-bf63-0242ac130002" {:id "0423191a-5fee-11ec-bf63-0242ac130002"}
       "09e59de6-5fee-11ec-bf63-0242ac130002" {:id "09e59de6-5fee-11ec-bf63-0242ac130002"}
       "15511020-5fee-11ec-bf63-0242ac130002" {:id "15511020-5fee-11ec-bf63-0242ac130002"}}]
-    {::mp/value-providers {'string? {:uuid mt/-string->uuid}}}]
+    {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}}]
 
    [[:map
      [:id string?]

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -115,6 +115,11 @@
     [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
      {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
     {::mp/value-providers {'string? {:uuid mt/-string->uuid}}}]
+   [[:map-of :uuid [:map [:id :uuid]]]
+    [{"0423191a-5fee-11ec-bf63-0242ac130002" {:id "0423191a-5fee-11ec-bf63-0242ac130002"}
+      "09e59de6-5fee-11ec-bf63-0242ac130002" {:id "09e59de6-5fee-11ec-bf63-0242ac130002"}
+      "15511020-5fee-11ec-bf63-0242ac130002" {:id "15511020-5fee-11ec-bf63-0242ac130002"}}]
+    {::mp/value-providers {'string? {:uuid mt/-string->uuid}}}]
 
    [[:map
      [:id string?]


### PR DESCRIPTION
```clj
(require '[malli.provider :as mp])
(require '[malli.transform :as mt])

(mp/provide
 [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
  {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}])
; => [:map [:id string?]]

(mp/provide
 [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
  {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
 {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}})
; => [:map [:id :uuid]]

(mp/provide
 [{"0423191a-5fee-11ec-bf63-0242ac130002" {:id "0423191a-5fee-11ec-bf63-0242ac130002"}
   "09e59de6-5fee-11ec-bf63-0242ac130002" {:id "09e59de6-5fee-11ec-bf63-0242ac130002"}
   "15511020-5fee-11ec-bf63-0242ac130002" {:id "15511020-5fee-11ec-bf63-0242ac130002"}}]
 {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}})
; => [:map-of :uuid [:map [:id :uuid]]]
```