### PR TITLE
relates to #646

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* `malli.transform/default-value-transformer` accepts `mt/add-optional-keys` option:
+
+```clj
+(m/decode
+ [:map
+  [:name [:string {:default "kikka"}]]
+  [:description {:optional true} [:string {:default "kikka"}]]]
+ {}
+ (mt/default-value-transformer {::mt/add-optional-keys true}))
+; => {:name "kikka", :description "kikka"}
+```
+
 ## 0.8.4 (2022-03-02)
 
 * support for 2-arity `default-fn` option in `mt/default-value-transformer` [#582](https://github.com/metosin/malli/pull/582) & [#644](https://github.com/metosin/malli/pull/644)

--- a/README.md
+++ b/README.md
@@ -947,6 +947,30 @@ With custom function:
 ; => {:os "Mac OS X", :timezone "Europe/Helsinki"}
 ```
 
+Optional Keys are not added by default:
+
+```clj
+(m/decode
+ [:map
+  [:name [:string {:default "kikka"}]]
+  [:description {:optional true} [:string {:default "kikka"}]]]
+ {}
+ (mt/default-value-transformer))
+; => {:name "kikka"}
+```
+
+Adding optional keys too via `::mt/add-optional-keys` option:
+
+```clj
+(m/decode
+ [:map
+  [:name [:string {:default "kikka"}]]
+  [:description {:optional true} [:string {:default "kikka"}]]]
+ {}
+ (mt/default-value-transformer {::mt/add-optional-keys true}))
+; => {:name "kikka", :description "kikka"}
+```
+
 Single sweep of defaults & string encoding:
 
 ```clj

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -380,7 +380,7 @@
 (defn default-value-transformer
   ([]
    (default-value-transformer nil))
-  ([{:keys [key default-fn defaults] :or {key :default, default-fn (fn [_ x] x)}}]
+  ([{:keys [key default-fn defaults ::add-optional-keys] :or {key :default, default-fn (fn [_ x] x)}}]
    (let [get-default (fn [schema]
                        (if-some [e (some-> schema m/properties (find key))]
                          (constantly (val e))
@@ -391,7 +391,7 @@
          add-defaults {:compile (fn [schema _]
                                   (let [defaults (into {}
                                                        (keep (fn [[k {:keys [optional] :as p} v]]
-                                                               (when-not optional
+                                                               (when (or (not optional) add-optional-keys)
                                                                  (let [e (find p key)]
                                                                    (when-some [f (if e (constantly (val e))
                                                                                        (get-default v))]

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -790,9 +790,13 @@
 
   (testing "optional key"
     (is (= {:x 5} (m/decode [:map [:x :int] [:y {:optional true, :default 0} :int]] {:x 5}
-                            mt/default-value-transformer)))
+                            (mt/default-value-transformer))))
+    (is (= {:x 5, :y 0} (m/decode [:map [:x :int] [:y {:optional true, :default 0} :int]] {:x 5}
+                                  (mt/default-value-transformer {::mt/add-optional-keys true}))))
     (is (= {:x 5} (m/decode [:map [:x :int] [:y {:optional true} [:int {:default 0}]]] {:x 5}
-                            mt/default-value-transformer))))
+                            (mt/default-value-transformer))))
+    (is (= {:x 5, :y 0} (m/decode [:map [:x :int] [:y {:optional true} [:int {:default 0}]]] {:x 5}
+                                  (mt/default-value-transformer {::mt/add-optional-keys true})))))
 
   (testing "with custom options"
     (is (= false (m/decode [:and {:? false} boolean?] nil (mt/default-value-transformer {:key :?}))))


### PR DESCRIPTION
```clj
(m/decode
 [:map
  [:name [:string {:default "kikka"}]]
  [:description {:optional true} [:string {:default "kikka"}]]]
 {}
 (mt/default-value-transformer {::mt/add-optional-keys true}))
; => {:name "kikka", :description "kikka"}
```
