### PR TITLE
Use Fipp for fast pretty-printing clj-kondo config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Malli is in well matured [alpha](README.md#alpha).
 ## UNRELEASED
 
 * [clj-kondo 2021.12.16+](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md#20211216) can load malli type configs automatically from new location (`.clj-kondo/metosin/malli-types/config.edn`)
+* use [fipp](https://github.com/brandonbloom/fipp) for fast pretty-printing the clj-kondo configs
 * updated dependencies:
 
 ```clj

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -1,5 +1,6 @@
 (ns malli.clj-kondo
   (:require #?(:clj [clojure.java.io :as io])
+            [fipp.edn :as fipp]
             [malli.core :as m]))
 
 (declare transform)
@@ -151,7 +152,7 @@
        ;; delete the old file if exists (does not throw)
        (.delete (io/file ".clj-kondo" "configs" "malli" "config.edn"))
        (io/make-parents cfg-file)
-       (spit cfg-file config)
+       (spit cfg-file (with-out-str (fipp/pprint config {:width 120})))
        config)))
 
 (defn from [{:keys [schema ns name]}]


### PR DESCRIPTION
example:

```clj
{:linters {:unresolved-symbol {:exclude [(malli.core/=>)]},
           :type-mismatch {:namespaces {malli.clj-kondo-test {kikka {:arities {1 {:args [:int], :ret :int},
                                                                               :varargs {:args [:int
                                                                                                :int
                                                                                                {:op :rest, :spec :int}],
                                                                                         :ret :int,
                                                                                         :min-arity 2}}},
                                                              siren {:arities {2 {:args [:ifn :coll], :ret :map}}}}}}}}
```