### PR TITLE
switch Value and Errors in the pretty output order

### DIFF
--- a/src/malli/dev/pretty.cljc
+++ b/src/malli/dev/pretty.cljc
@@ -34,8 +34,8 @@
   (let [{:keys [schema value]} explanation]
     {:body
      [:group
-      (-block "Value:" (v/-visit value printer) printer) :break :break
       (-block "Errors:" (v/-visit (me/humanize explanation) printer) printer) :break :break
+      (-block "Value:" (v/-visit value printer) printer) :break :break
       (-block "Schema:" (v/-visit schema printer) printer) :break :break
       (-block "More information:" (-link "https://cljdoc.org/d/metosin/malli/CURRENT" printer) printer)]}))
 


### PR DESCRIPTION
It's common for the error to go on top of the error report, as the most pertinent part of the information. Otherwise, if the value is too big, the output might become too unwieldy and hide the error. Even now it's not the first thing that catches the eye.

Perhaps there are other ways to address this rather than by changing the default. Please let me know... But I think it might be a reasonable change in this case.

![Screenshot 2022-07-05 at 01 01 30](https://user-images.githubusercontent.com/150242/177223955-1dba7392-bc0d-4ba6-b2be-25d394baf6d0.png)
