### PR TITLE
Map `:re` schema to clj-kondo `:string`

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -98,7 +98,7 @@
 (defmethod accept :maybe [_ _ [child] _] (if (keyword? child) (keyword "nilable" (name child)) child))
 (defmethod accept :tuple [_ _ children _] children)
 (defmethod accept :multi [_ _ _ _] :any) ;;??
-(defmethod accept :re [_ _ _ _] :regex)
+(defmethod accept :re [_ _ _ _] :string)
 (defmethod accept :fn [_ _ _ _] :fn)
 (defmethod accept :ref [_ _ _ _] :any) ;;??
 (defmethod accept :=> [_ _ _ _] :fn)

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -81,4 +81,8 @@
     (is (= {:op :rest :spec {:op :keys :req {:price :int}}}
            (clj-kondo/transform [:repeat [:map [:price :int]]])))
     (is (= {:op :rest :spec [:int]}
-           (clj-kondo/transform [:repeat [:tuple :int]])))))
+           (clj-kondo/transform [:repeat [:tuple :int]]))))
+
+  (testing "regular expressions"
+    (is (= :string (clj-kondo/transform [:re "kikka"]))
+        "the :re schema models a string, clj-kondo's :regex a Pattern object")))


### PR DESCRIPTION
`:re` schemas are currently mapped to `:regex` in the clj-kondo type generator. This causes schemas that require a string matching a certain pattern to be considered invalid by clj-kondo, as the `:regex` type expects a regular expression object, e.g. a `java.util.regex.Pattern` object.

See [this Slack thread](https://clojurians.slack.com/archives/CLDK6MFMK/p1651066428745799) as well.