### PR TITLE
Resolve symbols used in function schemas during macroexpansion

### DIFF
--- a/app/malli/helpers.cljs
+++ b/app/malli/helpers.cljs
@@ -1,0 +1,6 @@
+(ns malli.helpers)
+
+(def defs-small-int
+  [:int {:max 6}])
+
+(def int-schema :int)

--- a/app/malli/helpers2.cljs
+++ b/app/malli/helpers2.cljs
@@ -1,0 +1,61 @@
+(ns malli.helpers2
+  (:require
+    [malli.experimental :as mx]
+    [malli.core :as m]
+    [malli.helpers :as h :refer [int-schema]]))
+
+(mx/defn square-it :- h/int-schema
+  [x :- int?]
+  (str x)
+  ;(str (* x x))
+  )
+
+
+;(mx/defn f1 [] 1)
+;(mx/defn f3 [x :- :int] x)
+;(mx/defn f4 :- [:int {:min 0}]
+;  "int int -> int functions"
+;  [x :- [:int {:min 0}], y :- :int]
+;  (+ x y))
+
+(def AB [:map [:a [:int {:min 0}]] [:b :int]])
+(def CD [:map [:c [:int {:min 0}]] [:d :int]])
+
+
+;; schematized, nested keywords args
+(mx/defn f5 :- [:cat :int :int :int :int AB CD]
+  "Nested Keyword argument"
+  [[& {:keys [a b] :as m1} :- AB]
+   & {:keys [c d] :as m2} :- CD]
+  [a b c d m1 m2])
+
+(mx/defn f3 [x :- :int] x)
+(comment
+  (macroexpand
+    '(mx/defn f3 [x :- :int] x)
+    )
+  (macroexpand
+    '(mx/defn f5 :- [:cat :int :int :int :int AB CD]
+      "Nested Keyword argument"
+      [[& {:keys [a b] :as m1} :- AB]
+       & {:keys [c d] :as m2} :- CD]
+      [a b c d m1 m2])
+    )
+  )
+
+;(defn square-it [x] (* x x))
+;(m/=> square-it [:=> [:cat h/int-schema] int-schema])
+
+;(mx/defn square-it2 :- :int     ; h/int-schema
+;  [x :- :int]
+;  (* x x))
+
+;(comment
+;  (macroexpand
+;    '(m/=> square-it [:=> [:cat h/int-schema] :int])
+;    )
+;  (macroexpand-1
+;    '(mx/defn square-it :- :int     ; h/int-schema
+;      [x :- :int]
+;      (* x x))
+;    ))

--- a/app/malli/instrument_app.cljs
+++ b/app/malli/instrument_app.cljs
@@ -1,15 +1,21 @@
 (ns malli.instrument-app
   (:require
     [malli.clj-kondo :as mari]
+    [malli.helpers2 :as h2]
     [malli.core :as m]
     [malli.dev.cljs :as dev]
     [malli.dev.pretty :as pretty]
     [malli.generator :as mg]
     [malli.dev.cljs :as md]
+    [malli.experimental :as mx]
     [malli.instrument.cljs :as mi]))
 
 (defn init []
   (js/console.log "INIT!"))
+
+(comment
+  (meta #'h2/f3))
+
 
 (defn refresh {:dev/after-load true} []
   ;(.log js/console "hot reload")
@@ -166,11 +172,33 @@
 (m/=> plusX [:=> [:cat :int] MyInt])
 
 (defn try-it []
-  (plus "a"))
+
+  (println "sq: " (pr-str (h2/square-it 5)))
+  ;(plus "a")
+  )
 
 (defn ^:dev/after-load x []
   (println "AFTER LOAD - malli.dev.cljs/start!")
-  (md/start!)
+  ;(md/start!)
+
+  (mi/unstrument!)
+
+
+  ;; register all function schemas and instrument them based on the options
+  (md/collect-all!)
+
+  (mi/instrument! {:report (pretty/thrower)
+                   :filters
+                   [(mi/-filter-ns 'malli.helpers2 'malli.instrument-app)]})
+
+
+  (println "f3 1: " (h2/f3 500))
+
+
+  ;(println "f3: " (h2/f3 "500"))
+
+  ;(println "f5 " (h2/f5 [:a 1, :b 2] :c 3, :d 4 ))
+
   (js/setTimeout try-it 200)
   )
 

--- a/test/malli/instrument/fn_schemas.cljs
+++ b/test/malli/instrument/fn_schemas.cljs
@@ -1,5 +1,7 @@
 (ns malli.instrument.fn-schemas
-  (:require [malli.instrument.fn-schemas2 :as schemas :refer [VecOfStrings]]))
+  (:require
+    [malli.experimental :as mx]
+    [malli.instrument.fn-schemas2 :as schemas :refer [small-int int-arg VecOfStrings]]))
 
 (def VecOfInts [:vector :int])
 
@@ -34,3 +36,25 @@
   {:malli/schema [:=> [:cat malli.instrument.fn-schemas2/VecOfStrings] schemas/string]}
   [args]
   (apply str args))
+
+(mx/defn str-join-mx2 :- int?
+  [args :- VecOfInts]
+  (apply str args))
+
+(mx/defn power-ret-refer :- small-int
+  [x :- :int] (* x x))
+
+(mx/defn power-ret-ns :- schemas/small-int
+  [x :- :int] (* x x))
+
+(mx/defn power-arg-refer :- [:int {:max 6}]
+  [x :- int-arg] (* x x))
+
+(mx/defn power-arg-ns :- [:int {:max 6}]
+  [x :- schemas/int-arg] (* x x))
+
+(mx/defn power-full :- malli.instrument.fn-schemas2/small-int
+  [x :- malli.instrument.fn-schemas2/int-arg] (* x x))
+
+(mx/defn power-int? :- small-int
+  [x :- int?] (* x x))

--- a/test/malli/instrument/fn_schemas2.cljs
+++ b/test/malli/instrument/fn_schemas2.cljs
@@ -3,3 +3,8 @@
 (def VecOfStrings [:vector :string])
 
 (def string :string)
+
+(def small-int
+  [:int {:max 6}])
+
+(def int-arg :int)


### PR DESCRIPTION
Picking up on the work by @lsenjov in PR:
https://github.com/metosin/malli/pull/694

If a function schema uses a symbol alias either an ns alias or a refer'ed var the macro would expand as the alias literal. By resolving all symbols used in function schemas during macroexpansion time this problem is solved.