### PR TITLE
Add a more useful default error reporter for cljs instrumentation

### DIFF
--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -2,7 +2,6 @@
   #?(:cljs (:require-macros [malli.dev.cljs]))
   #?(:cljs (:require [malli.instrument.cljs]))
   #?(:clj (:require [malli.clj-kondo :as clj-kondo]
-                    [malli.dev.pretty :as pretty]
                     [malli.instrument.cljs :as mi])))
 
 #?(:clj (defmacro stop!
@@ -24,11 +23,11 @@
 #?(:clj (defmacro start!
           "Collects defn schemas from all loaded namespaces and starts instrumentation for
            a filtered set of function Vars (e.g. `defn`s). See [[malli.core/-instrument]] for possible options.
-           Differences from Clojure malli.dev/start:
+           Differences from Clojure `malli.dev/start!`:
 
-           - Does not emit clj-kondo type annotations.
+           - Does not emit clj-kondo type annotations. See `malli.clj-kondo/print-cljs!` to print clj-kondo config.
            - Does not re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
-          ([] (start!* &env {:report `(pretty/reporter)}))
+          ([] (start!* &env {}))
           ([options] (start!* &env options))))
 
 #?(:clj (defmacro collect-all! [] (mi/-collect-all-ns)))

--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -52,17 +52,26 @@
 ;; instrument
 ;;
 
-(defn -emit-instrument-fn [env {:keys [gen filters] :as instrument-opts} {:keys [schema] :as schema-map} ns-sym fn-sym]
+(defn -emit-instrument-fn [env {:keys [gen filters report] :as instrument-opts} {:keys [schema] :as schema-map} ns-sym fn-sym]
   ;; gen is a function
   (let [schema-map (-> schema-map
                        (select-keys [:gen :scope :report])
                        ;; The schema passed in may contain cljs vars that have to be resolved at runtime in cljs.
                        (assoc :schema `(m/function-schema ~schema)))
-        schema-map-with-gen
-        (as-> (merge (select-keys instrument-opts [:scope :report :gen]) schema-map) $
-          ;; use the passed in gen fn to generate a value
-          (cond (and gen (true? (:gen schema-map))) (assoc $ :gen gen)
-                :else (dissoc $ :gen)))
+        schema-map-with-gen (as-> (merge (select-keys instrument-opts [:scope :report :gen]) schema-map) $
+                              ;; use the passed in gen fn to generate a value
+                              (if (and gen (true? (:gen schema-map)))
+                                (assoc $ :gen gen)
+                                (dissoc $ :gen)))
+        ;; adds a more useful report function if none is provided.
+        schema-map-with-gen (if report
+                              schema-map-with-gen
+                              (assoc schema-map-with-gen :report
+                                                         `(cljs.core/fn [type# data#]
+                                                            (throw (cljs.core/ex-info
+                                                                     (cljs.core/str type# " error for instrumented function " '~fn-sym)
+                                                                     (assoc (cljs.core/select-keys data# [:value :args])
+                                                                       :type type# :fn '~fn-sym))))))
         replace-var-code (when (ana-api/resolve env fn-sym)
                            `(do
                               (swap! instrumented-vars #(assoc % '~fn-sym ~fn-sym))


### PR DESCRIPTION
Fipp, the pretty printer, is not designed with the browser console in
mind and the output when developing in cljs is not usable.
(Every print call invokes console.log which will result in a new output line per invocation, 
instead of all on one line like in a terminal).
This commit allows navigating directly to the callsite where the error occurred via a JavaScript stacktrace.

This should address https://github.com/metosin/malli/issues/675 and https://github.com/metosin/malli/issues/666

I believe we would have to create another pretty printer namespace for ClojureScript that mirrors the `malli.dev.pretty` namespace but with the browser console in mind to get useful output.
