### PR TITLE
Fix clj-kondo support for cljs

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -190,4 +190,15 @@
    (defn emit! [] (-> (collect) (linter-config) (save!)) nil))
 
 #?(:clj
-   (defmacro emit-cljs! [] (emit!)))
+   (defn collect-cljs
+     ([] (collect-cljs nil))
+     ([ns]
+      (let [-collect (fn [k] (or (nil? ns) (= k (symbol (str ns)))))]
+        (for [[k vs] (m/function-schemas :cljs) :when (-collect k) [_ v] vs v (from v)] v)))))
+
+#?(:clj
+   (defn emit-cljs!* []
+     (-> (collect-cljs) (linter-config) (save!)) nil))
+
+#?(:clj
+   (defmacro emit-cljs! [] (emit-cljs!*)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2404,9 +2404,11 @@
            sym `'~(symbol (str *ns*) (str name))]
        ;; in cljs we need to register the schema in clojure (the cljs compiler)
        ;; so it is visible in the (function-schemas :cljs) map at macroexpansion time.
-       (when (some? (:ns &env))
-         (-register-function-schema! (symbol (str *ns*)) name value (meta name) :cljs identity))
-       `(do (-register-function-schema! ~ns' ~name' ~value ~(meta name)) ~sym))))
+       (if (some? (:ns &env))
+         (do
+           (-register-function-schema! (symbol (str *ns*)) name value (meta name) :cljs identity)
+           `(do (-register-function-schema! ~ns' ~name' ~value ~(meta name) :cljs identity) ~sym))
+         `(do (-register-function-schema! ~ns' ~name' ~value ~(meta name)) ~sym)))))
 
 (defn -instrument
   "Takes an instrumentation properties map and a function and returns a wrapped function,

--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -23,7 +23,7 @@
         ;; register all function schemas and instrument them based on the options
         ~(mi/-collect-all-ns)
         ~(mi/-instrument env options)
-        ~(do (clj-kondo/emit!) nil)) ) )
+        ~(do (clj-kondo/emit-cljs!*) nil)) ) )
 
 #?(:clj (defmacro start!
           "Collects defn schemas from all loaded namespaces and starts instrumentation for

--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -28,7 +28,7 @@
             metadata (walk/postwalk -qualify-sym (m/-unlift-keys meta "malli"))]
         (m/-register-function-schema! ns simple-name schema* metadata :cljs identity)
         `(do
-           (m/-register-function-schema! '~ns '~simple-name ~schema* ~metadata)
+           (m/-register-function-schema! '~ns '~simple-name ~schema* ~metadata :cljs identity)
            '~(:name var-map))))))
 
 (defn -sequential [x] (cond (set? x) x (sequential? x) x :else [x]))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2467,9 +2467,9 @@
 
 (deftest function-schema-registry-test
   (swap! @#'m/-function-schemas* update :clj dissoc 'malli.core-test)
-  (let [prior-function-schemas (m/function-schemas)
+  (let [prior-function-schemas (m/function-schemas #?(:cljs :cljs :clj :clj))
         _ (m/=> function-schema-registry-test-fn [:=> :cat :nil])
-        new-function-schemas (m/function-schemas)
+        new-function-schemas (m/function-schemas #?(:cljs :cljs :clj :clj))
         this-ns-schemas (get new-function-schemas 'malli.core-test)
         fn-schema (get this-ns-schemas 'function-schema-registry-test-fn)]
     (is (= (inc (count prior-function-schemas)) (count new-function-schemas)))


### PR DESCRIPTION
Update function schema registration in cljs to store the schemas under the `:cljs` key and look them up via that key when emitting clj kondo configuration.