### PR TITLE
Fix #302: babashka compatibility

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -59,3 +59,25 @@ jobs:
         run: npm ci
       - name: Run tests
         run: bin/node
+
+  build-bb:
+    name: Babashka
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Java 11
+        uses: actions/setup-java@v3.4.0
+        with:
+          distribution: zulu
+          java-version: 11
+          cache: maven
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: latest
+          # bb: latest
+      - name: Download bb master
+        run: bash <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install) --version 0.8.157-SNAPSHOT
+      - name: Run tests
+        run: bb test-bb

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 [![cljdoc badge](https://cljdoc.org/badge/metosin/malli)](https://cljdoc.org/d/metosin/malli/)
 [![Clojars Project](https://img.shields.io/clojars/v/metosin/malli.svg)](https://clojars.org/metosin/malli)
 [![Slack](https://img.shields.io/badge/clojurians-malli-blue.svg?logo=slack)](https://clojurians.slack.com/messages/malli/)
+<a href="https://babashka.org" rel="nofollow"><img src="https://github.com/babashka/babashka/raw/master/logo/badge.svg" alt="bb compatible" style="max-width: 100%;"></a>
 
-Data-driven Schemas for Clojure/Script.
+Data-driven Schemas for Clojure/Script and [babashka](#babashka).
 
 **STATUS**: well matured [*alpha*](#alpha)
 
@@ -2897,6 +2898,31 @@ With sci (18Mb):
 ```clojure
 ./bin/native-image demosci
 ./demosci '[:fn (fn [x] (and (int? x) (> x 10)))]]' '12'
+```
+
+## Babashka
+
+Since version 0.8.9 malli is compatible with [babashka](https://babashka.org/),
+a native, fast starting Clojure interpreter for scripting.
+
+You can add malli to `bb.edn`:
+
+``` clojure
+{:deps {metosin/malli {:mvn/version "0.8.9"}}}
+```
+
+or directly in a babashka script:
+
+``` clojure
+(ns bb-malli
+  (:require [babashka.deps :as deps]))
+
+(deps/add-deps '{:deps {metosin/malli {:mvn/version "0.8.9"}}})
+
+(require '[malli.core :as malli])
+
+(prn (malli/validate [:map [:a [:int]]] {:a 1}))
+(prn (malli/explain [:map [:a [:int]]] {:a "foo"}))
 ```
 
 ## 3rd party libraries

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,20 @@
+{:deps {current/deps {:local/root "."}}
+ :tasks
+ {test-clj {:doc "Run JVM Clojure tests with kaocha"
+            :task (apply clojure (str "-A:" (System/getenv "CLOJURE"))
+                         "-M:test" "-m" "kaocha.runner" *command-line-args*)}
+
+  test-cljs {:doc "Run ClojureScript tests"
+             :task (do
+                     (println "Running CLJS tests without optimizations")
+                     (apply clojure "-M:test:cljs-test-runner" "-c" "{:optimizations :none, :preloads [sci.core]}"
+                            *command-line-args*)
+                     (println "Running CLJS tests with optimizations advanced")
+                     (apply clojure "-M:test:cljs-test-runner" "-c" "{:optimizations :none, :preloads [sci.core]}"
+                            *command-line-args*))}
+
+  test-bb {:doc "Run Babashka tests"
+           :extra-deps {org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
+                                                 :git/sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
+           :extra-paths ["src" "test"]
+           :task bb-test-runner/run-tests}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
-        borkdude/dynaload {:mvn/version "0.2.2"}
+        borkdude/dynaload {:mvn/version "0.3.4"}
         borkdude/edamame {:mvn/version "1.0.0"}
         org.clojure/test.check {:mvn/version "1.1.1"}
         ;; pretty errors, optional deps

--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -1,5 +1,6 @@
 (ns malli.impl.util
-  #?(:clj (:import (clojure.lang MapEntry LazilyPersistentVector)
+  #?(:clj (:import #?(:bb (clojure.lang MapEntry)
+                      :clj (clojure.lang MapEntry LazilyPersistentVector))
                    (java.util.concurrent TimeoutException TimeUnit FutureTask))))
 
 (def ^:const +max-size+ #?(:clj Long/MAX_VALUE, :cljs (.-MAX_VALUE js/Number)))
@@ -22,7 +23,8 @@
                      (if-not (zero? c)
                        (let [oa (object-array c), iter (.iterator ^Iterable os)]
                          (loop [n 0] (when (.hasNext iter) (aset oa n (f (.next iter))) (recur (unchecked-inc n))))
-                         (LazilyPersistentVector/createOwning oa)) []))
+                         #?(:bb (vec oa)
+                            :clj (LazilyPersistentVector/createOwning oa))) []))
              :cljs (into [] (map f) os))))
 
 #?(:clj

--- a/src/malli/sci.cljc
+++ b/src/malli/sci.cljc
@@ -2,11 +2,14 @@
   (:require [borkdude.dynaload :as dynaload]))
 
 (defn evaluator [options fail!]
-  (let [eval-string* (dynaload/dynaload 'sci.core/eval-string* {:default nil})
-        init (dynaload/dynaload 'sci.core/init {:default nil})
-        fork (dynaload/dynaload 'sci.core/fork {:default nil})]
-    (fn [] (if (and @eval-string* @init @fork)
-             (let [ctx (init options)]
-               (eval-string* ctx "(alias 'm 'malli.core)")
-               (fn eval [s] (eval-string* (fork ctx) (str s))))
-             fail!))))
+  #?(:bb (fn []
+           (fn [form]
+             (load-string (str "(ns user (:require [malli.core :as m]))\n" form))))
+     :default (let [eval-string* (dynaload/dynaload 'sci.core/eval-string* {:default nil})
+                    init (dynaload/dynaload 'sci.core/init {:default nil})
+                    fork (dynaload/dynaload 'sci.core/fork {:default nil})]
+                (fn [] (if (and @eval-string* @init @fork)
+                         (let [ctx (init options)]
+                           (eval-string* ctx "(alias 'm 'malli.core)")
+                           (fn eval [s] (eval-string* (fork ctx) (str s))))
+                         fail!)))))

--- a/test/bb_test_runner.clj
+++ b/test/bb_test_runner.clj
@@ -1,0 +1,40 @@
+(ns bb-test-runner
+  (:require
+   [clojure.test :as t]
+   [malli.clj-kondo-test]
+   [malli.core-test]
+   [malli.destructure-test]
+   [malli.dot-test]
+   [malli.error-test]
+   [malli.experimental-test]
+   [malli.generator-test]
+   [malli.instrument-test]
+   [malli.json-schema-test]
+   [malli.plantuml-test]
+   [malli.provider-test]
+   [malli.registry-test]
+   [malli.swagger-test]
+   [malli.transform-test]
+   [malli.util-test]))
+
+(defn run-tests [& _args]
+  (let [{:keys [fail error]}
+        (t/run-tests
+         'malli.core-test
+         'malli.clj-kondo-test
+         'malli.destructure-test
+         'malli.dot-test
+         'malli.error-test
+         'malli.experimental-test
+         'malli.instrument-test
+         'malli.json-schema-test
+         ;; 'malli.generator-test ;; skipped for now due to test.chuck incompatibility
+         'malli.plantuml-test
+         'malli.provider-test
+         'malli.registry-test
+         'malli.swagger-test
+         'malli.transform-test
+         'malli.util-test)]
+    (when (or (pos? fail)
+              (pos? error))
+      (System/exit 1))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -150,7 +150,8 @@
                               [:int [:map [:type [:= :int]] [:int int?]]]
                               [:multi [:map [:type [:= :multi]] [:multi {:optional true} [:ref ::multi]]]]]}} ::multi])))
 
-  #?(:clj (testing "regex"
+  #?(:bb nil ;; test.chuck doesn't work in bb
+     :clj (testing "regex"
             (let [re #"^\d+ \d+$"]
               (m/validate re (mg/generate re)))
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -1,10 +1,19 @@
 (ns malli.util-test
   (:require [clojure.test :refer [are deftest is testing]]
-            #?(:clj [jsonista.core :as json])
+            #?(:bb [cheshire.core :as json]
+               :clj [jsonista.core :as json])
             [malli.core :as m]
             [malli.impl.util :as miu]
             [malli.registry :as mr]
             [malli.util :as mu]))
+
+#?(:clj (defn from-json [s]
+          #?(:bb (json/parse-string s)
+             :clj (json/read-value s))))
+
+#?(:clj (defn to-json [x]
+          #?(:bb (json/generate-string x)
+             :clj (json/write-value-as-string x))))
 
 (defn form= [& ?schemas]
   (apply = (map #(if (m/schema? %) (m/form %) %) ?schemas)))
@@ -1048,11 +1057,11 @@
                             "value" 1}]
                  "schema" ["map" ["a" ["vector" ["maybe" "string"]]]]
                  "value" {"a" 1}}
