### PR TITLE
Allow custom options for `mx/defn` and custom type emitting

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -133,7 +133,9 @@
 (defmethod accept :union [_ schema _ options] (transform (m/deref schema) options))
 (defmethod accept :select-keys [_ schema _ options] (transform (m/deref schema) options))
 
-(defn- -walk [schema _ children options] (accept (m/type schema) schema children options))
+(defn- -walk [schema _ children options]
+  (or (:clj-kondo/type (m/type-properties schema))
+      (accept (m/type schema) schema children options)))
 
 (defn -transform [?schema options] (m/walk ?schema -walk options))
 

--- a/src/malli/experimental.cljc
+++ b/src/malli/experimental.cljc
@@ -48,7 +48,11 @@
                    ~name
                    ~@(some-> doc vector)
                    ~(assoc meta :raw-arglists (list 'quote raw-arglists), :schema schema)
-                   ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
+                   ~@(map (fn [{:keys [arglist prepost body]}]
+                            (if prepost
+                              `(~arglist ~prepost ~@body)
+                              `(~arglist ~@body)))
+                          parglists)
                    ~@(when-not single (some->> arities val :meta vector)))]
        (m/=> ~name ~schema)
        defn#)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2474,7 +2474,10 @@
         fn-schema (get this-ns-schemas 'function-schema-registry-test-fn)]
     (is (= (inc (count prior-function-schemas)) (count new-function-schemas)))
     (is (map? this-ns-schemas))
-    (is (map? fn-schema))))
+    (is (map? fn-schema))
+    (testing "fully namespaced symbols"
+      (is (= (m/=> malli.core-test/function-schema-registry-test-fn [:=> :cat :nil])
+             (m/=> function-schema-registry-test-fn [:=> :cat :nil]))))))
 
 (deftest -instrument-test
   (let [int<=6 [:int {:max 6}]]


### PR DESCRIPTION
I was trying to use custom types in `mx/defn` and was not able to, so
here I'm just passing `:malli/options` metadata which has the
custom options (with some `:registry`). Also, I'm checking if there is
some `prepost` instead of outputting `nil`.

`m/=>` was not working to namespaced symbols (maybe this was
intentional?), so this PR allows it to pass it, altough it has to be
fully qualified.

When emitting the configuration to `clj-kondo` for some custom
type, it was returning `:any`, but now it's outputting a type which the
user-defined in the type properties at the `:clj-kondo/type` key.

Let me know if it makes sense o/