### PR TITLE
Only call functions from a cljs macro, not other macros

### DIFF
--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -19,7 +19,7 @@
         ~(mi/-unstrument env nil)
 
         ;; register all function schemas and instrument them based on the options
-        ~(mi/-collect-all-ns)
+        ~(mi/-collect-all-ns env)
         ~(mi/-instrument env options))))
 
 #?(:clj (defmacro start!
@@ -32,4 +32,4 @@
           ([] (start!* &env {:report `(pretty/thrower)}))
           ([options] (start!* &env options))))
 
-#?(:clj (defmacro collect-all! [] (mi/-collect-all-ns)))
+#?(:clj (defmacro collect-all! [] (mi/-collect-all-ns &env)))


### PR DESCRIPTION
It seems like `-collect-all-ns` expanding to `(collect! {:ns ~(ana-api/all-ns)})` was causing issues with hot code reloading.
This PR switches to have the `dev/cljs/start!` macro use functions as helpers instead of other cljs macros.
Addresses:
https://github.com/metosin/malli/issues/695