### PR TITLE
2-arity default-fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* support for `default-fn` in `mt/default-value-transformer`
+
 ## 0.8.3 (2022-02-15)
 
 * FIX: qualified-keyword with namespace doesn't generate the ns [#642](https://github.com/metosin/malli/issues/642)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Malli is in well matured [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* support for `default-fn` in `mt/default-value-transformer`
+* support for 2-arity `default-fn` option in `mt/default-value-transformer` [#582](https://github.com/metosin/malli/pull/582) & [#644](https://github.com/metosin/malli/pull/644)
 
 ## 0.8.3 (2022-02-15)
 

--- a/README.md
+++ b/README.md
@@ -862,6 +862,20 @@ With custom key and type defaults:
 ; => {:user {:name "", :description "-"}}
 ```
 
+With custom function:
+
+```clj
+(m/decode
+ [:map
+  [:os [:string {:property "os.name"}]]
+  [:timezone [:string {:property "user.timezone"}]]]
+ {} 
+ (mt/default-value-transformer 
+  {:key :property
+   :default-fn (fn [_ x] (System/getProperty x))}))
+; => {:os "Mac OS X", :timezone "Europe/Helsinki"}
+```
+
 Single sweep of defaults & string encoding:
 
 ```clj

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -832,21 +832,24 @@
                   [:first {:default 1} int?]
                   [:second {:default 2} int?]]]
       (testing "called on each defaulted value"
-        (let [seen (atom [])]
-          (is (= {:first 1, :second 2} (m/encode schema nil (mt/default-value-transformer {:default-fn (fn [x] (swap! seen conj x) x)}))))
+        (let [seen (atom [])
+              transformer (mt/default-value-transformer {:default-fn (fn [_ x] (swap! seen conj x) x)})]
+          (is (= {:first 1, :second 2} (m/encode schema nil transformer)))
           (is (= [{} 1 2] @seen))))
 
       (testing "only called on defaulted value"
-        (let [seen (atom [])]
-          (is (= {:first -1, :second 2} (m/encode schema {:first -1} (mt/default-value-transformer {:default-fn (fn [x] (swap! seen conj x) x)}))))
+        (let [seen (atom [])
+              transformer (mt/default-value-transformer {:default-fn (fn [_ x] (swap! seen conj x) x)})]
+          (is (= {:first -1, :second 2} (m/encode schema {:first -1} transformer)))
           (is (= [2] @seen)))))
 
     (testing "custom default :key"
       (let [schema [:map {}
                     [:first {:default 1, :name 'one} int?]
                     [:second {:default 2, :name 'two} int?]]]
-        (let [seen (atom [])]
-          (is (= {:first 'one, :second 'two} (m/encode schema {} (mt/default-value-transformer {:key :name, :default-fn (fn [x] (swap! seen conj x) x)}))))
+        (let [seen (atom [])
+              transformer (mt/default-value-transformer {:key :name, :default-fn (fn [_ x] (swap! seen conj x) x)})]
+          (is (= {:first 'one, :second 'two} (m/encode schema {} transformer)))
           (is (= ['one 'two] @seen)))))))
 
 (deftest type-properties-based-transformations


### PR DESCRIPTION
```clj
(m/decode
 [:map
  [:os [:string {:property "os.name"}]]
  [:timezone [:string {:property "user.timezone"}]]]
 {} 
 (mt/default-value-transformer 
  {:key :property
   :default-fn (fn [_ x] (System/getProperty x))}))
; => {:os "Mac OS X", :timezone "Europe/Helsinki"}
```