### PR TITLE
Pass function metadata to malli.core/-instrument

### DIFF
--- a/src/malli/instrument.clj
+++ b/src/malli/instrument.clj
@@ -23,7 +23,7 @@
                                           (true? (:gen d)) (dissoc $ :gen)
                                           :else $))]
                          (alter-meta! v assoc ::original-fn original-fn)
-                         (alter-var-root v (constantly (m/-instrument dgen original-fn)))
+                         (alter-var-root v (constantly (m/-instrument dgen original-fn nil :original-fn-meta (meta v))))
                          (println "..instrumented" v))
            :unstrument (when-let [original-fn (-original v)]
                          (alter-meta! v dissoc ::original-fn)


### PR DESCRIPTION
This change extends the third arity of malli.core/-instrument so that it
optionally accepts the metadata of the old function. That metadata is
passed downstream to the `report` function.

This new modality is called in malli.instrument so that when we render
we can know the name (and the source file location) of the offending
function.