### PR TITLE
Use JS constructor property to access RegExp

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2262,7 +2262,9 @@
          (reduce -register-var {}))))
 
 (defn class-schemas []
-  {#?(:clj Pattern, :cljs js/RegExp) (-re-schema true)})
+  {#?(:clj Pattern,
+      ;; closure will complain if you reference the global RegExp object.
+      :cljs (unchecked-get #"" "constructor")) (-re-schema true)})
 
 (defn comparator-schemas []
   (->> {:> >, :>= >=, :< <, :<= <=, := =, :not= not=}


### PR DESCRIPTION
This removes the warning under advanced compilation about accessing the global `RegExp` function from goog closure.

 Addresses: https://github.com/metosin/malli/issues/87

see here for more info:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/constructor