### PR TITLE
Add seq to tuple transformation

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -416,7 +416,8 @@
 (defn collection-transformer []
   (let [coders {:vector -sequential-or-set->vector
                 :sequential -sequential-or-set->seq
-                :set -sequential->set}]
+                :set -sequential->set
+                :tuple -sequential->vector}]
     (transformer
      {:decoders coders
       :encoders coders})))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -354,7 +354,8 @@
     ;; sets to sequences / vectors, lose order, is this a good transformation?
     (is (= [1 3 2] (m/decode [:vector int?] #{1 2 3} mt/collection-transformer)))
     (is (= #{1 2 3} (m/decode [:set {:decode/string #(map str %)} int?]
-                              "123" mt/string-transformer))))
+                              "123" mt/string-transformer)))
+    (is (= [1 2 3] (m/decode [:tuple int? int? int?] '(1 2 3) mt/collection-transformer))))
   (testing "encode"
     (is (= #{1 2 3} (m/encode [:set int?] [1 2 3] mt/collection-transformer))))
 


### PR DESCRIPTION
Implementation of #734. I chose `-sequential->vector` instead of the more generous `-sequential-or-set->vector` as order matters in tuples.