### PR TITLE
Add instrumentation and clj-kondo support for ClojureScript

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If you have questions about contributing or about malli in general, join the [#m
 * Create a topic branch from where you want to base your work (usually the master branch)
 * Check the formatting rules from existing code (no trailing whitespace, mostly default indentation)
 * Ensure any new code is well-tested, and if possible, any issue fixed is covered by one or more new tests
-* Verify that all tests pass using `./bin/kaocha`
+* Verify that all tests pass using `./bin/kaocha` and `./bin/node`
 * Push your code to your fork of the repository
 * Make a Pull Request
 

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -1,4 +1,5 @@
 (ns malli.clj-kondo
+  #?(:cljs (:require-macros [malli.clj-kondo]))
   (:require #?(:clj [clojure.java.io :as io])
             [fipp.edn :as fipp]
             [malli.core :as m]))
@@ -175,15 +176,18 @@
   ([] (collect nil))
   ([ns]
    (let [-collect (fn [k] (or (nil? ns) (= k (symbol (str ns)))))]
-     (->> (for [[k vs] (m/function-schemas) :when (-collect k) [_ v] vs v (from v)] v)))))
+     (for [[k vs] (m/function-schemas) :when (-collect k) [_ v] vs v (from v)] v))))
 
 (defn linter-config [xs]
   (reduce
     (fn [acc {:keys [ns name arity] :as data}]
       (assoc-in
-        acc [:linters :type-mismatch :namespaces (symbol (str ns)) name :arities arity]
+        acc [:linters :type-mismatch :namespaces ns name :arities arity]
         (select-keys data [:args :ret :min-arity])))
     {:linters {:unresolved-symbol {:exclude ['(malli.core/=>)]}}} xs))
 
 #?(:clj
    (defn emit! [] (-> (collect) (linter-config) (save!)) nil))
+
+#?(:clj
+   (defmacro emit-cljs! [] (emit!)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2387,6 +2387,9 @@
      (let [name' `'~(symbol (str name))
            ns' `'~(symbol (str *ns*))
            sym `'~(symbol (str *ns*) (str name))]
+       ;; in cljs we need to register the schema in clojure (the cljs compiler) so it is visible in the -function-schemas* map at macroexpansion time.
+       (when (some? (:ns &env))
+         (-register-function-schema! (symbol (str *ns*)) name value (meta name)))
        `(do (-register-function-schema! ~ns' ~name' ~value ~(meta name)) ~sym))))
 
 (defn -instrument

--- a/src/malli/dev/cljs.clj
+++ b/src/malli/dev/cljs.clj
@@ -1,0 +1,27 @@
+(ns malli.dev.cljs
+  (:require
+    [malli.clj-kondo :as clj-kondo]
+    [malli.instrument.cljs :as mi]))
+
+(defmacro stop!
+  "Stops instrumentation for all functions vars and removes clj-kondo type annotations."
+  []
+  `(do
+     ~(mi/unstrument* nil)
+     ~(do (clj-kondo/save! {}) nil)))
+
+(defmacro start!
+  "Collects defn schemas from all loaded namespaces and starts instrumentation for
+   a filtered set of function Vars (e.g. `defn`s). See [[malli.core/-instrument]] for possible options.
+   Also emits clj-kondo type annotations.
+   This does NOT re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
+  [options]
+  `(do
+     ~(mi/unstrument* nil)
+     ~(do (clj-kondo/save! {}) nil)
+     ;; malli.dev/stop ^^
+
+     ;; register all function schemas and instrument them based on the options
+     ~(mi/collect-all-ns*)
+     ~(mi/instrument* options)
+     ~(do (clj-kondo/emit!) nil)))

--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -1,0 +1,156 @@
+(ns malli.instrument.cljs
+  (:require
+    [cljs.analyzer.api :as ana-api]
+    [malli.core :as m]
+    [malli.generator :as mg]))
+
+;;
+;; instrument
+;;
+
+(defn emit-instrument-fn [{:keys [gen filters] :as instrument-opts} {:keys [schema] :as schema-map} ns-sym fn-sym]
+  ;; gen is a function
+  (let [schema-map (assoc (select-keys schema-map [:gen :scope :report])
+                     ;; At macroexpansion time the schema will be a JVM object, this converts it to a JS object.
+                     :schema `(m/function-schema ~(m/form schema)))
+        schema-map-with-gen
+                   (as-> (merge (select-keys instrument-opts [:scope :report :gen]) schema-map) $
+                     ;; use the passed in gen fn to generate a value
+                     (cond (and gen (true? (:gen schema-map))) (assoc $ :gen gen)
+                           :else (dissoc $ :gen)))
+        replace-var-code
+                   `(do
+                      (swap! instrumented-vars #(assoc % '~fn-sym ~fn-sym))
+                      (set! ~fn-sym (m/-instrument ~schema-map-with-gen ~fn-sym))
+                      (.log js/console "..instrumented" '~fn-sym)
+                      '~fn-sym)]
+    (if filters
+      `(when (some #(% '~ns-sym (var ~fn-sym) ~schema-map) ~filters)
+         ~replace-var-code)
+      replace-var-code)))
+
+(defn instrument*
+  [{:keys [data] :or {data (m/function-schemas)} :as opts}]
+  (let [r
+        (reduce
+          (fn [acc [ns-sym sym-map]]
+            (reduce-kv
+              (fn [acc' fn-sym schema-map]
+                (conj acc'
+                  (emit-instrument-fn opts schema-map ns-sym (symbol (str ns-sym) (str fn-sym)))))
+              acc sym-map))
+          []
+          data)]
+    `(filterv some? ~r)))
+
+(defmacro instrument!
+  "Applies instrumentation for a filtered set of function Vars (e.g. `defn`s).
+   See [[malli.core/-instrument]] for possible options."
+  ([] (instrument* {}))
+  ([opts] (instrument* opts)))
+
+;;
+;; unstrument
+;;
+
+(defn emit-unstrument-fn [{:keys [schema filters] :as opts} ns-sym fn-sym]
+  (let [opts (assoc (select-keys opts [:gen :scope :report])
+               ;; At macroexpansion time the schema will be a JVM object, this converts it to a JS object.
+               :schema `(m/function-schema ~(m/form schema)))
+        replace-with-orig
+             `(when-let [orig-fn# (get @instrumented-vars '~fn-sym)]
+                (swap! instrumented-vars #(dissoc % '~fn-sym))
+                (set! ~fn-sym orig-fn#)
+                (.log js/console "..unstrumented" '~fn-sym)
+                '~fn-sym)]
+    (if filters
+      `(when (some #(% ~ns-sym (var ~fn-sym) ~opts) ~filters)
+         ~replace-with-orig)
+      replace-with-orig)))
+
+(defn unstrument*
+  [opts]
+  (let [r (reduce
+            (fn [acc [ns-sym sym-map]]
+              (reduce-kv
+                (fn [acc' fn-sym schema-map]
+                  (conj acc'
+                    (emit-unstrument-fn (assoc opts :schema (:schema schema-map))
+                      ns-sym
+                      (symbol
+                        (str ns-sym) (str fn-sym)))))
+                acc sym-map))
+            []
+            (m/function-schemas))]
+    `(filterv some? ~r)))
+
+(defmacro unstrument!
+  "Removes instrumentation from a filtered set of function Vars (e.g. `defn`s).
+   See [[malli.core/-instrument]] for possible options."
+  ([] (unstrument* {}))
+  ([opts] (unstrument* opts)))
+
+;;
+;; Collect schemas - register them into the known malli.core/-function-schemas* atom based on their metadata.
+;;
+
+(defn -collect! [simple-name {:keys [meta] :as var-map}]
+  (let [ns     (symbol (namespace (:name var-map)))
+        schema (:malli/schema meta)]
+    (when schema
+      (m/-register-function-schema! ns simple-name schema (m/-unlift-keys meta "malli"))
+      `(do (m/-register-function-schema! '~ns '~simple-name ~schema ~(m/-unlift-keys meta "malli"))
+           '~(:name var-map)))))
+
+(defn -sequential [x] (cond (set? x) x (sequential? x) x :else [x]))
+
+(defmacro collect!
+  "Reads all public Vars from a given namespace(s) and registers a function (var) schema if `:malli/schema`
+   metadata is present. The following metadata key can be used:
+
+   | key             | description |
+   | ----------------|-------------|
+   | `:malli/schema` | function schema
+   | `:malli/scope`  | optional set of scope definitions, defaults to `#{:input :output}`
+   | `:malli/report` | optional side-effecting function of `key data -> any` to report problems, defaults to `m/-fail!`
+   | `:malli/gen`    | optional value `true` or function of `schema -> schema -> value` to be invoked on the args to get the return value"
+  ([] `(collect! ~{:ns (symbol (str *ns*))}))
+  ([{:keys [ns]}]
+   (reduce (fn [acc [var-name var-map]] (let [v (-collect! var-name var-map)] (cond-> acc v (conj v))))
+     #{}
+     (mapcat (fn [n]
+               (let [ns-sym (cond (symbol? n) n
+                                  ;; handles (quote ns-name) - quoted symbols passed to cljs macros show up this way.
+                                  (list? n) (second n)
+                                  :else (symbol (str n)))]
+                 (ana-api/ns-publics ns-sym)))
+       (-sequential ns)))))
+
+;; intended to be called from a cljs macro
+(defn collect-all-ns* []
+  `(collect! {:ns ~(ana-api/all-ns)}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Generative testing, check function return values vs their parameters
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn emit-check [{:keys [schema]} fn-sym]
+  `(let [schema# (m/function-schema ~(m/form schema))
+         fn#     (or (get @instrumented-vars '~fn-sym) '~fn-sym)]
+     (when-let [err# (mg/check schema# fn#)]
+       ['~fn-sym err#])))
+
+(defn check* []
+  (let [r (reduce (fn [acc [ns-sym sym-map]]
+                    (reduce-kv (fn [acc' fn-sym schema-map]
+                                 (conj acc' (emit-check schema-map (symbol (str ns-sym) (str fn-sym)))))
+                      acc sym-map))
+            []
+            (m/function-schemas))]
+    `(into {} ~r)))
+
+(defmacro check
+  "Checks all registered function schemas using generative testing.
+   Returns nil or a map of symbol -> explanation in case of errors."
+  []
+  (check*))

--- a/src/malli/instrument/cljs.cljs
+++ b/src/malli/instrument/cljs.cljs
@@ -1,0 +1,7 @@
+(ns malli.instrument.cljs
+  (:require-macros [malli.instrument.cljs]))
+
+(defonce instrumented-vars (atom {}))
+
+(defn -filter-var [f] (fn [_ s _] (f s)))
+(defn -filter-ns [& ns] (fn [n _ _] ((set ns) n)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2453,6 +2453,8 @@
     (is (m/validate [List :int] '(1 2)))
     (is (not (m/validate [List :int] [1 2])))))
 
+(defn function-schema-registry-test-fn [])
+
 (deftest function-schema-registry-test
   (swap! @#'m/-function-schemas* dissoc 'malli.core-test)
   (let [prior-function-schemas (m/function-schemas)

--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -1,0 +1,45 @@
+(ns malli.instrument.cljs-test
+  (:require
+    [cljs.test :refer [deftest is testing]]
+    [malli.core :as m]
+    [malli.instrument.cljs :as mi]))
+
+(defn plus [x] (inc x))
+(m/=> plus [:=> [:cat :int] [:int {:max 6}]])
+
+(defn ->plus [] plus)
+
+(defn minus
+  "kukka"
+  {:malli/schema [:=> [:cat :int] [:int {:min 6}]]
+   :malli/scope  #{:input :output}}
+  [x] (dec x))
+
+(defn ->minus [] minus)
+
+(deftest instrument!-test
+
+  (testing "without instrumentation"
+    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
+    (is (= "21" ((->plus) "2")))
+    (is (= 7 ((->plus) 6))))
+
+  (testing "with instrumentation"
+    (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" ((->plus) "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" ((->plus) 6)))))
+
+(mi/collect!)
+
+(deftest collect!-test
+
+  (testing "without instrumentation"
+
+    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
+    (is (= 1 ((->minus) "2")))
+    (is (= 5 ((->minus) 6))))
+
+  (testing "with instrumentation"
+    (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" ((->minus) "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" ((->minus) 6)))))


### PR DESCRIPTION
Addresses https://github.com/metosin/malli/issues/482 

Implements function instrumentation for ClojureScript code, attempting
to match as closely as possible to the Clojure implementation.

Adds separate namespaces to implement instrumentation support in cljs
because macros are required to dynamically change vars in cljs
(symbol literals are required at runtime).

malli.dev.cljs/start! does not feature a watch on the function schemas
atom because the var names need to be known at compile time in order
for a macro to produce valid cljs code. In cljs, hot code reloading
is the norm so this isn'ta major deficiency.

