### PR TITLE
Add more configuration options to pretty printer docs

### DIFF
--- a/docs/function-schemas.md
+++ b/docs/function-schemas.md
@@ -683,7 +683,10 @@ To throw the prettified error instead of just printint it:
 Pretty printer uses [fipp](https://github.com/brandonbloom/fipp) under the hood and has lot of configuration options:
 
 ```clj
-(dev/start! {:report (pretty/reporter (pretty/-printer {:width 80}))})
+(dev/start! {:report (pretty/reporter (pretty/-printer {:width 80
+                                                        :print-length 30
+                                                        :print-level 2
+                                                        :print-meta true}))})
 ```
 
 ### TL;DR


### PR DESCRIPTION
Self explanatory: the fipp repository does a good job showing the documentation available for their pretty printer, can't hurt to have it reflected here as well.