### PR TITLE
Remove clj-kondo config output for cljs schemas

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -189,16 +189,16 @@
 #?(:clj
    (defn emit! [] (-> (collect) (linter-config) (save!)) nil))
 
-#?(:clj
-   (defn collect-cljs
-     ([] (collect-cljs nil))
-     ([ns]
-      (let [-collect (fn [k] (or (nil? ns) (= k (symbol (str ns)))))]
-        (for [[k vs] (m/function-schemas :cljs) :when (-collect k) [_ v] vs v (from v)] v)))))
+(defn collect-cljs
+  ([] (collect-cljs nil))
+  ([ns]
+   (let [-collect (fn [k] (or (nil? ns) (= k (symbol (str ns)))))]
+     (for [[k vs] (m/function-schemas :cljs) :when (-collect k) [_ v] vs v (from v)] v))))
 
-#?(:clj
-   (defn emit-cljs!* []
-     (-> (collect-cljs) (linter-config) (save!)) nil))
+#?(:cljs
+   (defn- print!* [config]
+     (js/console.log (with-out-str (fipp/pprint config {:width 120})))))
 
-#?(:clj
-   (defmacro emit-cljs! [] (emit-cljs!*)))
+#?(:cljs
+   (defn print-cljs! []
+     (-> (collect-cljs) (linter-config) (print!*)) nil))

--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -13,23 +13,23 @@
           `(do
              ~(mi/-unstrument &env nil)
              ~(do (clj-kondo/save! {}) nil))))
+
 #?(:clj
    (defn start!* [env options]
      `(do
         ~(mi/-unstrument env nil)
-        ~(do (clj-kondo/save! {}) nil)
-        ;; malli.dev/stop ^^
 
         ;; register all function schemas and instrument them based on the options
         ~(mi/-collect-all-ns)
-        ~(mi/-instrument env options)
-        ~(do (clj-kondo/emit-cljs!*) nil)) ) )
+        ~(mi/-instrument env options))))
 
 #?(:clj (defmacro start!
           "Collects defn schemas from all loaded namespaces and starts instrumentation for
            a filtered set of function Vars (e.g. `defn`s). See [[malli.core/-instrument]] for possible options.
-           Also emits clj-kondo type annotations.
-           This does NOT re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
+           Differences from Clojure malli.dev/start:
+
+           - Does not emit clj-kondo type annotations.
+           - Does not re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
           ([] (start!* &env {:report `(pretty/reporter)}))
           ([options] (start!* &env options))))
 

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -52,20 +52,29 @@
                 :z :vector}}
          (clj-kondo/transform Schema)))
 
-  #?(:clj
-     (is (= {'malli.clj-kondo-test
-             {'kikka
-              {:arities {1 {:args [:int],
-                            :ret :int},
-                         :varargs {:args [:int :int {:op :rest, :spec :int}],
-                                   :ret :int,
-                                   :min-arity 2}}}
-              'siren
-              {:arities {2 {:args [:ifn :coll], :ret :map}}}}}
-            (-> 'malli.clj-kondo-test
-                (clj-kondo/collect)
-                (clj-kondo/linter-config)
-                (get-in [:linters :type-mismatch :namespaces])))))
+  (let [expected-out
+        {'malli.clj-kondo-test
+         {'kikka
+          {:arities {1        {:args [:int],
+                               :ret  :int},
+                     :varargs {:args      [:int :int {:op :rest, :spec :int}],
+                               :ret       :int,
+                               :min-arity 2}}}
+          'siren
+          {:arities {2 {:args [:ifn :coll], :ret :map}}}}}]
+    #?(:clj
+       (is (= expected-out
+             (-> 'malli.clj-kondo-test
+               (clj-kondo/collect)
+               (clj-kondo/linter-config)
+               (get-in [:linters :type-mismatch :namespaces])))))
+
+    #?(:cljs
+       (is (= expected-out
+             (-> 'malli.clj-kondo-test
+               (clj-kondo/collect-cljs)
+               (clj-kondo/linter-config)
+               (get-in [:linters :type-mismatch :namespaces]))))))
   (testing "sequential elements"
     (is (= {:op :rest :spec :int}
            (clj-kondo/transform [:repeat :int])))


### PR DESCRIPTION
I have been trying this out and unfortunately realized that kondo support will not be so simple.

If the cljs schemas use vars that are only available during the cljs runtime
we do not have access to them during macroexpansion and thus will cause exceptions.

This line https://github.com/metosin/malli/blob/303c6062f02a2beed62e432c1a1a1046cfa1e288/src/malli/clj_kondo.cljc#L161
will attempt to construct a malli schema and if there any symbols that represent clojurescript variables then there is no way to know their values in clojure.

For now I think removing the kondo support makes sense to allow the instrumentation to work.

As an alternative, we could potentially add clojurescript code that will print out the kondo config to the javascript console when all the vars are available and the user can copy it to the condo config file. I know it's not a great solution but at least provides some value.

_update_: I added a printer helper for cljs.