### PR TITLE
`::mp/value-decoders` multiple type example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1559,10 +1559,13 @@ Adding custom decoding via `::mp/value-decoders` option:
 
 ```clj
 (mp/provide
- [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
-  {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
- {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}})
-; => [:map [:id :uuid]]
+ [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"
+   :time "2021-01-01T00:00:00Z"}
+  {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"
+   :time "2022-01-01T00:00:00Z"}]
+ {::mp/value-decoders {'string? {:uuid mt/-string->uuid
+                                 'inst? mt/-string->date}}})
+; => [:map [:id :uuid] [:time inst?]
 ```
 
 ## Destructuring


### PR DESCRIPTION
malli.provider `::mp/value-decoders` multiple type example