### PR TITLE
Fully qualify symbols used in cljs metadata schemas

### DIFF
--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -1,5 +1,6 @@
 (ns malli.instrument.cljs-test
   (:require [cljs.test :refer [deftest is testing]]
+            [malli.instrument.fn-schemas :refer [sum-nums str-join str-join2 str-join3 str-join4]]
             [malli.core :as m]
             [malli.experimental :as mx]
             [malli.instrument.cljs :as mi]))
@@ -62,13 +63,17 @@
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (power "2")))
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (power 6)))))
 
-(mi/collect!)
+(mi/collect! {:ns ['malli.instrument.cljs-test 'malli.instrument.fn-schemas]})
 
 (deftest collect!-test
 
   (testing "with instrumentation"
-    (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
-
+    (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test 'malli.instrument.fn-schemas)]})
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join2 [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join3 [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join4 [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (sum-nums "2")))
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (minus "2")))
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus 6)))
 
@@ -76,10 +81,15 @@
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus-small-int 10))))
 
   (testing "without instrumentation"
-    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
+    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test 'malli.instrument.fn-schemas)]})
 
     (is (= 1 (minus "2")))
     (is (= 5 (minus 6)))
+    (is (= (sum-nums [2 "3" 4 5]) "2345"))
+    (is (= (str-join [1 "2"]) "12"))
+    (is (= (str-join2 [1 "2"]) "12"))
+    (is (= (str-join3 [1 "2"]) "12"))
+    (is (= (str-join4 [1 "2"]) "12"))
 
     (is (= 1 (minus-small-int "2")))
     (is (= 9 (minus-small-int 10)))))

--- a/test/malli/instrument/fn_schemas.cljs
+++ b/test/malli/instrument/fn_schemas.cljs
@@ -1,0 +1,31 @@
+(ns malli.instrument.fn-schemas
+  (:require [malli.instrument.fn-schemas2 :as schemas :refer [VecOfStrings]]))
+
+(def VecOfInts [:vector :int])
+
+(defn sum-nums
+  {:malli/schema [:=> [:cat VecOfInts] :int]}
+  [args]
+  (apply + args))
+
+(defn str-join
+  {:malli/schema [:=> [:cat VecOfStrings] schemas/string]}
+  [args]
+  (apply str args))
+
+(def str-join-schema [:=> [:cat VecOfStrings] schemas/string])
+
+(defn str-join2
+  {:malli/schema [:=> [:cat VecOfStrings] schemas/string]}
+  [args]
+  (apply str args))
+
+(defn str-join3
+  {:malli/schema str-join-schema}
+  [args]
+  (apply str args))
+
+(defn str-join4
+  {:malli/schema [:=> [:cat malli.instrument.fn-schemas2/VecOfStrings] schemas/string]}
+  [args]
+  (apply str args))

--- a/test/malli/instrument/fn_schemas2.cljs
+++ b/test/malli/instrument/fn_schemas2.cljs
@@ -1,0 +1,5 @@
+(ns malli.instrument.fn-schemas2)
+
+(def VecOfStrings [:vector :string])
+
+(def string :string)


### PR DESCRIPTION
This PR ensures all vars used in cljs schemas are fully qualified.  This is necessary because the namespace where `collect!` is invoked will be the one where the generated code from the macro is produced, which likely won't have those vars available.

This should fix the issue https://github.com/metosin/malli/issues/659