### PR TITLE
Add experimental inline instrumented defn macro

### DIFF
--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -52,7 +52,8 @@
                            [:rest [:? [:catn
                                        [:amp "Amp"]
                                        [:arg "Arg"]]]]]}}
-    "Binding"]))
+    "Binding"]
+    {:registry (m/default-schemas)}))
 
 (def Binding (-create false))
 (def SchematizedBinding (-create true))

--- a/src/malli/experimental.cljc
+++ b/src/malli/experimental.cljc
@@ -1,60 +1,94 @@
 (ns malli.experimental
-  (:refer-clojure :exclude [defn])
-  #?(:cljs (:require-macros malli.experimental))
-  (:require [clojure.core :as c]
-            [malli.core :as m]
-            [malli.destructure :as md]))
+  #?@(:cljs
+      [(:require-macros malli.experimental)
+       (:require
+         [malli.core :as m]
+         [malli.dev.pretty])])
+  #?@(:clj
+      [(:refer-clojure :exclude [defn])
+       (:require
+         [clojure.core :as c]
+         [malli.core :as m]
+         [malli.dev.pretty]
+         [malli.destructure :as md])]))
 
-(c/defn -schema [inline-schemas]
-  (m/schema
-   [:schema
-    {:registry {"Schema" any?
-                "Separator" (if inline-schemas [:= :-] md/Never)
-                "Args" [:vector :any]
-                "PrePost" [:map
-                           [:pre {:optional true} [:sequential any?]]
-                           [:post {:optional true} [:sequential any?]]]
-                "Arity" [:catn
-                         [:args "Args"]
-                         [:prepost [:? "PrePost"]]
-                         [:body [:* :any]]]
-                "Params" [:catn
-                          [:name symbol?]
-                          [:return [:? [:catn
-                                        [:- "Separator"]
-                                        [:schema "Schema"]]]]
-                          [:doc [:? string?]]
-                          [:meta [:? :map]]
-                          [:arities [:altn
-                                     [:single "Arity"]
-                                     [:multiple [:catn
-                                                 [:arities [:+ [:schema "Arity"]]]
-                                                 [:meta [:? :map]]]]]]]}}
-    "Params"]))
+#?(:clj
+   (c/defn -schema [inline-schemas]
+     (m/schema
+       [:schema
+        {:registry {"Schema"    any?
+                    "Separator" (if inline-schemas [:= :-] md/Never)
+                    "Args"      [:vector :any]
+                    "PrePost"   [:map
+                                 [:pre {:optional true} [:sequential any?]]
+                                 [:post {:optional true} [:sequential any?]]]
+                    "Arity"     [:catn
+                                 [:args "Args"]
+                                 [:prepost [:? "PrePost"]]
+                                 [:body [:* :any]]]
+                    "Params"    [:catn
+                                 [:name symbol?]
+                                 [:return [:? [:catn
+                                               [:- "Separator"]
+                                               [:schema "Schema"]]]]
+                                 [:doc [:? string?]]
+                                 [:meta [:? :map]]
+                                 [:arities [:altn
+                                            [:single "Arity"]
+                                            [:multiple [:catn
+                                                        [:arities [:+ [:schema "Arity"]]]
+                                                        [:meta [:? :map]]]]]]]}}
+        "Params"]
+       {:registry (m/default-schemas)})))
 
-(def SchematizedParams (-schema true))
-(def Params (-schema false))
+#?(:clj (def SchematizedParams (-schema true)))
+#?(:clj (def Params (-schema false)))
 
