### PR TITLE
Make `schema?`, `into-schema?` open to extensions

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1907,7 +1907,7 @@
 
 (defn into-schema?
   "Checks if x is a IntoSchema instance"
-  [x] (#?(:clj instance?, :cljs implements?) malli.core.IntoSchema x))
+  [x] (satisfies? IntoSchema x))
 
 (defn into-schema
   "Creates a Schema instance out of type, optional properties map and children"
@@ -1958,7 +1958,7 @@
 
 (defn schema?
   "Checks if x is a Schema instance"
-  [x] (#?(:clj instance?, :cljs implements?) malli.core.Schema x))
+  [x] (satisfies? Schema x))
 
 (defn schema
   "Creates a Schema object from any of the following:

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2659,3 +2659,15 @@
       (is (m/schema? (via-ast :my/bigger-than-3)))
       (is (m/schema? (via-ast :my-bigger-than-4)))
       (is (m/schema? (via-ast 'my/bigger-than-5))))))
+
+(defrecord ExtensionExample []
+  m/Schema
+  m/IntoSchema)
+
+(deftest schema?-test
+  (is (m/schema? (reify m/Schema)))
+  (is (m/schema? (map->ExtensionExample {}))))
+
+(deftest into-schema?-test
+  (is (m/into-schema? (reify m/IntoSchema)))
+  (is (m/into-schema? (map->ExtensionExample {}))))


### PR DESCRIPTION
Hi there,

in Malli 0.8.3 it was easier to implement custom Schema types.

In 0.8.4, protocol extension effectively became a closed thing, since custom implementations would be omitted by `schema?` / `into-schema?`, and therefore also omitted by dependent logic.

I'd be much thankful if it was kept open, which would allow me to continue experimenting with Var support (which so far has been a success and a justified venture).

In general, other users might have other interesting ideas to implement, so leaving the protocol open doesn't seem too crazy.

I'm aware `satisfies?` has a higher cost than `instance?`, however `satisfies?` is far from being implemented naively AFAIK.

Cheers - V