### PR TITLE
Construct schema objects at runtime when instrumenting cljs fns

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2370,7 +2370,9 @@
 ;;
 
 (defonce ^:private -function-schemas* (atom {}))
+(defonce ^:private -function-schemas-cljs* (atom {}))
 (defn function-schemas [] @-function-schemas*)
+(defn function-schemas-cljs [] @-function-schemas-cljs*)
 
 (defn function-schema
   ([?schema]
@@ -2382,14 +2384,18 @@
 (defn -register-function-schema! [ns name schema data]
   (swap! -function-schemas* assoc-in [ns name] (merge data {:schema (function-schema schema), :ns ns, :name name})))
 
+(defn -register-function-schema-cljs! [ns name schema data]
+  ;; we cannot invoke `function-schema` at macroexpansion-time - `schema` could contain cljs vars that will only resovle at runtime.
+  (swap! -function-schemas-cljs* assoc-in [ns name] (merge data {:schema schema, :ns ns, :name name})))
+
 #?(:clj
    (defmacro => [name value]
      (let [name' `'~(symbol (str name))
            ns' `'~(symbol (str *ns*))
            sym `'~(symbol (str *ns*) (str name))]
-       ;; in cljs we need to register the schema in clojure (the cljs compiler) so it is visible in the -function-schemas* map at macroexpansion time.
+       ;; in cljs we need to register the schema in clojure (the cljs compiler) so it is visible in the -function-schemas-cljs* map at macroexpansion time.
        (when (some? (:ns &env))
-         (-register-function-schema! (symbol (str *ns*)) name value (meta name)))
+         (-register-function-schema-cljs! (symbol (str *ns*)) name value (meta name)))
        `(do (-register-function-schema! ~ns' ~name' ~value ~(meta name)) ~sym))))
 
 (defn -instrument

--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -7,6 +7,8 @@
 (defn plus [x] (inc x))
 (m/=> plus [:=> [:cat :int] [:int {:max 6}]])
 
+(def small-int [:int {:max 6}])
+
 (defn ->plus [] plus)
 
 (defn minus
@@ -15,17 +17,39 @@
    :malli/scope  #{:input :output}}
   [x] (dec x))
 
+(defn minus-small-int
+  "kukka"
+  {:malli/schema [:=> [:cat :int] small-int]
+   :malli/scope  #{:input :output}}
+  [x] (dec x))
+
 (defn ->minus [] minus)
+
+(defn plus-small-int [x] (inc x))
+(m/=> plus-small-int [:=> [:cat :int] small-int])
+
+(def Over100 (m/-simple-schema {:type 'Over100, :pred #(and (int? %) (< 100 %))}))
+
+(defn plus-over-100 [x] (inc x))
+(m/=> plus-over-100 [:=> [:cat :int] Over100])
 
 (deftest instrument!-test
 
   (testing "without instrumentation"
     (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
     (is (= "21" ((->plus) "2")))
+    (is (= (plus-small-int 8) 9))
+    (is (= (plus-over-100 8) 9))
     (is (= 7 ((->plus) 6))))
 
   (testing "with instrumentation"
     (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (plus-small-int "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (plus-small-int 8)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (plus-over-100 "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (plus-over-100 8)))
+
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" ((->plus) "2")))
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" ((->plus) 6)))))
 
@@ -37,9 +61,15 @@
 
     (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
     (is (= 1 ((->minus) "2")))
-    (is (= 5 ((->minus) 6))))
+    (is (= 5 ((->minus) 6)))
+
+    (is (= 1 (minus-small-int "2")))
+    (is (= 9 (minus-small-int 10))))
 
   (testing "with instrumentation"
     (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" ((->minus) "2")))
-    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" ((->minus) 6)))))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" ((->minus) 6)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (minus-small-int "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus-small-int 10)))))


### PR DESCRIPTION
Addresses the errors that came up in the prior cljs instrumentation PR:
https://github.com/metosin/malli/pull/604

This solution involves adding a new atom to contain the cljs vars that contain function schemas. 

I think we could have one atom for both clj + cljs if they don't invoke `m/function-schema` when registering the function schema,
and then in clojure, when instrumenting here: (https://github.com/metosin/malli/blob/80775e74eaf191f3916649ccbeae095dcfad62e9/src/malli/instrument.clj#L26)
updating the schema to check that it is a function schema at that point.

for example:
```clojure
(m/-instrument (update dgen :schema m/function-schema) original-fn)
```

what do you think?

*update*: I think the intention of throwing on invalid fn schema would be lost though for clojure usage as the user would only find out when/if they instrument the function.
I think this dual setup of one atom for cljs and one for clj may be the most straightforward, but maybe you have some ideas.