### PR TITLE
cljs instrumentation: ensure malli.generator is available at runtime

### DIFF
--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -1,8 +1,7 @@
 (ns malli.instrument.cljs
   (:require [cljs.analyzer.api :as ana-api]
             [clojure.walk :as walk]
-            [malli.core :as m]
-            [malli.generator :as mg]))
+            [malli.core :as m]))
 
 ;;
 ;; Collect schemas - register them into the known malli.core/-function-schemas[-cljs]* atom based on their metadata.
@@ -125,7 +124,7 @@
 (defn -emit-check [{:keys [schema]} fn-sym]
   `(let [schema# (m/function-schema ~schema)
          fn# (or (get @instrumented-vars '~fn-sym) ~fn-sym)]
-     (when-let [err# (mg/check schema# fn#)]
+     (when-let [err# (perform-check schema# fn#)]
        ['~fn-sym err#])))
 
 (defn -check []

--- a/src/malli/instrument/cljs.cljs
+++ b/src/malli/instrument/cljs.cljs
@@ -1,7 +1,11 @@
 (ns malli.instrument.cljs
-  (:require-macros [malli.instrument.cljs]))
+  (:require-macros [malli.instrument.cljs])
+  (:require [malli.generator :as mg]))
 
 (defonce instrumented-vars (atom {}))
 
 (defn -filter-var [f] (fn [_ s _] (f s)))
 (defn -filter-ns [& ns] (fn [n _ _] ((set ns) n)))
+
+(defn perform-check [schema f]
+  (mg/check schema f))

--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -95,3 +95,7 @@
 
     (is (= 1 (minus-small-int "2")))
     (is (= 9 (minus-small-int 10)))))
+
+(deftest check-test
+  (let [results (mi/check)]
+    (is (map? results))))


### PR DESCRIPTION
To resolve https://github.com/metosin/malli/issues/684

This ensures the client code does not need to `(require [malli.generator])` - the library code will require it instead so the compiler makes it available.