### PR TITLE
mask valid values by default with malli.dev.pretty/explain

### DIFF
--- a/src/malli/dev/pretty.cljc
+++ b/src/malli/dev/pretty.cljc
@@ -11,7 +11,8 @@
             :width 100
             :colors v/-dark-colors
             :unknown (fn [x] (when (m/schema? x) (m/form x)))
-            :throwing-fn-top-level-ns-names ["malli" "clojure"]}
+            :throwing-fn-top-level-ns-names ["malli" "clojure" "malli"]
+            ::me/mask-valid-values '...}
            options))))
 
 (defn -errors [explanation printer]
@@ -30,14 +31,13 @@
 ;; formatters
 ;;
 
-(defmethod v/-format ::m/explain [_ _ explanation printer]
-  (let [{:keys [schema value]} explanation]
-    {:body
-     [:group
-      (-block "Errors:" (v/-visit (me/humanize explanation) printer) printer) :break :break
-      (-block "Value:" (v/-visit value printer) printer) :break :break
-      (-block "Schema:" (v/-visit schema printer) printer) :break :break
-      (-block "More information:" (-link "https://cljdoc.org/d/metosin/malli/CURRENT" printer) printer)]}))
+(defmethod v/-format ::m/explain [_ _ {:keys [schema] :as explanation} printer]
+  {:body
+   [:group
+    (-block "Value:" (v/-visit (me/error-value explanation printer) printer) printer) :break :break
+    (-block "Errors:" (v/-visit (me/humanize explanation) printer) printer) :break :break
+    (-block "Schema:" (v/-visit schema printer) printer) :break :break
+    (-block "More information:" (-link "https://cljdoc.org/d/metosin/malli/CURRENT" printer) printer)]})
 
 (defmethod v/-format ::m/invalid-input [_ _ {:keys [args input fn-name]} printer]
   {:body

--- a/src/malli/dev/virhe.cljc
+++ b/src/malli/dev/virhe.cljc
@@ -111,7 +111,7 @@
                    :print-length *print-length*
                    :print-level *print-level*
                    :print-meta *print-meta*}]
-     (map->EdnPrinter (cond->> options defaults (merge defaults))))))
+     (map->EdnPrinter (cond-> defaults options (merge options))))))
 
 (defn -pprint
   ([x] (-pprint x (-printer)))
@@ -158,12 +158,7 @@
   (-color :text body printer))
 
 (defn -section [title location body printer]
-  [:group
-   (-title title location printer)
-   :break :break
-   body
-   :break :break
-   (-footer printer)])
+  [:group (-title title location printer) :break :break body :break :break (-footer printer)])
 
 ;;
 ;; formatting

--- a/test/demo.clj
+++ b/test/demo.clj
@@ -15,3 +15,21 @@
    {:name "Endy"
     :age 17
     :home {:zip 33100}}))
+
+(comment
+ (pretty/explain
+  [:map
+   [:id :int]
+   [:tags [:set :keyword]]
+   [:address [:map
+              [:street :string]
+              [:city :string]
+              [:zip :int]
+              [:lonlat [:tuple :double :double]]]]]
+  {:id "123"
+   :EXTRA "KEY"
+   :tags #{:artesan "coffee" :garden}
+   :address {:street "Ahlmanintie 29"
+             :city "Tampere"
+             :zip 33100
+             :lonlat [61.4858322, 23.7832851]}}))


### PR DESCRIPTION
```clojure
(malli.dev.pretty/explain
 [:map
  [:id :int]
  [:tags [:set :keyword]]
  [:address [:map
             [:street :string]
             [:city :string]
             [:zip :int]
             [:lonlat [:tuple :double :double]]]]]
 {:id "123"
  :EXTRA "KEY"
  :tags #{:artesan "coffee" :garden}
  :address {:street "Ahlmanintie 29"
            :city "Tampere"
            :zip 33100
            :lonlat [61.4858322, 23.7832851]}})
```

=> 

<img width="589" alt="Screenshot 2022-08-10 at 17 44 48" src="https://user-images.githubusercontent.com/567532/183933032-4c4c1b6e-7295-43e9-bb33-3cd0557668aa.png">

