### PR TITLE
Fix quote in unstrument macro for cljs

### DIFF
--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -73,7 +73,7 @@
            (.log js/console "..unstrumented" '~fn-sym)
            '~fn-sym)]
     (if filters
-      `(when (some #(% ~ns-sym (var ~fn-sym) ~opts) ~filters)
+      `(when (some #(% '~ns-sym (var ~fn-sym) ~opts) ~filters)
          ~replace-with-orig)
       replace-with-orig)))
 

--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -66,15 +66,6 @@
 
 (deftest collect!-test
 
-  (testing "without instrumentation"
-    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
-
-    (is (= 1 (minus "2")))
-    (is (= 5 (minus 6)))
-
-    (is (= 1 (minus-small-int "2")))
-    (is (= 9 (minus-small-int 10))))
-
   (testing "with instrumentation"
     (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
 
@@ -82,4 +73,13 @@
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus 6)))
 
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (minus-small-int "2")))
-    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus-small-int 10)))))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus-small-int 10))))
+
+  (testing "without instrumentation"
+    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
+
+    (is (= 1 (minus "2")))
+    (is (= 5 (minus 6)))
+
+    (is (= 1 (minus-small-int "2")))
+    (is (= 9 (minus-small-int 10)))))


### PR DESCRIPTION
fixes unstrument filtering for cljs, as mentioned here:

https://github.com/metosin/malli/pull/611