### PR TITLE
Accept UUIDs up to version 8 when decoding from a string

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -94,7 +94,7 @@
     (try
       #?(:clj  (UUID/fromString x)
          ;; http://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid
-         :cljs (if (re-find #"^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" x)
+         :cljs (if (re-find #"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" x)
                  (uuid x)
                  x))
       (catch #?(:clj Exception, :cljs js/Error) _ x))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -833,12 +833,15 @@
 (deftest map-of-json-keys-transform
   (let [schema [:map-of int? uuid?]]
     (doseq [data [{:0 "2ac307dc-4ec8-4046-9b7e-57716b7ecfd2"
-                   :1 "820e5003-6fff-480b-9e2b-ec3cdc5d2f78"}
+                   :1 "820e5003-6fff-480b-9e2b-ec3cdc5d2f78"
+                   :2 "017de28f-5801-8c62-9ce9-cef70883794a"}
                   {"0" "2ac307dc-4ec8-4046-9b7e-57716b7ecfd2"
-                   "1" "820e5003-6fff-480b-9e2b-ec3cdc5d2f78"}]]
+                   "1" "820e5003-6fff-480b-9e2b-ec3cdc5d2f78"
+                   "2" "017de28f-5801-8c62-9ce9-cef70883794a"}]]
 
       (is (= {0 #uuid"2ac307dc-4ec8-4046-9b7e-57716b7ecfd2"
-              1 #uuid"820e5003-6fff-480b-9e2b-ec3cdc5d2f78"}
+              1 #uuid"820e5003-6fff-480b-9e2b-ec3cdc5d2f78"
+              2 #uuid"017de28f-5801-8c62-9ce9-cef70883794a"}
              (m/decode schema data mt/json-transformer))))))
 
 #?(:clj


### PR DESCRIPTION
Hi Tommi, I am using sequential UUIDs on a project (using this library https://github.com/yetanalytics/colossal-squuid) and noticed they were not being coerced to UUIDs in ClojureScript. This PR updates the regex that accepts a valid UUID string on cljs to work up to version 8.