### PR TITLE
malli.experimental.lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* new ns, `malli.experimental.lite`, see the [docs](README.md#lite).
+
 ## 0.8.1 (2022-02-05)
 
 * FIX: bug in inferring with value encoders [#631](https://github.com/metosin/malli/issues/631)

--- a/README.md
+++ b/README.md
@@ -2431,6 +2431,36 @@ Visualized with [PlantText](https://www.planttext.com/):
 
 <img src="https://raw.githubusercontent.com/metosin/malli/master/docs/img/plantuml.png"/>
 
+## Lite
+
+Simple syntax sugar, like [data-specs](https://cljdoc.org/d/metosin/spec-tools/CURRENT/doc/data-specs), but for malli.
+
+```clj
+(require '[malli.experimental.lite :as l])
+
+(l/schema
+ {:map1 {:x int?
+         :y [:maybe string?]
+         :z (l/maybe keyword?)}
+  :map2 {:min-max [:int {:min 0 :max 10}]
+         :tuples (l/vector (l/tuple int? string?))
+         :optional (l/optional (l/maybe :boolean))
+         :set-of-maps (l/set {:e int?
+                              :f string?})
+         :map-of-int (l/map-of int? {:s string?})}})
+;[:map
+; [:map1
+;  [:map
+;   [:x int?]
+;   [:y [:maybe string?]]
+;   [:z [:maybe keyword?]]]]
+; [:map2
+;  [:map
+;   [:min-max [:int {:min 0, :max 10}]]
+;   [:tuples [:vector [:tuple int? string?]]]
+;   [:optional {:optional true} [:maybe :boolean]]
+```
+
 ## Performance
 
 Malli tries to be really, really fast.

--- a/src/malli/experimental/lite.cljc
+++ b/src/malli/experimental/lite.cljc
@@ -1,0 +1,22 @@
+(ns malli.experimental.lite
+  (:refer-clojure :exclude [set vector and or])
+  (:require [malli.core :as m]))
+
+(declare schema)
+
+(defrecord -Optional [value])
+(defn -schema [t & xs] (schema (into [t] (map schema xs))))
+(defn -entry [[k v]]
+  (let [[v optional] (if (instance? -Optional v) [(:value v) true] [v])]
+    (cond-> [k] optional (conj {:optional true}) :always (conj (schema v)))))
+
+(defn schema [x] (m/schema (if (map? x) (into [:map] (map -entry x)) x)))
+
+(defn optional [x] (->-Optional x))
+(defn maybe [x] (-schema :maybe x))
+(defn set [x] (-schema :set x))
+(defn vector [x] (-schema :vector x))
+(defn map-of [k v] (-schema :map-of k v))
+(defn tuple [& xs] (apply -schema :tuple xs))
+(defn and [& xs] (apply -schema :and xs))
+(defn or [& xs] (apply -schema :or xs))

--- a/test/malli/experimental/lite_test.cljc
+++ b/test/malli/experimental/lite_test.cljc
@@ -1,0 +1,31 @@
+(ns malli.experimental.lite-test
+  (:require [clojure.test :refer :all]
+            [malli.experimental.lite :as l]
+            [malli.core :as m]))
+
+(deftest schema-test
+  (let [lschema (l/schema
+                 {:int int?
+                  :opt (l/optional {:a int?})
+                  :maybe (l/maybe {:a int?})
+                  :set (l/set {:a int?})
+                  :vector (l/vector {:a int?})
+                  :nested {:int int?
+                           :map-of (l/map-of int? {:a int?})
+                           :tuple (l/tuple int? {:a int?})
+                           :and (l/and {:a int?} :map)
+                           :or (l/or {:a int?} {:b int?})}})
+        mschema (m/schema
+                 [:map
+                  [:int int?]
+                  [:opt {:optional true} [:map [:a int?]]]
+                  [:maybe [:maybe [:map [:a int?]]]]
+                  [:set [:set [:map [:a int?]]]]
+                  [:vector [:vector [:map [:a int?]]]]
+                  [:nested [:map
+                            [:int int?]
+                            [:map-of [:map-of int? [:map [:a int?]]]]
+                            [:tuple [:tuple int? [:map [:a int?]]]]
+                            [:and [:and [:map [:a int?]] :map]]
+                            [:or [:or [:map [:a int?]] [:map [:b int?]]]]]]])]
+    (is (= (m/form lschema) (m/form mschema)))))

--- a/test/malli/experimental/lite_test.cljc
+++ b/test/malli/experimental/lite_test.cljc
@@ -1,5 +1,5 @@
 (ns malli.experimental.lite-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [malli.experimental.lite :as l]
             [malli.core :as m]))
 


### PR DESCRIPTION
Simple syntax sugar, like [data-specs](https://cljdoc.org/d/metosin/spec-tools/CURRENT/doc/data-specs), but for malli.

```clj
(require '[malli.experimental.lite :as l])

(l/schema
 {:map1 {:x int?
         :y [:maybe string?]
         :z (l/maybe keyword?)}
  :map2 {:min-max [:int {:min 0 :max 10}]
         :tuples (l/vector (l/tuple int? string?))
         :optional (l/optional (l/maybe :boolean))
         :set-of-maps (l/set {:e int?
                              :f string?})
         :map-of-int (l/map-of int? {:s string?})}})
;[:map
; [:map1
;  [:map
;   [:x int?]
;   [:y [:maybe string?]]
;   [:z [:maybe keyword?]]]]
; [:map2
;  [:map
;   [:min-max [:int {:min 0, :max 10}]]
;   [:tuples [:vector [:tuple int? string?]]]
;   [:optional {:optional true} [:maybe :boolean]]
```