### PR TITLE
Fix cat{n} unparser with invalid value

### DIFF
--- a/src/malli/impl/regex.cljc
+++ b/src/malli/impl/regex.cljc
@@ -184,20 +184,20 @@
   (let [unparsers (vec unparsers)]
     (fn [tup]
       (if (and (vector? tup) (= (count tup) (count unparsers)))
-        (reduce-kv (fn [coll i unparser] (miu/-map-valid #(into coll %) (unparser (get tup i))))
-                   [] unparsers)
+        (miu/-reduce-kv-valid (fn [coll i unparser] (miu/-map-valid #(into coll %) (unparser (get tup i))))
+                              [] unparsers)
         :malli.core/invalid))))
 
 (defn catn-unparser [& unparsers]
   (let [unparsers (into {} unparsers)]
     (fn [m]
       (if (and (map? m) (= (count m) (count unparsers)))
-        (reduce-kv (fn [coll tag unparser]
-                     (if-some [kv (find m tag)]
-                       (miu/-map-valid #(into coll %) (unparser (val kv)))
-                       :malli.core/invalid))
-                   ;; `m` is in hash order, so have to iterate over `unparsers` to restore seq order:
-                   [] unparsers)
+        (miu/-reduce-kv-valid (fn [coll tag unparser]
+                                (if-some [kv (find m tag)]
+                                  (miu/-map-valid #(into coll %) (unparser (val kv)))
+                                  :malli.core/invalid))
+                              ;; `m` is in hash order, so have to iterate over `unparsers` to restore seq order:
+                              [] unparsers)
         :malli.core/invalid))))
 
 (defn cat-transformer

--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -10,6 +10,7 @@
 (defn -invalid? [x] #?(:clj (identical? x :malli.core/invalid), :cljs (keyword-identical? x :malli.core/invalid)))
 (defn -map-valid [f v] (if (-invalid? v) v (f v)))
 (defn -map-invalid [f v] (if (-invalid? v) (f v) v))
+(defn -reduce-kv-valid [f init coll] (reduce-kv (comp #(-map-invalid reduced %) f) init coll))
 
 (defn -error
   ([path in schema value] {:path path, :in in, :schema schema, :value value})

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2659,3 +2659,7 @@
       (is (m/schema? (via-ast :my/bigger-than-3)))
       (is (m/schema? (via-ast :my-bigger-than-4)))
       (is (m/schema? (via-ast 'my/bigger-than-5))))))
+
+(deftest cat-catn-unparse-test
+  (is (= ::m/invalid (m/unparse [:cat string? int? string?] [1 2 3])))
+  (is (= ::m/invalid (m/unparse [:catn [:a string?] [:b int?] [:c string?]] {:a 1 :b 2 :c 3}))))


### PR DESCRIPTION
The reduce-kv calls need to short-circuit on ::m/invalid.

Discovered by Typed Clojure.