### PR TITLE
Don't lose properties when updating a key

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -374,8 +374,8 @@
       ;; remove
       (letfn [(cut [v] (into (subvec v 0 i) (subvec v (inc i))))]
         (-simple-entry-parser (dissoc keyset k) (cut children) (cut forms)))
-      (let [c [k p s]
-            p (if i (if override p (nth (children i) 1)) p)
+      (let [p (if i (if override p (nth (children i) 1)) p)
+            c [k p s]
             f (if (seq p) [k p (-form s)] [k (-form s)])]
         (if i
           ;; update

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -466,7 +466,13 @@
                     [:a int?]
                     [:b {:optional true} int?]
                     [:c string?]
-                    [:d boolean?]]))))
+                    [:d boolean?]]))
+
+    (testing "Optional property is maintained when optional key is updated"
+      (is (true? (m/validate
+                  (mu/update schema :b identity)
+                  {:a 1
+                   :c "a string"}))))))
 
 (deftest assoc-in-test
   (is (mu/equals (mu/assoc-in (m/schema [:vector int?]) [0] string?) [:vector string?]))
@@ -507,7 +513,17 @@
                  [:map [:a {:optional false} [:map [:x {:optional false} any?]]]]))
   (is (mu/equals (mu/update-in (m/schema [:map [:a {:optional true} [:map [:x {:optional true} int?]]]])
                                [[:a] [:x {:optional false}]] (constantly any?))
-                 [:map [:a [:map [:x {:optional false} any?]]]])))
+                 [:map [:a [:map [:x {:optional false} any?]]]]))
+
+  (testing "Optional property is maintained when optional key is updated"
+    (let [schema [:map {:title "map"}
+                  [:a int?]
+                  [:b {:optional true} int?]
+                  [:c string?]]]
+      (is (true? (m/validate
+                  (mu/update-in schema [:b] identity)
+                  {:a 1
+                   :c "a string"}))))))
 
 (deftest transform-entries-test
   (let [registry           (mr/composite-registry {:a/x int?} (m/default-schemas))


### PR DESCRIPTION
Fixes #645

Updating a key in a schema that had `{:optional true}` (or any properties) would lose those properties, and a subsequent attempt to validate against that schema without that key would fail. It appears to me (not looked at this codebase before) that this was simply because the new child was being calculated before calculating the properties.

One thing I admittedly don't understand is that even before my fix the output to update looked ok:

```
(malli.util/update
  [:map
   [:a {:optional true} int?]
   [:b {:optional true} string?]]
  :a
  identity)
;; => [:map [:a {:optional true} int?] [:b {:optional true} string?]]
```

This is why the existing tests pass, because they just check this output (I've added a test to run `validate`).

But if you, say, called `malli.util/to-map-syntax` on it, you could see the properties had been lost:

```
{:type :map, :children [[:a nil {:type int?}] [:b {:optional true} {:type string?}]]}
```

With this PR that is no longer the case.