-(c/defn -defn [schema args]
-  (let [{:keys [name return doc meta arities] :as parsed} (m/parse schema args)
-        _ (when (= ::m/invalid parsed) (m/-fail! ::parse-error {:schema schema, :args args}))
-        parse (fn [{:keys [args] :as parsed}] (merge (md/parse args) parsed))
-        ->schema (fn [{:keys [schema]}] [:=> schema (:schema return :any)])
-        single (= :single (key arities))
-        parglists (if single (->> arities val parse vector) (->> arities val :arities (map parse)))
-        raw-arglists (map :raw-arglist parglists)
-        schema (as-> (map ->schema parglists) $ (if single (first $) (into [:function] $)))]
-    `(let [defn# (c/defn
-                   ~name
-                   ~@(some-> doc vector)
-                   ~(assoc meta :raw-arglists (list 'quote raw-arglists), :schema schema)
-                   ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
-                   ~@(when-not single (some->> arities val :meta vector)))]
-       (m/=> ~name ~schema)
-       defn#)))
+#?(:clj
+   (c/defn -defn [schema args]
+     (let [{:keys [name return doc meta arities] :as parsed} (m/parse schema args)
+           _            (when (= ::m/invalid parsed) (m/-fail! ::parse-error {:schema schema, :args args}))
+           parse        (fn [{:keys [args] :as parsed}] (merge (md/parse args) parsed))
+           ->schema     (fn [{:keys [schema]}] [:=> schema (:schema return :any)])
+           single       (= :single (key arities))
+           parglists    (if single (->> arities val parse vector) (->> arities val :arities (map parse)))
+           raw-arglists (map :raw-arglist parglists)
+           schema       (as-> (map ->schema parglists) $ (if single (first $) (into [:function] $)))]
+       `(let [defn# (c/defn
+                      ~name
+                      ~@(some-> doc vector)
+                      ~(assoc meta :raw-arglists (list 'quote raw-arglists), :schema schema)
+                      ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
+                      ~@(when-not single (some->> arities val :meta vector)))]
+          (m/=> ~name ~schema)
+          defn#))))
 
+#?(:clj
+   (c/defn ->defn [schema report args]
+     (let [{:keys [name return doc meta arities] :as parsed} (m/parse schema args)
+           _            (when (= ::m/invalid parsed) (m/-fail! ::parse-error {:schema schema, :args args}))
+           parse        (fn [{:keys [args] :as parsed}] (merge (md/parse args) parsed))
+           ->schema     (fn [{:keys [schema]}] [:=> schema (:schema return :any)])
+           single       (= :single (key arities))
+           parglists    (if single (->> arities val parse vector) (->> arities val :arities (map parse)))
+           raw-arglists (map :raw-arglist parglists)
+           schema       (as-> (map ->schema parglists) $ (if single (first $) (into [:function] $)))]
+       `(def ~name (m/-instrument {:schema ~schema :report ~report}
+                     (c/fn ~name
+                       ~@(map (fn [{:keys [arglist prepost body]}] `(~arglist ~prepost ~@body)) parglists)
+                       ~@(when-not single (some->> arities val :meta vector))))))))
 ;;
 ;; public api
 ;;
 
 #?(:clj (defmacro defn [& args] (-defn SchematizedParams args)))
+
+#?(:clj (defmacro >defn
+          "Emits an instrumented function which throws for invalid args or output schemas."
+          [& args]
+          (let [report
+                (if (:ns &env)
+                  `(fn [type# data#] ((malli.dev.pretty/thrower) type#
+                                      (assoc data# :fn-name ~(symbol (str (:name (:ns &env))) (str (first args))))))
+                  `(malli.dev.pretty/thrower))]
+            (->defn SchematizedParams report args))))

--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -148,3 +148,32 @@
 (deftest check-test
   (let [results (mi/check)]
     (is (map? results))))
+
+(mx/>defn times :- :int
+  "x times y"
+  [x :- :int, y :- small-int]
+  (* x y))
+
+(mx/>defn times2 :- :int
+  "x times y"
+  ([x :- :int] (+ 50 x))
+  ([x :- :int, y :- small-int]
+   (* x y)))
+
+(deftest test-experimental-defn
+  (testing "throws on invalid args"
+    (is (thrown-with-msg? js/Error #"Invalid function arguments" (times "2" 1)))
+    (is (thrown-with-msg? js/Error #"Invalid function arguments" (times 2 10)))
+    (is (= 2 (times 2 1)))
+
+    (is (thrown-with-msg? js/Error #"Invalid function arguments" (times2 "2")))
+    (is (thrown-with-msg? js/Error #"Invalid function arguments" (times2 2 10)))
+
+    (is (= 52 (times2 2)))
+    (is (= 2 (times2 2 1))))
+
+  (testing "var metadata is present"
+    (is (= '([x y]) (-> #'times meta :arglists)))
+    (is (= '([x] [x y])) (-> #'times2 meta :arglists))
+    (is (= "x times y" (-> #'times meta :doc)))
+    (is (= "x times y" (-> #'times2 meta :doc)))))


### PR DESCRIPTION
This came out of the discussion over here:
https://github.com/metosin/malli/issues/695

When working in cljs having the code output by macros in the same namespace you're working in will enable repl-driven development without needing to think about refreshing the namespace where `instrument!` was called. 

This PR adds a macro, inspired by Guardrails/Ghostwheel `>defn` macro, which will output an instrumented function.
A parallel `noop` ns can be added to allow controlling this via shadow-cljs config (see https://github.com/fulcrologic/guardrails#dead-code-elimination)

I needed to add the `{:registry (m/default-schemas)}` lines because the schemas used for the parsing code will not always be available if the user is using a custom registry.