### PR TITLE
Remove unstrument from malli.dev.cljs/start - favor hot reloading

### DIFF
--- a/docs/clojurescript-function-instrumentation.md
+++ b/docs/clojurescript-function-instrumentation.md
@@ -5,7 +5,7 @@ Function instrumentation is also supported when developing ClojureScript browser
 Things work differently from the Clojure version of instrumentation because there are no runtime Vars in ClojureScript and thus the 
 instrumentation must happen at compile-time using macros.
 The macro will emit code that `set!`s the function at runtime with a version that validates the function's inputs and outputs
-against its declare malli schema.
+against its declared malli schema.
 
 # Dev Setup
 
@@ -24,13 +24,23 @@ For an application that uses React.js such as Reagent you will typically declare
 ...}
 ```
 
-In your init namespace require `malli.dev.cljs`:
+In your application's entry namespace you need to tell the compiler to always reload this namespace so that the macro will rerun when
+you change schemas and function definitions in other namespaces while developing.
+
+We do this with the `{:dev/always true}` metadata on the namespace:
+
+(this was pointed out by Thomas Heller [here](https://clojureverse.org/t/problem-using-malli-clojurescript-instrumentation-and-shadow-cljs/8612/2).
+  If you're still running into stale code issues during development you can try requiring all namespaces in a preload like he suggests in that comment)
 
 ```clj
-(require [malli.dev.cljs :as md])
+(ns co.my-org.my-app.entry
+  {:dev/always true}
+  (:require [malli.dev.cljs :as md]))
 ```
 
-and invoke `start!` in your init function before rendering your application:
+and require the `malli.dev.cljs` namespace.
+
+In your init function before rendering your application invoke `malli.dev.cljs/start!`
 
 ```clj
 (defn ^:export init [] 

--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -16,8 +16,6 @@
 #?(:clj
    (defn start!* [env options]
      `(do
-        ~(mi/-unstrument env nil)
-
         ;; register all function schemas and instrument them based on the options
         ~(mi/-collect-all-ns env)
         ~(mi/-instrument env options))))
@@ -27,6 +25,7 @@
            a filtered set of function Vars (e.g. `defn`s). See [[malli.core/-instrument]] for possible options.
            Differences from Clojure `malli.dev/start!`:
 
+           - Does not unstrument functions - this is handled by hot reloading.
            - Does not emit clj-kondo type annotations. See `malli.clj-kondo/print-cljs!` to print clj-kondo config.
            - Does not re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
           ([] (start!* &env {:report `(pretty/thrower)}))


### PR DESCRIPTION
This was pointed out in this issue https://github.com/metosin/malli/issues/695
That during (cljs) development if you're changing function definitions in a leaf namespace and do not re-eval the entry namespace where `malli.dev.cljs/start!` is called then you will get stale function values. This is because instrument captures the value of the function. The steps are:

1. instrument captures value of function, stores it in an atom.
2. developer changes definition of function (and code is hot-reloaded)
3. dev/start! runs and set!s previous function value from step 1.
4. developer is confused and code is broken.

So effectively hot reloading already is unstrument.