### PR TITLE
Fix breaking instrumenting => when using schemas in other namespaces

### DIFF
--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -47,7 +47,9 @@
     (is (= (plus-over-100 8) 9))
 
     (is (= 4 (power "2")))
-    (is (= 36 (power 6)))
+    (is (= 36 (power 6))))
+  (testing "without instrumentation, from another ns"
+    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test.indirect-fn)]})
 
     (is (= 4 (indirect-fn/power-ret-refer "2")))
     (is (= 36 (indirect-fn/power-ret-refer 6)))
@@ -59,7 +61,10 @@
     (is (= 36 (indirect-fn/power-arg-refer 6)))
 
     (is (= 4 (indirect-fn/power-arg-ns "2")))
-    (is (= 36 (indirect-fn/power-arg-ns 6))))
+    (is (= 36 (indirect-fn/power-arg-ns 6)))
+
+    (is (= 4 (indirect-fn/power-full "2")))
+    (is (= 36 (indirect-fn/power-full 6))))
 
   (testing "with instrumentation"
     (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
@@ -74,7 +79,9 @@
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (plus-over-100 8)))
 
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (power "2")))
-    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (power 6)))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (power 6))))
+  (testing "with instrumentation, from another ns"
+    (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test.indirect-fn)]})
 
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (indirect-fn/power-ret-refer "2")))
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-ret-refer 6)))
@@ -86,7 +93,10 @@
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-arg-refer 6)))
 
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (indirect-fn/power-arg-ns "2")))
-    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-arg-ns 6)))))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-arg-ns 6)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (indirect-fn/power-full "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-full 6)))))
 
 (mi/collect! {:ns ['malli.instrument.cljs-test 'malli.instrument.fn-schemas]})
 

--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -1,6 +1,7 @@
 (ns malli.instrument.cljs-test
   (:require [cljs.test :refer [deftest is testing]]
             [malli.instrument.fn-schemas :refer [sum-nums sum-nums2 str-join str-join2 str-join3 str-join4]]
+            [malli.instrument.cljs-test.indirect-fn :as indirect-fn]
             [malli.core :as m]
             [malli.experimental :as mx]
             [malli.instrument.cljs :as mi]))
@@ -46,7 +47,19 @@
     (is (= (plus-over-100 8) 9))
 
     (is (= 4 (power "2")))
-    (is (= 36 (power 6))))
+    (is (= 36 (power 6)))
+
+    (is (= 4 (indirect-fn/power-ret-refer "2")))
+    (is (= 36 (indirect-fn/power-ret-refer 6)))
+
+    (is (= 4 (indirect-fn/power-ret-ns "2")))
+    (is (= 36 (indirect-fn/power-ret-ns 6)))
+
+    (is (= 4 (indirect-fn/power-arg-refer "2")))
+    (is (= 36 (indirect-fn/power-arg-refer 6)))
+
+    (is (= 4 (indirect-fn/power-arg-ns "2")))
+    (is (= 36 (indirect-fn/power-arg-ns 6))))
 
   (testing "with instrumentation"
     (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test)]})
@@ -61,7 +74,19 @@
     (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (plus-over-100 8)))
 
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (power "2")))
-    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (power 6)))))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (power 6)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (indirect-fn/power-ret-refer "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-ret-refer 6)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (indirect-fn/power-ret-ns "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-ret-ns 6)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (indirect-fn/power-arg-refer "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-arg-refer 6)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (indirect-fn/power-arg-ns "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (indirect-fn/power-arg-ns 6)))))
 
 (mi/collect! {:ns ['malli.instrument.cljs-test 'malli.instrument.fn-schemas]})
 

--- a/test/malli/instrument/cljs_test/defs.cljs
+++ b/test/malli/instrument/cljs_test/defs.cljs
@@ -1,0 +1,7 @@
+(ns malli.instrument.cljs-test.defs
+  "Storing defs for indirect-fn")
+
+(def defs-small-int
+  [:int {:max 6}])
+
+(def defs-int-arg :int)

--- a/test/malli/instrument/cljs_test/indirect_fn.cljs
+++ b/test/malli/instrument/cljs_test/indirect_fn.cljs
@@ -23,3 +23,6 @@
 (mx/defn power-arg-ns :- [:int {:max 6}]
   "Arg, ns"
   [x :- defs/defs-int-arg] (* x x))
+(mx/defn power-full :- malli.instrument.cljs-test.defs/defs-small-int
+  "This appears to pass correctly, when the above aren't breaking during instrumentation"
+  [x :- malli.instrument.cljs-test.defs/defs-int-arg] (* x x))

--- a/test/malli/instrument/cljs_test/indirect_fn.cljs
+++ b/test/malli/instrument/cljs_test/indirect_fn.cljs
@@ -1,0 +1,25 @@
+(ns malli.instrument.cljs-test.indirect-fn
+  "Bug to do with when things are instrumented
+   This declared functions here to be used in cljs_test"
+  (:require [malli.core :as m]
+            [malli.experimental :as mx]
+            [malli.instrument.cljs-test.defs
+             :as defs
+             :refer [defs-small-int defs-int-arg]]))
+
+;; There's a matrix of things to test here
+;; Calling either arg or return type from another namespace
+;;  vs whether doing it as a refer or as a namespaced var
+;; This hits all 4
+(mx/defn power-ret-refer :- defs-small-int
+  "Ret, refer"
+  [x :- :int] (* x x))
+(mx/defn power-ret-ns :- defs/defs-small-int
+  "Ret, ns"
+  [x :- :int] (* x x))
+(mx/defn power-arg-refer :- [:int {:max 6}]
+  "Arg, refer"
+  [x :- defs-int-arg] (* x x))
+(mx/defn power-arg-ns :- [:int {:max 6}]
+  "Arg, ns"
+  [x :- defs/defs-int-arg] (* x x))


### PR DESCRIPTION
Adds a fix and failing tests for https://github.com/metosin/malli/issues/693

At `m/=>` compile time, walks the schema for symbols and namespaces them.

Bug:
Very specifically: the issue happens when you `mi/instrument!` in namespace A, with `mx/defn` or `m/=>` a function in another namespace B, that uses a return type/arg type stored in another var in a third namespace C.
They also fail if the vars are in namespace B, and aren't `refer`red in namespace A.
It does appear to work correctly if the return/arg var are fully namespaced from B.