### PR TITLE
malli.destructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Malli is in well matured [alpha](README.md#alpha).
 
 ## UNRELEASED
 
+* **BREAKING**: local registries in vector syntax are stored as identity, not as form
 * new `malli.destructure` ns for parsing Clojure & Plumatic destructuring binding syntaxes
 
 ```clj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* new `malli.destructure` ns for parsing Clojure & Plumatic destructuring binding syntaxes
+
+```clj
+(require '[malli.destructure :as md])
+
+(-> '[a b & cs] (md/parse) :schema)
+; => [:cat :any :any [:* :any]]
+
+(-> '[a :- :string, b & cs :- [:* :int]] (md/parse) :schema)
+; => [:cat :string :any [:* :int]]
+```
+
 ## 0.7.5 (2021-12-19)
 
 * [clj-kondo 2021.12.16+](https://github.com/clj-kondo/clj-kondo/blob/master/CHANGELOG.md#20211216) can load malli type configs automatically from new location (`.clj-kondo/metosin/malli-types/config.edn`)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Data-driven Schemas for Clojure/Script.
 - [Validation](#validation) and [Value Transformation](#value-transformation)
 - First class [Error Messages](#error-messages) with [Spell Checking](#spell-checking)
 - [Generating values](#value-generation) from Schemas
-- [Inferring Schemas](#inferring-schemas) from sample values and [destructuring syntax](#destructuring).
+- [Inferring Schemas](#inferring-schemas) from sample values and [Destructuring](#destructuring).
 - Tools for [Programming with Schemas](#programming-with-schemas)
 - [Parsing](#parsing-values), [Unparsing](#unparsing-values) and [Sequence Schemas](#sequence-schemas)
 - [Persisting schemas](#persisting-schemas), even [function schemas](#serializable-functions)
@@ -1568,7 +1568,7 @@ Schemas can also be inferred from [Clojure Destructuring Syntax](https://clojure
 (infer '[a b & cs])
 ; => [:cat :any :any [:* :any]]
 ```
-Malli also supports [Plumatic Schema style](https://github.com/plumatic/schema#beyond-type-hints):
+Malli also supports adding type hints as an extension to the normal Clojure syntax (enabled by default), inspired by [Plumatic Schema](https://github.com/plumatic/schema#beyond-type-hints).
 
 ```clj
 (infer '[a :- :int, b :- :string & cs :- [:* :boolean]])
@@ -1610,13 +1610,14 @@ A more complete example:
          & {:keys [d e]
             :demo/keys [f]
             g :demo/g
+            [h] :h
             :or {d 0}
             :as opts}])
 ;[:cat
 ; :any
-; [:maybe [:cat 
-;          [:? :any] 
-;          [:? :any] 
+; [:maybe [:cat
+;          [:? :any]
+;          [:? :any]
 ;          [:* :any]]]
 ; [:altn
 ;  [:map
@@ -1624,7 +1625,10 @@ A more complete example:
 ;    [:d {:optional true} :any]
 ;    [:e {:optional true} :any]
 ;    [:demo/f {:optional true}]
-;    [:demo/g {:optional true}]]]
+;    [:demo/g {:optional true}]
+;    [:h {:optional true} [:maybe [:cat
+;                                  [:? :any]
+;                                  [:* :any]]]]]]
 ;  [:args
 ;   [:*
 ;    [:alt
@@ -1632,6 +1636,9 @@ A more complete example:
 ;     [:cat [:= :e] :any]
 ;     [:cat [:= :demo/f] :demo/f]
 ;     [:cat [:= :demo/g] :demo/g]
+;     [:cat [:= :h] [:maybe [:cat
+;                            [:? :any]
+;                            [:* :any]]]]
 ;     [:cat :any :any]]]]]]
 ```
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1898,7 +1898,7 @@
    (let [properties (when properties (when (pos? (count properties)) properties))
          r (when properties (properties :registry))
          options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
-         properties (if r (assoc properties :registry (-property-registry r options -form)) properties)]
+         properties (if r (assoc properties :registry (-property-registry r options identity)) properties)]
      (-into-schema (-lookup! type into-schema? options) properties children options))))
 
 (defn type

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -5,54 +5,53 @@
 (def Bind
   (m/schema
    [:schema
-    {:registry
-     {"Schema" any?
-      "Amp" [:= '&]
-      "As" [:= :as]
-      "Local" [:and symbol? [:not "Amp"]]
-      "Separator" [:= :-]
-      "Map" [:map
-             [:keys {:optional true} [:vector ident?]]
-             [:strs {:optional true} [:vector ident?]]
-             [:syms {:optional true} [:vector ident?]]
-             [:or {:optional true} [:map-of simple-symbol? any?]]
-             [:as {:optional true} "Local"]]
-      "Vector" [:catn
-                [:elems [:* "SchematizedArgument"]]
-                [:rest [:? [:catn
-                            [:amp "Amp"]
-                            [:arg "SchematizedArgument"]]]]
-                [:as [:? [:catn
-                          [:as "As"]
-                          [:sym "Local"]
-                          [:schema [:? [:catn
+    {:registry {"Schema" any?
+                "Amp" [:= '&]
+                "As" [:= :as]
+                "Local" [:and symbol? [:not "Amp"]]
+                "Separator" [:= :-]
+                "Map" [:map
+                       [:keys {:optional true} [:vector ident?]]
+                       [:strs {:optional true} [:vector ident?]]
+                       [:syms {:optional true} [:vector ident?]]
+                       [:or {:optional true} [:map-of simple-symbol? any?]]
+                       [:as {:optional true} "Local"]]
+                "Vector" [:catn
+                          [:elems [:* "SchematizedArgument"]]
+                          [:rest [:? [:catn
+                                      [:amp "Amp"]
+                                      [:arg "SchematizedArgument"]]]]
+                          [:as [:? [:catn
+                                    [:as "As"]
+                                    [:sym "Local"]
+                                    [:schema [:? [:catn
+                                                  [:- "Separator"]
+                                                  [:schema "Schema"]]]]]]]]
+                "Argument" [:alt
+                            [:catn [:sym "Local"]]
+                            [:catn [:map "Map"]]
+                            [:catn [:vec [:schema [:ref "Vector"]]]]]
+                "SchematizedArgument" [:alt
+                                       [:catn
+                                        [:arg "Argument"]]
+                                       [:catn
+                                        [:arg "Argument"]
                                         [:- "Separator"]
-                                        [:schema "Schema"]]]]]]]]
-      "Argument" [:alt
-                  [:catn [:sym "Local"]]
-                  [:catn [:map "Map"]]
-                  [:catn [:vec [:schema [:ref "Vector"]]]]]
-      "SchematizedArgument" [:alt
-                             [:catn
-                              [:arg "Argument"]]
-                             [:catn
-                              [:arg "Argument"]
-                              [:- "Separator"]
-                              [:schema "Schema"]]]
-      "Bind" [:catn
-              [:args [:* "SchematizedArgument"]]
-              [:rest [:? [:catn
-                          [:amp "Amp"]
-                          [:arg "SchematizedArgument"]]]]]}}
+                                        [:schema "Schema"]]]
+                "Bind" [:catn
+                        [:elems [:* "SchematizedArgument"]]
+                        [:rest [:? [:catn
+                                    [:amp "Amp"]
+                                    [:arg "SchematizedArgument"]]]]]}}
     "Bind"]))
 
-(declare transform)
+(declare -transform)
 
 (defn -maybe? [x] (and (vector? x) (= :maybe (first x))))
 
 (defn -vector [{:keys [elems rest]}]
-  (let [ess (map #(let [s (transform %)] (cond->> s (not (-maybe? s)) (conj [:?]))) elems)
-        rs (if rest (transform (:arg rest) true) [:* :any])]
+  (let [ess (map #(let [s (-transform %)] (cond->> s (not (-maybe? s)) (conj [:?]))) elems)
+        rs (if rest (-transform (:arg rest) true) [:* :any])]
     [:maybe (if (seq ess) (-> [:cat] (into ess) (conj rs)) rs)]))
 
 (defn -args [{:keys [keys strs syms]}]
@@ -67,10 +66,10 @@
 
 (defn -map-args [arg] [:altn [:map (-map arg)] [:args (-args arg)]])
 
-(defn transform
-  ([x] (transform x false))
+(defn -transform
+  ([x] (-transform x false))
   ([{{:keys [vec map]} :arg schema :schema :as all} rest]
-   (cond (and schema rest) [:and schema (transform (dissoc all :schema))]
+   (cond (and schema rest) [:and schema (-transform (dissoc all :schema))]
          schema schema
          vec (-vector vec)
          map (if rest (-map-args map) (-map map))
@@ -80,185 +79,12 @@
 (defn -unschematize [x]
   (walk/prewalk #(cond-> % (and (map? %) (:- %)) (dissoc :- :schema)) x))
 
-(defn args [bind]
-  (let [{:keys [args rest] :as parsed} (m/parse Bind bind)]
+(defn parse [bind]
+  (let [{:keys [elems rest] :as parsed} (m/parse Bind bind)]
     {:bind bind
      :parsed parsed
      :schema (cond-> :cat
-               (or (seq args) rest) (vector)
-               (seq args) (into (map transform args))
-               rest (conj (transform (:arg rest) true)))
+               (or (seq elems) rest) (vector)
+               (seq elems) (into (map -transform elems))
+               rest (conj (-transform (:arg rest) true)))
      :arglist (->> parsed -unschematize (m/unparse Bind))}))
-
-;; SPIKE
-(require '[malli.dev.pretty :as pretty])
-(defn -pp [x] (pretty/pprint x (pretty/-printer {:width 40})) (println))
-
-(defn expext [expectations]
-  (doseq [{:keys [name bind schema]} expectations]
-    (when-not (= schema (:schema (args bind)))
-      (-pp (args bind))
-      (-pp {:name name})
-      (-pp {:schema schema})
-      (assert false))))
-
-(expext
- [{:name "empty"
-   :bind '[]
-   :schema :cat}
-  {:name "1 arg"
-   :bind '[a]
-   :schema [:cat :any]}
-  {:name "2 args"
-   :bind '[a b]
-   :schema [:cat :any :any]}
-  {:name "2 + varargs"
-   :bind '[a b & cs]
-   :schema [:cat :any :any [:* :any]]}
-  {:name "sequence destructuring"
-   :bind '[a [b1 [b2] & bs :as bss] & [c1 c2 & cs :as css]]
-   :schema [:cat
-            :any
-            [:maybe
-             [:cat
-              [:? :any]
-              [:maybe
-               [:cat
-                [:? :any]
-                [:* :any]]]
-              [:* :any]]]
-            [:maybe
-             [:cat
-              [:? :any]
-              [:? :any]
-              [:* :any]]]]}
-  {:name "map destructuring"
-   :bind '[a {:keys [b c]
-              :strs [e f]
-              :syms [g h]
-              :or {b 0, e 0, g 0} :as bc}]
-   :schema [:cat
-            :any
-            [:map
-             [:b {:optional true} :any]
-             [:c {:optional true} :any]
-             ["e" {:optional true} :any]
-             ["f" {:optional true} :any]
-             ['g {:optional true} :any]
-             ['h {:optional true} :any]]]}
-  {:name "Keyword argument functions now also accept maps"
-   :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
-   :schema [:cat
-            [:altn
-             [:map [:map
-                    [:a {:optional true} :any]
-                    [:b {:optional true} :any]
-                    ["c" {:optional true} :any]
-                    ["d" {:optional true} :any]
-                    ['e {:optional true} :any]
-                    ['f {:optional true} :any]]]
-             [:args [:*
-                     [:alt
-                      [:cat [:= :a] :any]
-                      [:cat [:= :b] :any]
-                      [:cat [:= "c"] :any]
-                      [:cat [:= "d"] :any]
-                      [:cat [:= 'e] :any]
-                      [:cat [:= 'f] :any]]]]]]}
-  {:name "Nested Keyword argument"
-   :bind '[[& {:keys [a b] :as opts}]
-           & {:keys [a b] :as opts}]
-   :schema [:cat
-            [:maybe
-             [:altn
-              [:map [:map
-                     [:a {:optional true} :any]
-                     [:b {:optional true} :any]]]
-              [:args [:* [:alt
-                          [:cat [:= :a] :any]
-                          [:cat [:= :b] :any]]]]]]
-            [:altn
-             [:map [:map
-                    [:a {:optional true} :any]
-                    [:b {:optional true} :any]]]
-             [:args [:* [:alt
-                         [:cat [:= :a] :any]
-                         [:cat [:= :b] :any]]]]]]}])
-
-#_(-pp (args '[[& {:keys [a b] :as opts}]
-             & {:keys [a b] :as opts}]))
-
-(-pp (args '[a [b & bs] & cs]))
-#_(-pp (args '[& cs]))
-#_(-pp (args '[a [b1 [b2] & bs :as bss] & [c1 c2 & cs :as css]]))
-
-(defn destr [a [b & {:strs [c d] :as opts}]] [a b c d opts])
-(destr 1 [2 "c" 1 :a 1 :a 2 :a 3])
-
-(require '[malli.transform :as mt])
-(m/validate [:map [:x :int]] [[:x 1]])
-(m/decode [:map [:x :int]] {:x "1"} (mt/entry-transformer))
-(m/decode [:map [:x :int]] [[:x "1"]] (mt/entry-transformer))
-
-(m/parse
- [:cat
-  :int
-  [:* [:alt
-       [:cat [:= :x] :int]
-       [:cat [:= :y] :int]]]]
- [42 :x 1 :y 2 :y 1])
-
-(m/parse
- [:altn
-  [:map [:map
-         [:a :int]
-         [:b :int]]]
-  [:args [:* [:alt
-              [:cat [:= :a] :int]
-              [:cat [:= :b] :int]]]]]
- #_[{:a 1, :b 2}]
- [:b 1 :a 2])
-
-(m/parse
- [:cat
-  [:altn
-   [:map [:map
-          [:a :any]
-          [:b :any]]]
-   [:args [:*
-           [:alt
-            [:cat [:= :a] :any]
-            [:cat [:= :b] :any]]]]]]
- [:a 1 :b 2 :c 3])
-
-
-
-[:cat
- [:maybe
-  [:altn
-   [:map [:map
-          [:a {:optional true} :any]
-          [:b {:optional true} :any]]]
-   [:args [:* [:alt
-               [:cat [:= :a] :any]
-               [:cat [:= :b] :any]]]]]]
- [:altn
-  [:map [:map
-         [:a {:optional true} :any]
-         [:b {:optional true} :any]]]
-  [:args [:* [:alt
-              [:cat [:= :a] :any]
-              [:cat [:= :b] :any]]]]]]
-
-(args '[& {:as m :keys [id before after]}])
-;[:cat
-; [:altn
-;  [:map [:map
-;         [:id {:optional true} :any]
-;         [:before {:optional true} :any]
-;         [:after {:optional true} :any]]]
-;  [:args [:*
-;          [:alt
-;           [:cat [:= :id] :any]
-;           [:cat [:= :before] :any]
-;           [:cat [:= :after] :any]]]]]]

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -50,9 +50,9 @@
 (defn -any? [x] (= :any x))
 (defn -maybe? [x] (and (vector? x) (= :maybe (first x))))
 
-(defn -vector [{:keys [elems rest]}]
-  (let [ess (map #(let [s (-transform %)] (cond->> s (not (-maybe? s)) (conj [:?]))) elems)
-        rs (if rest (-transform (:arg rest) true) [:* :any])]
+(defn -vector [{:keys [elems rest]} options]
+  (let [ess (map #(let [s (-transform % options false)] (cond->> s (not (-maybe? s)) (conj [:?]))) elems)
+        rs (if rest (-transform (:arg rest) options true) [:* :any])]
     [:maybe (if (seq ess) (-> [:cat] (into ess) (conj rs)) rs)]))
 
 (defn -args [{:keys [keys strs syms]}]
@@ -65,27 +65,28 @@
         with (fn [ks f acc] (cond-> acc ks (into (map (entry f) ks))))]
     (->> [:map] (with keys keyword) (with strs str) (with syms identity))))
 
-(defn -map-args [arg rest] [:altn [:map (-map arg)] [:args (cond->> (-args arg) (not rest) (conj [:schema]))]])
+(defn -map-args [arg rest]
+  [:altn [:map (-map arg)] [:args (cond->> (-args arg) (not rest) (conj [:schema]))]])
 
-(defn -transform
-  ([x] (-transform x false))
-  ([{{:keys [vec map]} :arg schema :schema :as all} rest]
-   (cond (and schema rest) (let [s (-transform (dissoc all :schema))] (if (-any? s) schema [:and schema s]))
-         schema schema
-         vec (-vector vec)
-         map (-map-args map rest)
-         rest [:* :any]
-         :else :any)))
+(defn -transform [{{:keys [vec map]} :arg schema :schema :as all} options rest]
+  (cond (and schema rest) (let [s (-transform (dissoc all :schema) options false)] (if (-any? s) schema [:and schema s]))
+        schema schema
+        vec (-vector vec options)
+        map (-map-args map rest)
+        rest [:* :any]
+        :else :any))
 
 (defn -unschematize [x]
   (walk/prewalk #(cond-> % (and (map? %) (:- %)) (dissoc :- :schema)) x))
 
-(defn parse [bind]
-  (let [{:keys [elems rest] :as parsed} (m/parse Bind bind)]
-    {:bind bind
-     :parsed parsed
-     :schema (cond-> :cat
-               (or (seq elems) rest) (vector)
-               (seq elems) (into (map -transform elems))
-               rest (conj (-transform (:arg rest) true)))
-     :arglist (->> parsed -unschematize (m/unparse Bind))}))
+(defn parse
+  ([bind] (parse bind nil))
+  ([bind options]
+   (let [{:keys [elems rest] :as parsed} (m/parse Bind bind)]
+     {:bind bind
+      :parsed parsed
+      :schema (cond-> :cat
+                (or (seq elems) rest) (vector)
+                (seq elems) (into (map #(-transform % options false) elems))
+                rest (conj (-transform (:arg rest) options true)))
+      :arglist (->> parsed -unschematize (m/unparse Bind))})))

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -1,0 +1,264 @@
+(ns malli.destructure
+  (:require [malli.core :as m]
+            [clojure.walk :as walk]))
+
+(def Bind
+  (m/schema
+   [:schema
+    {:registry
+     {"Schema" any?
+      "Amp" [:= '&]
+      "As" [:= :as]
+      "Local" [:and symbol? [:not "Amp"]]
+      "Separator" [:= :-]
+      "Map" [:map
+             [:keys {:optional true} [:vector ident?]]
+             [:strs {:optional true} [:vector ident?]]
+             [:syms {:optional true} [:vector ident?]]
+             [:or {:optional true} [:map-of simple-symbol? any?]]
+             [:as {:optional true} "Local"]]
+      "Vector" [:catn
+                [:elems [:* "SchematizedArgument"]]
+                [:rest [:? [:catn
+                            [:amp "Amp"]
+                            [:arg "SchematizedArgument"]]]]
+                [:as [:? [:catn
+                          [:as "As"]
+                          [:sym "Local"]
+                          [:schema [:? [:catn
+                                        [:- "Separator"]
+                                        [:schema "Schema"]]]]]]]]
+      "Argument" [:alt
+                  [:catn [:sym "Local"]]
+                  [:catn [:map "Map"]]
+                  [:catn [:vec [:schema [:ref "Vector"]]]]]
+      "SchematizedArgument" [:alt
+                             [:catn
+                              [:arg "Argument"]]
+                             [:catn
+                              [:arg "Argument"]
+                              [:- "Separator"]
+                              [:schema "Schema"]]]
+      "Bind" [:catn
+              [:args [:* "SchematizedArgument"]]
+              [:rest [:? [:catn
+                          [:amp "Amp"]
+                          [:arg "SchematizedArgument"]]]]]}}
+    "Bind"]))
+
+(declare transform)
+
+(defn -maybe? [x] (and (vector? x) (= :maybe (first x))))
+
+(defn -vector [{:keys [elems rest]}]
+  (let [ess (map #(let [s (transform %)] (cond->> s (not (-maybe? s)) (conj [:?]))) elems)
+        rs (if rest (transform (:arg rest) true) [:* :any])]
+    [:maybe (if (seq ess) (-> [:cat] (into ess) (conj rs)) rs)]))
+
+(defn -args [{:keys [keys strs syms]}]
+  (let [entry (fn [f] (fn [x] [:cat [:= (f x)] :any]))
+        with (fn [ks f acc] (cond-> acc ks (into (map (entry f) ks))))]
+    (->> [:alt] (with keys keyword) (with strs str) (with syms identity) (conj [:*]))))
+
+(defn -map [{:keys [keys strs syms]}]
+  (let [entry (fn [f] (fn [x] [(f x) {:optional true} :any]))
+        with (fn [ks f acc] (cond-> acc ks (into (map (entry f) ks))))]
+    (->> [:map] (with keys keyword) (with strs str) (with syms identity))))
+
+(defn -map-args [arg] [:altn [:map (-map arg)] [:args (-args arg)]])
+
+(defn transform
+  ([x] (transform x false))
+  ([{{:keys [vec map]} :arg schema :schema :as all} rest]
+   (cond (and schema rest) [:and schema (transform (dissoc all :schema))]
+         schema schema
+         vec (-vector vec)
+         map (if rest (-map-args map) (-map map))
+         rest [:* :any]
+         :else :any)))
+
+(defn -unschematize [x]
+  (walk/prewalk #(cond-> % (and (map? %) (:- %)) (dissoc :- :schema)) x))
+
+(defn args [bind]
+  (let [{:keys [args rest] :as parsed} (m/parse Bind bind)]
+    {:bind bind
+     :parsed parsed
+     :schema (cond-> :cat
+               (or (seq args) rest) (vector)
+               (seq args) (into (map transform args))
+               rest (conj (transform (:arg rest) true)))
+     :arglist (->> parsed -unschematize (m/unparse Bind))}))
+
+;; SPIKE
+(require '[malli.dev.pretty :as pretty])
+(defn -pp [x] (pretty/pprint x (pretty/-printer {:width 40})) (println))
+
+(defn expext [expectations]
+  (doseq [{:keys [name bind schema]} expectations]
+    (when-not (= schema (:schema (args bind)))
+      (-pp (args bind))
+      (-pp {:name name})
+      (-pp {:schema schema})
+      (assert false))))
+
+(expext
+ [{:name "empty"
+   :bind '[]
+   :schema :cat}
+  {:name "1 arg"
+   :bind '[a]
+   :schema [:cat :any]}
+  {:name "2 args"
+   :bind '[a b]
+   :schema [:cat :any :any]}
+  {:name "2 + varargs"
+   :bind '[a b & cs]
+   :schema [:cat :any :any [:* :any]]}
+  {:name "sequence destructuring"
+   :bind '[a [b1 [b2] & bs :as bss] & [c1 c2 & cs :as css]]
+   :schema [:cat
+            :any
+            [:maybe
+             [:cat
+              [:? :any]
+              [:maybe
+               [:cat
+                [:? :any]
+                [:* :any]]]
+              [:* :any]]]
+            [:maybe
+             [:cat
+              [:? :any]
+              [:? :any]
+              [:* :any]]]]}
+  {:name "map destructuring"
+   :bind '[a {:keys [b c]
+              :strs [e f]
+              :syms [g h]
+              :or {b 0, e 0, g 0} :as bc}]
+   :schema [:cat
+            :any
+            [:map
+             [:b {:optional true} :any]
+             [:c {:optional true} :any]
+             ["e" {:optional true} :any]
+             ["f" {:optional true} :any]
+             ['g {:optional true} :any]
+             ['h {:optional true} :any]]]}
+  {:name "Keyword argument functions now also accept maps"
+   :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
+   :schema [:cat
+            [:altn
+             [:map [:map
+                    [:a {:optional true} :any]
+                    [:b {:optional true} :any]
+                    ["c" {:optional true} :any]
+                    ["d" {:optional true} :any]
+                    ['e {:optional true} :any]
+                    ['f {:optional true} :any]]]
+             [:args [:*
+                     [:alt
+                      [:cat [:= :a] :any]
+                      [:cat [:= :b] :any]
+                      [:cat [:= "c"] :any]
+                      [:cat [:= "d"] :any]
+                      [:cat [:= 'e] :any]
+                      [:cat [:= 'f] :any]]]]]]}
+  {:name "Nested Keyword argument"
+   :bind '[[& {:keys [a b] :as opts}]
+           & {:keys [a b] :as opts}]
+   :schema [:cat
+            [:maybe
+             [:altn
+              [:map [:map
+                     [:a {:optional true} :any]
+                     [:b {:optional true} :any]]]
+              [:args [:* [:alt
+                          [:cat [:= :a] :any]
+                          [:cat [:= :b] :any]]]]]]
+            [:altn
+             [:map [:map
+                    [:a {:optional true} :any]
+                    [:b {:optional true} :any]]]
+             [:args [:* [:alt
+                         [:cat [:= :a] :any]
+                         [:cat [:= :b] :any]]]]]]}])
+
+#_(-pp (args '[[& {:keys [a b] :as opts}]
+             & {:keys [a b] :as opts}]))
+
+(-pp (args '[a [b & bs] & cs]))
+#_(-pp (args '[& cs]))
+#_(-pp (args '[a [b1 [b2] & bs :as bss] & [c1 c2 & cs :as css]]))
+
+(defn destr [a [b & {:strs [c d] :as opts}]] [a b c d opts])
+(destr 1 [2 "c" 1 :a 1 :a 2 :a 3])
+
+(require '[malli.transform :as mt])
+(m/validate [:map [:x :int]] [[:x 1]])
+(m/decode [:map [:x :int]] {:x "1"} (mt/entry-transformer))
+(m/decode [:map [:x :int]] [[:x "1"]] (mt/entry-transformer))
+
+(m/parse
+ [:cat
+  :int
+  [:* [:alt
+       [:cat [:= :x] :int]
+       [:cat [:= :y] :int]]]]
+ [42 :x 1 :y 2 :y 1])
+
+(m/parse
+ [:altn
+  [:map [:map
+         [:a :int]
+         [:b :int]]]
+  [:args [:* [:alt
+              [:cat [:= :a] :int]
+              [:cat [:= :b] :int]]]]]
+ #_[{:a 1, :b 2}]
+ [:b 1 :a 2])
+
+(m/parse
+ [:cat
+  [:altn
+   [:map [:map
+          [:a :any]
+          [:b :any]]]
+   [:args [:*
+           [:alt
+            [:cat [:= :a] :any]
+            [:cat [:= :b] :any]]]]]]
+ [:a 1 :b 2 :c 3])
+
+
+
+[:cat
+ [:maybe
+  [:altn
+   [:map [:map
+          [:a {:optional true} :any]
+          [:b {:optional true} :any]]]
+   [:args [:* [:alt
+               [:cat [:= :a] :any]
+               [:cat [:= :b] :any]]]]]]
+ [:altn
+  [:map [:map
+         [:a {:optional true} :any]
+         [:b {:optional true} :any]]]
+  [:args [:* [:alt
+              [:cat [:= :a] :any]
+              [:cat [:= :b] :any]]]]]]
+
+(args '[& {:as m :keys [id before after]}])
+;[:cat
+; [:altn
+;  [:map [:map
+;         [:id {:optional true} :any]
+;         [:before {:optional true} :any]
+;         [:after {:optional true} :any]]]
+;  [:args [:*
+;          [:alt
+;           [:cat [:= :id] :any]
+;           [:cat [:= :before] :any]
+;           [:cat [:= :after] :any]]]]]]

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -28,12 +28,12 @@
                        [:catn [:map "Map"]]
                        [:catn [:vec [:schema [:ref "Vector"]]]]]
                 "Argument" [:catn [:arg "Arg"]]
-                "Bind" [:catn
-                        [:elems [:* "Argument"]]
-                        [:rest [:? [:catn
-                                    [:amp "Amp"]
-                                    [:arg "Argument"]]]]]}}
-    "Bind"]))
+                "Binding" [:catn
+                           [:elems [:* "Argument"]]
+                           [:rest [:? [:catn
+                                       [:amp "Amp"]
+                                       [:arg "Argument"]]]]]}}
+    "Binding"]))
 
 (def SchematizedBinding
   (m/schema
@@ -71,12 +71,12 @@
                              [:arg "Arg"]
                              [:- "Separator"]
                              [:schema "Schema"]]]
-                "Bind" [:catn
-                        [:elems [:* "Argument"]]
-                        [:rest [:? [:catn
-                                    [:amp "Amp"]
-                                    [:arg "Argument"]]]]]}}
-    "Bind"]))
+                "Binding" [:catn
+                           [:elems [:* "Argument"]]
+                           [:rest [:? [:catn
+                                       [:amp "Amp"]
+                                       [:arg "Argument"]]]]]}}
+    "Binding"]))
 
 (declare -transform)
 

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -5,8 +5,8 @@
 
 (defn -map-like? [x] (or (map? x) (and (seqable? x) (every? (fn [e] (and (vector? e) (= 2 (count e)))) x))))
 (defn -qualified-key? [k] (and (qualified-keyword? k) (-> k name #{"keys" "syms"})))
-(def MapLike (m/-collection-schema {:type :map-like, :empty {}, :pred -map-like?}))
-(def Never (m/-simple-schema {:type :never, :pred (fn [_] false)}))
+(def MapLike (m/-collection-schema {:type 'MapLike, :empty {}, :pred -map-like?}))
+(def Never (m/-simple-schema {:type 'Never, :pred (fn [_] false)}))
 
 (defn -schema [inline-schemas]
   (m/schema

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -2,6 +2,9 @@
   (:require [malli.core :as m]
             [clojure.walk :as walk]))
 
+(defn -ns-keys [m]
+  (->> (dissoc m :keys :strs :syms :or :as) (keys) (every? #(and (qualified-keyword? %) (-> % name #{"keys" "syms"})))))
+
 (def Binding
   (m/schema
    [:schema
@@ -9,12 +12,14 @@
                 "Amp" [:= '&]
                 "As" [:= :as]
                 "Local" [:and symbol? [:not "Amp"]]
-                "Map" [:map
-                       [:keys {:optional true} [:vector ident?]]
-                       [:strs {:optional true} [:vector ident?]]
-                       [:syms {:optional true} [:vector ident?]]
-                       [:or {:optional true} [:map-of simple-symbol? any?]]
-                       [:as {:optional true} "Local"]]
+                "Map" [:and
+                       [:map
+                        [:keys {:optional true} [:vector ident?]]
+                        [:strs {:optional true} [:vector ident?]]
+                        [:syms {:optional true} [:vector ident?]]
+                        [:or {:optional true} [:map-of simple-symbol? any?]]
+                        [:as {:optional true} "Local"]]
+                       [:fn -ns-keys]]
                 "Vector" [:catn
                           [:elems [:* "Argument"]]
                           [:rest [:? [:catn
@@ -43,12 +48,14 @@
                 "As" [:= :as]
                 "Local" [:and symbol? [:not "Amp"]]
                 "Separator" [:= :-]
-                "Map" [:map
-                       [:keys {:optional true} [:vector ident?]]
-                       [:strs {:optional true} [:vector ident?]]
-                       [:syms {:optional true} [:vector ident?]]
-                       [:or {:optional true} [:map-of simple-symbol? any?]]
-                       [:as {:optional true} "Local"]]
+                "Map" [:and
+                       [:map
+                        [:keys {:optional true} [:vector ident?]]
+                        [:strs {:optional true} [:vector ident?]]
+                        [:syms {:optional true} [:vector ident?]]
+                        [:or {:optional true} [:map-of simple-symbol? any?]]
+                        [:as {:optional true} "Local"]]
+                       [:fn -ns-keys]]
                 "Vector" [:catn
                           [:elems [:* "Argument"]]
                           [:rest [:? [:catn

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -101,7 +101,7 @@
         :let [f ({"keys" keyword, "syms" symbol} (name k))], :when f, v vs] (f (namespace k) (str v))))
 
 (defn -keys [{:keys [keys strs syms] :as arg}]
-  (->> (distinct (-qualified arg)) (concat (map keyword keys) (map str strs) syms)))
+  (->> (-qualified arg) (concat (map keyword keys) (map str strs) syms) (distinct)))
 
 (defn -map-args [arg rest]
   (let [keys (-keys arg)]

--- a/src/malli/dot.cljc
+++ b/src/malli/dot.cljc
@@ -29,7 +29,7 @@
       (swap! registry* assoc k
              (m/walk v (fn [schema path children _]
                          (let [options (update (m/options schema) :registry #(mr/composite-registry @registry* %))
-                               schema (m/into-schema (m/type schema) (m/properties schema) children options)]
+                               schema (m/into-schema (m/parent schema) (m/properties schema) children options)]
                            (if (and (seq path) (= :map (m/type schema)))
                              (let [ref (-schema-name k path)]
                                (swap! registry* assoc ref (mu/update-properties schema assoc ::entity k))

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -9,12 +9,21 @@
    {:name "1 arg"
     :bind '[a]
     :schema [:cat :any]}
+   {:name "1 arg, schematized"
+    :bind '[a :- :int]
+    :schema [:cat :int]}
    {:name "2 args"
     :bind '[a b]
     :schema [:cat :any :any]}
+   {:name "2 args, schematized"
+    :bind '[a :- :int, b :- :boolean]
+    :schema [:cat :int :boolean]}
    {:name "2 + varargs"
     :bind '[a b & cs]
     :schema [:cat :any :any [:* :any]]}
+   {:name "2 + varargs, schematize"
+    :bind '[a, b :- :int & cs :- [:* :boolean]]
+    :schema [:cat :any :int [:* :boolean]]}
    {:name "sequence destructuring"
     :bind '[a [b1 [b2] & bs :as bss] & [c1 c2 & cs :as css]]
     :schema [:cat
@@ -25,6 +34,23 @@
                [:maybe
                 [:cat
                  [:? :any]
+                 [:* :any]]]
+               [:* :any]]]
+             [:maybe
+              [:cat
+               [:? :any]
+               [:? :any]
+               [:* :any]]]]}
+   {:name "Sequence destructuring, schematized"
+    :bind '[a :- :int [b1 :- :int [b2 :- :int] & bs :as bss :- [:vector :int]] & [c1 c2 & cs :as css]]
+    :schema [:cat
+             :int
+             [:maybe
+              [:cat
+               [:? :int]
+               [:maybe
+                [:cat
+                 [:? :int]
                  [:* :any]]]
                [:* :any]]]
              [:maybe

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -57,7 +57,9 @@
                         [:cat [:= "e"] :any]
                         [:cat [:= 'f] :any]
                         [:cat [:= 'g] :any]
-                        [:cat :any :any]]]]]]]}
+                        [:cat :any :any]]]]]]]
+    :errors '[[{::keysz [z]}]
+              [{:kikka/keyz [z]}]]}
    {:name "Keyword argument functions now also accept maps"
     :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
     :schema [:cat
@@ -206,13 +208,16 @@
 
 (deftest parse-test
   (let [test-all (fn [expectations options]
-                (doseq [{:keys [name bind] expected :schema} expectations]
+                (doseq [{:keys [name bind errors] expected :schema} expectations]
                   (testing (str "- " name " -")
                     (let [{:keys [arglist schema]} (md/parse bind options)]
                       (testing "has expected schema"
                         (is (= expected schema)))
                       (testing "has valid arglist"
-                        (is (not= ::m/invalid arglist)))))))]
+                        (is (not= ::m/invalid arglist)))
+                      (testing "errors"
+                        (doseq [error errors]
+                          (is (thrown? #?(:clj Exception, :cljs js/Error) (md/parse error)))))))))]
 
     (testing "schematized syntax"
       (let [syntax '[x :- :int]]

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -34,56 +34,70 @@
                [:* :any]]]]}
    {:name "map destructuring"
     :bind '[a {:keys [b c]
-               :strs [e f]
-               :syms [g h]
-               :or {b 0, e 0, g 0} :as bc}]
+               :strs [d e]
+               :syms [f g]
+               :or {b 0, d 0, f 0} :as map}]
     :schema [:cat
              :any
-             [:map
-              [:b {:optional true} :any]
-              [:c {:optional true} :any]
-              ["e" {:optional true} :any]
-              ["f" {:optional true} :any]
-              ['g {:optional true} :any]
-              ['h {:optional true} :any]]]}
-   {:name "Keyword argument functions now also accept maps"
-    :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
-    :schema [:cat
              [:altn
               [:map [:map
-                     [:a {:optional true} :any]
                      [:b {:optional true} :any]
-                     ["c" {:optional true} :any]
+                     [:c {:optional true} :any]
                      ["d" {:optional true} :any]
-                     ['e {:optional true} :any]
-                     ['f {:optional true} :any]]]
-              [:args [:*
-                      [:alt
-                       [:cat [:= :a] :any]
-                       [:cat [:= :b] :any]
-                       [:cat [:= "c"] :any]
-                       [:cat [:= "d"] :any]
-                       [:cat [:= 'e] :any]
-                       [:cat [:= 'f] :any]]]]]]}
+                     ["e" {:optional true} :any]
+                     ['f {:optional true} :any]
+                     ['g {:optional true} :any]]]
+              [:args [:schema
+                      [:*
+                       [:alt
+                        [:cat [:= :b] :any]
+                        [:cat [:= :c] :any]
+                        [:cat [:= "d"] :any]
+                        [:cat [:= "e"] :any]
+                        [:cat [:= 'f] :any]
+                        [:cat [:= 'g] :any]
+                        [:cat :any :any]]]]]]]}
+   {:name "Keyword argument functions now also accept maps"
+      :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
+      :schema [:cat
+               [:altn
+                [:map [:map
+                       [:a {:optional true} :any]
+                       [:b {:optional true} :any]
+                       ["c" {:optional true} :any]
+                       ["d" {:optional true} :any]
+                       ['e {:optional true} :any]
+                       ['f {:optional true} :any]]]
+                [:args [:*
+                        [:alt
+                         [:cat [:= :a] :any]
+                         [:cat [:= :b] :any]
+                         [:cat [:= "c"] :any]
+                         [:cat [:= "d"] :any]
+                         [:cat [:= 'e] :any]
+                         [:cat [:= 'f] :any]
+                         [:cat :any :any]]]]]]}
    {:name "Nested Keyword argument"
-    :bind '[[& {:keys [a b] :as opts}]
-            & {:keys [a b] :as opts}]
-    :schema [:cat
-             [:maybe
-              [:altn
-               [:map [:map
-                      [:a {:optional true} :any]
-                      [:b {:optional true} :any]]]
-               [:args [:* [:alt
-                           [:cat [:= :a] :any]
-                           [:cat [:= :b] :any]]]]]]
-             [:altn
-              [:map [:map
-                     [:a {:optional true} :any]
-                     [:b {:optional true} :any]]]
-              [:args [:* [:alt
-                          [:cat [:= :a] :any]
-                          [:cat [:= :b] :any]]]]]]}])
+      :bind '[[& {:keys [a b] :as opts}]
+              & {:keys [a b] :as opts}]
+      :schema [:cat
+               [:maybe
+                [:altn
+                 [:map [:map
+                        [:a {:optional true} :any]
+                        [:b {:optional true} :any]]]
+                 [:args [:* [:alt
+                             [:cat [:= :a] :any]
+                             [:cat [:= :b] :any]
+                             [:cat :any :any]]]]]]
+               [:altn
+                [:map [:map
+                       [:a {:optional true} :any]
+                       [:b {:optional true} :any]]]
+                [:args [:* [:alt
+                            [:cat [:= :a] :any]
+                            [:cat [:= :b] :any]
+                            [:cat :any :any]]]]]]}])
 
 (deftest parse-test
   (doseq [{:keys [name bind schema]} expectations]

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -314,3 +314,6 @@
 
     (testing "schematized clojure"
       (test-all schematized-expectations))))
+
+(deftest binding-schema
+  (is (m/form md/Binding)))

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -219,9 +219,7 @@
                   (testing (str "- " name " -")
                     (let [{:keys [arglist schema]} (md/parse bind options)]
                       (testing "has expected schema"
-                        (when-not (is (= expected schema))
-                          (prn "?" expected)
-                          (prn ">" schema)))
+                        (is (= expected schema)))
                       (testing "has valid arglist"
                         (is (not= ::m/invalid arglist)))
                       (testing "errors"

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -215,10 +215,13 @@
                         (is (not= ::m/invalid arglist)))))))]
 
     (testing "schematized syntax"
-      (testing "fails by default"
-        (is (thrown? #?(:clj Exception, :cljs js/Error) (md/parse '[x :- :int]))))
-      (testing "succeeds with schematized clojure"
-        (is (= [:cat :int] (:schema (md/parse '[x :- :int] {::md/schema md/SchematizedBinding}))))))
+      (let [syntax '[x :- :int]]
+
+        (testing "fails by default"
+          (is (thrown? #?(:clj Exception, :cljs js/Error) (md/parse syntax))))
+
+        (testing "succeeds with schematized clojure"
+          (is (= [:cat :int] (:schema (md/parse syntax {::md/schema md/SchematizedBinding})))))))
 
     (testing "vanilla clojure"
       (test-all expectations nil))

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -9,21 +9,12 @@
    {:name "1 arg"
     :bind '[a]
     :schema [:cat :any]}
-   {:name "1 arg, schematized"
-    :bind '[a :- :int]
-    :schema [:cat :int]}
    {:name "2 args"
     :bind '[a b]
     :schema [:cat :any :any]}
-   {:name "2 args, schematized"
-    :bind '[a :- :int, b :- :boolean]
-    :schema [:cat :int :boolean]}
    {:name "2 + varargs"
     :bind '[a b & cs]
     :schema [:cat :any :any [:* :any]]}
-   {:name "2 + varargs, schematize"
-    :bind '[a, b :- :int & cs :- [:* :boolean]]
-    :schema [:cat :any :int [:* :boolean]]}
    {:name "sequence destructuring"
     :bind '[a [b1 [b2] & bs :as bss] & [c1 c2 & cs :as css]]
     :schema [:cat
@@ -34,23 +25,6 @@
                [:maybe
                 [:cat
                  [:? :any]
-                 [:* :any]]]
-               [:* :any]]]
-             [:maybe
-              [:cat
-               [:? :any]
-               [:? :any]
-               [:* :any]]]]}
-   {:name "Sequence destructuring, schematized"
-    :bind '[a :- :int [b1 :- :int [b2 :- :int] & bs :as bss :- [:vector :int]] & [c1 c2 & cs :as css]]
-    :schema [:cat
-             :int
-             [:maybe
-              [:cat
-               [:? :int]
-               [:maybe
-                [:cat
-                 [:? :int]
                  [:* :any]]]
                [:* :any]]]
              [:maybe
@@ -84,48 +58,159 @@
                         [:cat [:= 'g] :any]
                         [:cat :any :any]]]]]]]}
    {:name "Keyword argument functions now also accept maps"
-      :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
-      :schema [:cat
-               [:altn
-                [:map [:map
-                       [:a {:optional true} :any]
-                       [:b {:optional true} :any]
-                       ["c" {:optional true} :any]
-                       ["d" {:optional true} :any]
-                       ['e {:optional true} :any]
-                       ['f {:optional true} :any]]]
-                [:args [:*
-                        [:alt
-                         [:cat [:= :a] :any]
-                         [:cat [:= :b] :any]
-                         [:cat [:= "c"] :any]
-                         [:cat [:= "d"] :any]
-                         [:cat [:= 'e] :any]
-                         [:cat [:= 'f] :any]
-                         [:cat :any :any]]]]]]}
+    :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
+    :schema [:cat
+             [:altn
+              [:map [:map
+                     [:a {:optional true} :any]
+                     [:b {:optional true} :any]
+                     ["c" {:optional true} :any]
+                     ["d" {:optional true} :any]
+                     ['e {:optional true} :any]
+                     ['f {:optional true} :any]]]
+              [:args [:*
+                      [:alt
+                       [:cat [:= :a] :any]
+                       [:cat [:= :b] :any]
+                       [:cat [:= "c"] :any]
+                       [:cat [:= "d"] :any]
+                       [:cat [:= 'e] :any]
+                       [:cat [:= 'f] :any]
+                       [:cat :any :any]]]]]]}
    {:name "Nested Keyword argument"
-      :bind '[[& {:keys [a b] :as opts}]
-              & {:keys [a b] :as opts}]
-      :schema [:cat
+    :bind '[[& {:keys [a b] :as opts}]
+            & {:keys [a b] :as opts}]
+    :schema [:cat
+             [:maybe
+              [:altn
+               [:map [:map
+                      [:a {:optional true} :any]
+                      [:b {:optional true} :any]]]
+               [:args [:* [:alt
+                           [:cat [:= :a] :any]
+                           [:cat [:= :b] :any]
+                           [:cat :any :any]]]]]]
+             [:altn
+              [:map [:map
+                     [:a {:optional true} :any]
+                     [:b {:optional true} :any]]]
+              [:args [:* [:alt
+                          [:cat [:= :a] :any]
+                          [:cat [:= :b] :any]
+                          [:cat :any :any]]]]]]}])
+
+(def schematized-expectations
+  [{:name "empty"
+    :bind '[]
+    :schema :cat}
+   {:name "1 arg"
+    :bind '[a :- :int]
+    :schema [:cat :int]}
+   {:name "2 args"
+    :bind '[a :- :int, b :- :boolean]
+    :schema [:cat :int :boolean]}
+   {:name "2 + varargs"
+    :bind '[a, b :- :int & cs :- [:* :boolean]]
+    :schema [:cat :any :int [:* :boolean]]}
+   {:name "Sequence destructuring - 1"
+    :bind '[a :- :int [b1 :- :int [b2 :- :int] & bs :as bss]]
+    :schema [:cat
+             :int
+             [:maybe
+              [:cat
+               [:? :int]
                [:maybe
-                [:altn
-                 [:map [:map
-                        [:a {:optional true} :any]
-                        [:b {:optional true} :any]]]
-                 [:args [:* [:alt
-                             [:cat [:= :a] :any]
-                             [:cat [:= :b] :any]
-                             [:cat :any :any]]]]]]
-               [:altn
-                [:map [:map
-                       [:a {:optional true} :any]
-                       [:b {:optional true} :any]]]
-                [:args [:* [:alt
-                            [:cat [:= :a] :any]
-                            [:cat [:= :b] :any]
-                            [:cat :any :any]]]]]]}])
+                [:cat
+                 [:? :int]
+                 [:* :any]]]
+               [:* :any]]]]}
+   {:name "Sequence destructuring - 2 (rest)"
+    :bind '[a :- :int [b1 :- :int [b2 :- :int] & bs :- [:* :int] :as bss]]
+    :schema [:cat
+             :int
+             [:maybe
+              [:cat
+               [:? :int]
+               [:maybe
+                [:cat
+                 [:? :int]
+                 [:* :any]]]
+               [:* :int]]]]}
+   {:name "Sequence destructuring - 3 (as)"
+    :bind '[a :- :int [b1 :- :int [b2 :- :int] & bs :as bss :- [:* :int]]]
+    :schema [:cat
+             :int
+             [:schema [:* :int]]]}
+   {:name "Sequence destructuring - 4 (bind rest)"
+    :bind '[a :- :int & [b1 :- :int [b2 :- :int] & bs :- [:* :int] :as bss]]
+    :schema [:cat
+             :int
+             [:maybe
+              [:cat
+               [:? :int]
+               [:maybe
+                [:cat
+                 [:? :int]
+                 [:* :any]]]
+               [:* :int]]]]}
+   {:name "map destructuring"
+    :bind '[a :- :int, {:keys [b c]
+                        :strs [d e]
+                        :syms [f g]
+                        :or {b 0, d 0, f 0} :as map}
+            :- [:map
+                [:b :int]
+                [:c :int]
+                ["d" :string]
+                ["e" :string]
+                [f :symbol]
+                [g :symbol]]]
+    :schema [:cat
+             :int
+             [:map
+              [:b :int]
+              [:c :int]
+              ["d" :string]
+              ["e" :string]
+              ['f :symbol]
+              ['g :symbol]]]}
+   {:name "Keyword argument functions now also accept maps"
+    :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}
+            :- [:map
+                [:b :int]
+                [:c :int]
+                ["d" :string]
+                ["e" :string]
+                [f :symbol]
+                [g :symbol]]]
+    :schema [:cat
+             [:map
+              [:b :int]
+              [:c :int]
+              ["d" :string]
+              ["e" :string]
+              ['f :symbol]
+              ['g :symbol]]]}
+   {:name "Nested Keyword argument"
+    :bind '[[& {:keys [a b] :as opts} :- [:map [:a :int] [:b :int]]]
+            & {:keys [a b] :as opts} :- [:map [:a :int] [:b :int]]]
+    :schema [:cat
+             [:maybe
+              [:map
+               [:a :int]
+               [:b :int]]]
+             [:map
+              [:a :int]
+              [:b :int]]]}])
 
 (deftest parse-test
-  (doseq [{:keys [name bind schema]} expectations]
-    (testing name
-      (is (= schema (:schema (md/parse bind)))))))
+
+  (testing "vanilla clojure"
+    (doseq [{:keys [name bind schema]} expectations]
+      (testing name
+        (is (= schema (:schema (md/parse bind)))))))
+
+  (testing "schematized clojure"
+    (doseq [{:keys [name bind schema]} schematized-expectations]
+      (testing name
+        (is (= schema (:schema (md/parse bind))))))))

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -34,51 +34,55 @@
                [:? :any]
                [:* :any]]]]}
    {:name "map destructuring"
-    :bind '[a {:keys [b c]
-               :strs [d e]
-               :syms [f g]
+    :bind '[a {:keys [b]
+               :strs [c]
+               :syms [d]
+               :demo/keys [e]
+               :demo/syms [f]
                :or {b 0, d 0, f 0} :as map}]
     :schema [:cat
              :any
              [:altn
               [:map [:map
                      [:b {:optional true} :any]
-                     [:c {:optional true} :any]
-                     ["d" {:optional true} :any]
-                     ["e" {:optional true} :any]
-                     ['f {:optional true} :any]
-                     ['g {:optional true} :any]]]
+                     ["c" {:optional true} :any]
+                     ['d {:optional true} :any]
+                     [:demo/e {:optional true} :any]
+                     ['demo/f {:optional true} :any]]]
               [:args [:schema
                       [:*
                        [:alt
                         [:cat [:= :b] :any]
-                        [:cat [:= :c] :any]
-                        [:cat [:= "d"] :any]
-                        [:cat [:= "e"] :any]
-                        [:cat [:= 'f] :any]
-                        [:cat [:= 'g] :any]
+                        [:cat [:= "c"] :any]
+                        [:cat [:= 'd] :any]
+                        [:cat [:= :demo/e] :any]
+                        [:cat [:= 'demo/f] :any]
                         [:cat :any :any]]]]]]]
     :errors '[[{::keysz [z]}]
               [{:kikka/keyz [z]}]]}
    {:name "Keyword argument functions now also accept maps"
-    :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
+    :bind '[a & {:keys [b]
+                 :strs [c]
+                 :syms [d]
+                 :demo/keys [e]
+                 :demo/syms [f]
+                 :or {b 0, d 0, f 0} :as map}]
     :schema [:cat
+             :any
              [:altn
               [:map [:map
-                     [:a {:optional true} :any]
                      [:b {:optional true} :any]
                      ["c" {:optional true} :any]
-                     ["d" {:optional true} :any]
-                     ['e {:optional true} :any]
-                     ['f {:optional true} :any]]]
+                     ['d {:optional true} :any]
+                     [:demo/e {:optional true} :any]
+                     ['demo/f {:optional true} :any]]]
               [:args [:*
                       [:alt
-                       [:cat [:= :a] :any]
                        [:cat [:= :b] :any]
                        [:cat [:= "c"] :any]
-                       [:cat [:= "d"] :any]
-                       [:cat [:= 'e] :any]
-                       [:cat [:= 'f] :any]
+                       [:cat [:= 'd] :any]
+                       [:cat [:= :demo/e] :any]
+                       [:cat [:= 'demo/f] :any]
                        [:cat :any :any]]]]]]}
    {:name "Nested Keyword argument"
     :bind '[[& {:keys [a b] :as opts}]
@@ -157,43 +161,46 @@
                  [:* :any]]]
                [:* :int]]]]}
    {:name "map destructuring"
-    :bind '[a :- :int, {:keys [b c]
-                        :strs [d e]
-                        :syms [f g]
+    :bind '[a :- :int, {:keys [b]
+                        :strs [c]
+                        :syms [d]
+                        :demo/keys [e]
+                        :demo/syms [f]
                         :or {b 0, d 0, f 0} :as map}
             :- [:map
                 [:b :int]
-                [:c :int]
-                ["d" :string]
-                ["e" :string]
-                [f :symbol]
-                [g :symbol]]]
+                ["c" :int]
+                [d :string]
+                [:demo/e :string]
+                [demo/f :symbol]]]
     :schema [:cat
              :int
              [:map
               [:b :int]
-              [:c :int]
-              ["d" :string]
-              ["e" :string]
-              ['f :symbol]
-              ['g :symbol]]]}
+              ["c" :int]
+              ['d :string]
+              [:demo/e :string]
+              ['demo/f :symbol]]]}
    {:name "Keyword argument functions now also accept maps"
-    :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}
+    :bind '[& {:keys [b]
+               :strs [c]
+               :syms [d]
+               :demo/keys [e]
+               :demo/syms [f]
+               :or {b 0, d 0, f 0} :as map}
             :- [:map
                 [:b :int]
-                [:c :int]
-                ["d" :string]
-                ["e" :string]
-                [f :symbol]
-                [g :symbol]]]
+                ["c" :int]
+                [d :string]
+                [:demo/e :string]
+                [demo/f :symbol]]]
     :schema [:cat
              [:map
               [:b :int]
-              [:c :int]
-              ["d" :string]
-              ["e" :string]
-              ['f :symbol]
-              ['g :symbol]]]}
+              ["c" :int]
+              ['d :string]
+              [:demo/e :string]
+              ['demo/f :symbol]]]}
    {:name "Nested Keyword argument"
     :bind '[[& {:keys [a b] :as opts} :- [:map [:a :int] [:b :int]]]
             & {:keys [a b] :as opts} :- [:map [:a :int] [:b :int]]]
@@ -212,7 +219,9 @@
                   (testing (str "- " name " -")
                     (let [{:keys [arglist schema]} (md/parse bind options)]
                       (testing "has expected schema"
-                        (is (= expected schema)))
+                        (when-not (is (= expected schema))
+                          (prn "?" expected)
+                          (prn ">" schema)))
                       (testing "has valid arglist"
                         (is (not= ::m/invalid arglist)))
                       (testing "errors"

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -1,0 +1,91 @@
+(ns malli.destructure-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [malli.destructure :as md]))
+
+(def expectations
+  [{:name "empty"
+    :bind '[]
+    :schema :cat}
+   {:name "1 arg"
+    :bind '[a]
+    :schema [:cat :any]}
+   {:name "2 args"
+    :bind '[a b]
+    :schema [:cat :any :any]}
+   {:name "2 + varargs"
+    :bind '[a b & cs]
+    :schema [:cat :any :any [:* :any]]}
+   {:name "sequence destructuring"
+    :bind '[a [b1 [b2] & bs :as bss] & [c1 c2 & cs :as css]]
+    :schema [:cat
+             :any
+             [:maybe
+              [:cat
+               [:? :any]
+               [:maybe
+                [:cat
+                 [:? :any]
+                 [:* :any]]]
+               [:* :any]]]
+             [:maybe
+              [:cat
+               [:? :any]
+               [:? :any]
+               [:* :any]]]]}
+   {:name "map destructuring"
+    :bind '[a {:keys [b c]
+               :strs [e f]
+               :syms [g h]
+               :or {b 0, e 0, g 0} :as bc}]
+    :schema [:cat
+             :any
+             [:map
+              [:b {:optional true} :any]
+              [:c {:optional true} :any]
+              ["e" {:optional true} :any]
+              ["f" {:optional true} :any]
+              ['g {:optional true} :any]
+              ['h {:optional true} :any]]]}
+   {:name "Keyword argument functions now also accept maps"
+    :bind '[& {:keys [a b], :strs [c d], :syms [e f] :as opts}]
+    :schema [:cat
+             [:altn
+              [:map [:map
+                     [:a {:optional true} :any]
+                     [:b {:optional true} :any]
+                     ["c" {:optional true} :any]
+                     ["d" {:optional true} :any]
+                     ['e {:optional true} :any]
+                     ['f {:optional true} :any]]]
+              [:args [:*
+                      [:alt
+                       [:cat [:= :a] :any]
+                       [:cat [:= :b] :any]
+                       [:cat [:= "c"] :any]
+                       [:cat [:= "d"] :any]
+                       [:cat [:= 'e] :any]
+                       [:cat [:= 'f] :any]]]]]]}
+   {:name "Nested Keyword argument"
+    :bind '[[& {:keys [a b] :as opts}]
+            & {:keys [a b] :as opts}]
+    :schema [:cat
+             [:maybe
+              [:altn
+               [:map [:map
+                      [:a {:optional true} :any]
+                      [:b {:optional true} :any]]]
+               [:args [:* [:alt
+                           [:cat [:= :a] :any]
+                           [:cat [:= :b] :any]]]]]]
+             [:altn
+              [:map [:map
+                     [:a {:optional true} :any]
+                     [:b {:optional true} :any]]]
+              [:args [:* [:alt
+                          [:cat [:= :a] :any]
+                          [:cat [:= :b] :any]]]]]]}])
+
+(deftest parse-test
+  (doseq [{:keys [name bind schema]} expectations]
+    (testing name
+      (is (= schema (:schema (md/parse bind)))))))


### PR DESCRIPTION
# What

1. Support for Clojure Binding syntax (destructuring)
2. Support for Plumatic-style schematized binding syntax (destructuring)

## Public API

```clj
(defn parse
  "Takes a destructuring bindings vector (arglist)
   and returns a map with keys:

   | key            | description |
   | ---------------|-------------|
   | `:raw-arglist` | the original arglist (can have type-hints)
   | `:arglist`     | simplified clojure arglist (no type-hints)
   | `:schema`      | extracted malli schema
   | `:parsed`      | full parse results

   Parsing can be configured using the following options:

   | key                    | description |
   | -----------------------|-------------|
   | `::md/inline-schemas`  | support plumatic-style inline schemas (true)
   | `::md/sequential-maps` | support sequential maps in non-rest position (true)
   | `::md/references`      | qualified schema references used (true)
   | `::md/required-keys`   | destructured keys are required (false)
   | `::md/closed-maps`     | destructured maps are closed (false)

   Examples:

      (require '[malli.destructure :as md])

      (-> '[a b & cs] (md/parse) :schema)
      ; => [:cat :any :any [:* :any]]

      (-> '[a :- :string, b & cs :- [:* :int]] (md/parse) :schema)
      ; => [:cat :string :any [:* :int]]"
  ...)
```

## 1) Clojure Binding syntax

```clj
(require '[malli.destructure :as md])

(-> '[a [b c & rest :as bc]
      & {:keys [d e]
         :demo/keys [f]
         g :demo/g
         :or {d 0}
         :as opts}]
    (md/parse)
    (select-keys [:arglist :schema]))
;{:arglist [a [b c & rest :as bc]
;           & {:keys [d e]
;              :demo/keys [f]
;              g :demo/g
;              :or {d 0}
;              :as opts}],
; :schema [:cat
;          :any
;          [:maybe [:cat [:? :any] [:? :any] [:* :any]]]
;          [:altn
;           [:map
;            [:map
;             [:d {:optional true} :any]
;             [:e {:optional true} :any]
;             [:demo/f {:optional true}]
;             [:demo/g {:optional true}]]]
;           [:args
;            [:*
;             [:alt
;              [:cat [:= :d] :any]
;              [:cat [:= :e] :any]
;              [:cat [:= :demo/f] :demo/f]
;              [:cat [:= :demo/g] :demo/g]
;              [:cat :any :any]]]]]]}
```

## 2) Plumatic-style schematized binding syntax

```clj
(-> '[a :- :int,
      [b :- :boolean
       c
       & rest :- [:* :string]
       :as bc]
      & {:keys [d e]
         :demo/keys [f]
         g :demo/g
         :or {d 0}
         :as opts}]
    (md/parse)
    (select-keys [:arglist :schema]))
;{:arglist '[a [b c & rest :as bc]
;            & {:keys [d e]
;               :demo/keys [f]
;               g :demo/g
;               :or {d 0}
;               :as opts}],
; :schema [:cat
;          :int
;          [:maybe [:cat [:? :boolean] [:? :any] [:* :string]]]
;          [:altn
;           [:map
;            [:map
;             [:d {:optional true} :any]
;             [:e {:optional true} :any]
;             [:demo/f {:optional true}]
;             [:demo/g {:optional true}]]]
;           [:args
;            [:*
;             [:alt
;              [:cat [:= :d] :any]
;              [:cat [:= :e] :any]
;              [:cat [:= :demo/f] :demo/f]
;              [:cat [:= :demo/g] :demo/g]
;              [:cat :any :any]]]]]]}
```