-                (json/read-value (json/write-value-as-string (mu/explain-data schema input-1)))))
+                (from-json (to-json (mu/explain-data schema input-1)))))
          (is (= {"errors" [{"in" ["a" 0]
                             "path" ["a" 0 0]
                             "schema" "string"
                             "value" true}]
                  "schema" ["map" ["a" ["vector" ["maybe" "string"]]]]
                  "value" {"a" [true]}}
-                (json/read-value (json/write-value-as-string (mu/explain-data schema input-2)))))))))
+                (from-json (to-json (mu/explain-data schema input-2)))))))))


### PR DESCRIPTION
This PR relies on bb master which adds compatibility with malli. Fixes #302.

Notes:
- To make malli work well with bb, the `:bb` reader conditionals rely less on internal details of Clojure and use core functions instead, similar to what happens in `:cljs` branches. As discussed with @puredanger, I didn't add `LazilyPersistentVector` to bb as that was too far off from what is considered a public API.
- Upgrade `borkdude/dynaload` which was made compatible with bb
- Add bb test runner to ensure no breakage happens with future changes to malli
- The evaluation part is implemented by just using `load-string` in bb, since SCI itself isn't exposed yet (might happen in the future). SCI also has `eval-form` which lets you skip the string parsing bit, that might be more performant, but we can address that in a future PR.

@ikitommi I'm not sure what the workflow is with `metosin/malli` but I usually squash+merge the commits through the Github  option (dropdown in merge button). If you want I can squash this PR manually as well.

If you want to try:

```
bash <(curl -s https://raw.githubusercontent.com/babashka/babashka/master/install) --version 0.8.157-SNAPSHOT --dir /tmp
```

for installing bb master in /tmp.
Then in a script:

``` clojure
(ns malli-test
  (:require [babashka.deps :as deps]))

(deps/add-deps '{:deps {metosin/malli
                        {:git/url "https://github.com/borkdude/malli"
                         :git/sha "1ec8582e3a39c8d170cf5f8a7482386bf66370fe"}}})

(require '[malli.core :as malli])

(prn (malli/validate [:map [:a [:int]]] {:a 1}))
(prn (malli/explain [:map [:a [:int]]] {:a "foo"}))
``` 