### PR TITLE
:maybe map schema can use :nilable prop in clj-kondo :op spec

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -95,7 +95,11 @@
           (symbol? child) :symbol
           :else :any)))))
 
-(defmethod accept :maybe [_ _ [child] _] (if (keyword? child) (keyword "nilable" (name child)) child))
+(defmethod accept :maybe [_ _ [child] _]
+  (cond
+    (= :keys (:op child)) (assoc child :nilable true)
+    (keyword? child) (keyword "nilable" (name child))
+    :else child))
 (defmethod accept :tuple [_ _ children _] children)
 (defmethod accept :multi [_ _ _ _] :any) ;;??
 (defmethod accept :re [_ _ _ _] :string)

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -44,7 +44,7 @@
           :req {::id :string,
                 :name :string,
                 :description :nilable/string,
-                :select-keys {:op :keys, :req {:x :int}},
+                :select-keys {:op :keys, :req {:x :int} :nilable true},
                 :nested {:op :keys, :req {:id :string, :price :double}},
                 :string-type-enum :nilable/string
                 :keyword-type-enum :keyword


### PR DESCRIPTION
Fixes #714 

The accompanying clj-kondo [PR](https://github.com/clj-kondo/clj-kondo/pull/1736) has been merged, but not released yet.