### PR TITLE
Qualified keyword with preconfigured namespace

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -158,24 +158,21 @@
       (gen/fmap #(apply concat %) (-coll-gen schema identity options))
       (-coll-gen schema identity options))))
 
-(defn -qualified-ident-gen [schema mk-gen-with-namespace mk-gen-random]
+(defn -qualified-ident-gen [schema mk-value-with-ns value-with-ns-gen-size mk-gen-random]
   (if-let [namespace-unparsed (:namespace (m/properties schema))]
-    (mk-gen-with-namespace (name namespace-unparsed))
+    (gen/fmap (fn [k] (mk-value-with-ns (name namespace-unparsed) (name k)))
+              value-with-ns-gen-size)
     (mk-gen-random)))
 
 (defn -qualified-keyword-gen [schema]
-  (-qualified-ident-gen
-   schema
-   (fn [ns-name] (gen/fmap (fn [k] (keyword ns-name (name k)))
-                           gen/keyword))
-   #(gen/such-that qualified-keyword? gen/keyword-ns)))
+  (-qualified-ident-gen schema
+                        keyword gen/keyword
+                        #(gen/such-that qualified-keyword? gen/keyword-ns)))
 
 (defn -qualified-symbol-gen [schema]
-  (-qualified-ident-gen
-   schema
-   (fn [ns-name] (gen/fmap (fn [k] (symbol ns-name (name k)))
-                           gen/symbol))
-   #(gen/such-that qualified-symbol? gen/symbol-ns)))
+  (-qualified-ident-gen schema
+                        symbol gen/symbol
+                        #(gen/such-that qualified-symbol? gen/symbol-ns)))
 
 ;;
 ;; User-facing API

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -158,6 +158,18 @@
 ;; generators
 ;;
 
+(defn- qualified-keyword-generator [schema]
+  (if-let [namespace-unparsed (:namespace (m/properties schema))]
+    (gen/fmap (fn [k] (keyword (name namespace-unparsed) (name k)))
+              gen/keyword)
+    (gen/such-that qualified-keyword? gen/keyword-ns)))
+
+(defn- qualified-symbol-generator [schema]
+  (if-let [namespace-unparsed (:namespace (m/properties schema))]
+    (gen/fmap (fn [k] (symbol (name namespace-unparsed) (name k)))
+              gen/symbol)
+    (gen/such-that qualified-symbol? gen/symbol-ns)))
+
 (defmulti -schema-generator (fn [schema options] (m/type schema options)) :default ::default)
 
 (defmethod -schema-generator ::default [schema options] (ga/gen-for-pred (m/validator schema options)))
@@ -202,8 +214,8 @@
 (defmethod -schema-generator :boolean [_ _] gen/boolean)
 (defmethod -schema-generator :keyword [_ _] gen/keyword)
 (defmethod -schema-generator :symbol [_ _] gen/symbol)
-(defmethod -schema-generator :qualified-keyword [_ _] (gen/such-that qualified-keyword? gen/keyword-ns))
-(defmethod -schema-generator :qualified-symbol [_ _] (gen/such-that qualified-symbol? gen/symbol-ns))
+(defmethod -schema-generator :qualified-keyword [schema _] (qualified-keyword-generator schema))
+(defmethod -schema-generator :qualified-symbol [schema _] (qualified-symbol-generator schema))
 (defmethod -schema-generator :uuid [_ _] gen/uuid)
 
 (defmethod -schema-generator :=> [schema options] (-=>-gen schema options))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -58,6 +58,64 @@
                                    :gen/NaN? true}))
       (is (not (test-presence special? nil)))))
 
+  (testing "qualified-keyword properties"
+    (testing "no namespace => random"
+      (is (< 1 (->> (mg/sample [:qualified-keyword {:namespace nil}]
+                               {:size 100})
+                    (map namespace)
+                    frequencies
+                    (count))))
+      (is (< 1 (->> (mg/sample [:qualified-keyword {}]
+                               {:size 100})
+                    (map namespace)
+                    frequencies
+                    (count)))))
+    (testing "namespace => keyword with exact namesapce"
+      (is (= {"hi" 100}
+             (->> (mg/sample [:qualified-keyword {:namespace :hi}]
+                             {:size 100})
+                  (map namespace)
+                  frequencies)))
+      (is (= {"hi" 100}
+             (->> (mg/sample [:qualified-keyword {:namespace "hi"}]
+                             {:size 100})
+                  (map namespace)
+                  frequencies))))
+    (testing "generated result should pass validation"
+      (is (->> (mg/sample [:qualified-keyword {:namespace "hi"}]
+                          {:size 100})
+               (remove (partial m/validate [:qualified-keyword {:namespace "hi"}]))
+               empty?))))
+
+  (testing "qualified-symbol properties"
+    (testing "no namespace => random"
+      (is (< 1 (->> (mg/sample [:qualified-symbol {:namespace nil}]
+                               {:size 100})
+                    (map namespace)
+                    frequencies
+                    (count))))
+      (is (< 1 (->> (mg/sample [:qualified-symbol {}]
+                               {:size 100})
+                    (map namespace)
+                    frequencies
+                    (count)))))
+    (testing "namespace => symbol with exact namesapce"
+      (is (= {"hi" 100}
+             (->> (mg/sample [:qualified-symbol {:namespace :hi}]
+                             {:size 100})
+                  (map namespace)
+                  frequencies)))
+      (is (= {"hi" 100}
+             (->> (mg/sample [:qualified-symbol {:namespace "hi"}]
+                             {:size 100})
+                  (map namespace)
+                  frequencies))))
+    (testing "generated result should pass validation"
+      (is (->> (mg/sample [:qualified-symbol {:namespace "hi"}]
+                          {:size 100})
+               (remove (partial m/validate [:qualified-symbol {:namespace "hi"}]))
+               empty?))))
+
   (testing "map entries"
     (is (= {:korppu "koira"
             :piilomaan "pikku aasi"


### PR DESCRIPTION
Closes https://github.com/metosin/malli/issues/642

Got some help from `p-himik`: https://clojurians.slack.com/archives/C03S1KBA2/p1644919467267179
and `borkdude`.

In this PR I also did update the generator for symbols but it doesn't validate the namespace and I didn't touch the validator of symbols.