### PR TITLE
cljs instrumentation DX - clear metadata schemas before collection

### DIFF
--- a/app/malli/instrument_app.cljs
+++ b/app/malli/instrument_app.cljs
@@ -1,7 +1,7 @@
 (ns malli.instrument-app
   (:require
     [malli.clj-kondo :as mari]
-    [malli.helpers2 :as h2]
+    ;[malli.helpers2 :as h2]
     [malli.core :as m]
     [malli.dev.cljs :as dev]
     [malli.dev.pretty :as pretty]
@@ -13,9 +13,8 @@
 (defn init []
   (js/console.log "INIT!"))
 
-(comment
-  (meta #'h2/f3))
-
+;(comment
+;  (meta #'h2/f3))
 
 (defn refresh {:dev/after-load true} []
   ;(.log js/console "hot reload")
@@ -29,20 +28,7 @@
 (comment
   (x+y 5 "10"))
 
-(comment
-  (dev/collect-all!)
-  (macroexpand '(dev/collect-all!))
-  (mi/instrument!))
-
 (defn sum [a b] (+ a b))
-
-(comment
-  (sum 1000 "1")
-  (mi/instrument! {})
-  @mi/instrumented-vars
-  (m/function-schemas)
-  (sum 1 1)
-  )
 
 (def sum2
   (m/-instrument {:schema (m/schema [:=> [:cat :int :int] :int])
@@ -69,8 +55,6 @@
   (dec x))
 
 (defn plus-gen
-  "a normal clojure function:malli.core/invalid-schema {:schema #object[malli.core.t_malli$core61329]}
-, no dependencies to malli"
   {:malli/schema [:=> [:cat :int] [:int {:min 6}]]}
   [x]
   (dec x))
@@ -173,35 +157,27 @@
 
 (defn try-it []
 
-  (println "sq: " (pr-str (h2/square-it 5)))
-  ;(plus "a")
+  (println "minus2")
+  (minus2 1 )
   )
 
 (defn ^:dev/after-load x []
   (println "AFTER LOAD - malli.dev.cljs/start!")
-  ;(md/start!)
+  (md/start!)
+  (js/setTimeout try-it 100)
 
-  (mi/unstrument!)
-
-
+  ;(mi/unstrument!)
   ;; register all function schemas and instrument them based on the options
-  (md/collect-all!)
-
-  (mi/instrument! {:report (pretty/thrower)
+  ;(md/collect-all!)
+  #_(mi/instrument! {:report (pretty/thrower)
                    :filters
                    [(mi/-filter-ns 'malli.helpers2 'malli.instrument-app)]})
-
-
-  (println "f3 1: " (h2/f3 500))
-
 
   ;(println "f3: " (h2/f3 "500"))
 
   ;(println "f5 " (h2/f5 [:a 1, :b 2] :c 3, :d 4 ))
 
-  (js/setTimeout try-it 200)
   )
-
 
 (comment
   ((->minus) 5)

--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
                         jmh-clojure/task {:mvn/version "0.1.1"}}
                  :main-opts ["-m" "jmh.main"]}
            :shadow {:extra-paths ["app"]
-                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.19.4"}
+                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.19.9"}
                                  binaryage/devtools {:mvn/version "1.0.6"}}}
            :slow {:extra-deps {io.dominic/slow-namespace-clj
                                {:git/url "https://git.sr.ht/~severeoverfl0w/slow-namespace-clj"

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2399,6 +2399,8 @@
 (defonce ^:private -function-schemas* (atom {}))
 (defn function-schemas ([] (function-schemas :clj)) ([key] (@-function-schemas* key)))
 
+(defn -deregister-function-schemas! [key] (swap! -function-schemas* assoc key {}))
+
 (defn -deregister-metadata-function-schemas!
   [key]
   (swap! -function-schemas* update key

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2399,6 +2399,23 @@
 (defonce ^:private -function-schemas* (atom {}))
 (defn function-schemas ([] (function-schemas :clj)) ([key] (@-function-schemas* key)))
 
+(defn -deregister-metadata-function-schemas!
+  [key]
+  (swap! -function-schemas* update key
+    (fn [fn-schemas-map]
+      (reduce-kv (fn [acc ns-sym fn-map]
+                   (assoc acc ns-sym
+                     (reduce-kv
+                       (fn [acc2 fn-sym fn-map]
+                         ;; rm metadata schemas
+                         (if (:metadata-schema? fn-map)
+                           acc2
+                           (assoc acc2 fn-sym fn-map)))
+                       {}
+                       fn-map)))
+        {}
+        fn-schemas-map))))
+
 (defn function-schema
   ([?schema] (function-schema ?schema nil))
   ([?schema options]

--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -4,7 +4,8 @@
                      [malli.dev.pretty :as pretty]))
   #?(:clj (:require [malli.clj-kondo :as clj-kondo]
                     [malli.dev.pretty :as pretty]
-                    [malli.instrument.cljs :as mi])))
+                    [malli.instrument.cljs :as mi]
+                    [malli.core :as m])))
 
 #?(:clj (defmacro stop!
           "Stops instrumentation for all functions vars and removes clj-kondo type annotations."
@@ -17,6 +18,8 @@
    (defn start!* [env options]
      `(do
         ;; register all function schemas and instrument them based on the options
+        ;; first clear out all metadata schemas to support dev-time removal of metadata schemas on functions - they should not be instrumented
+        ~(m/-deregister-metadata-function-schemas! :cljs)
         ~(mi/-collect-all-ns env)
         ~(mi/-instrument env options))))
 

--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -35,3 +35,8 @@
           ([options] (start!* &env options))))
 
 #?(:clj (defmacro collect-all! [] (mi/-collect-all-ns &env)))
+
+
+#?(:clj (defmacro deregister-function-schemas! []
+          (m/-deregister-function-schemas! :cljs)
+          nil))

--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -4,7 +4,7 @@
             [malli.core :as m]))
 
 ;;
-;; Collect schemas - register them into the known malli.core/-function-schemas[-cljs]* atom based on their metadata.
+;; Collect metadata declared function schemas - register them into the known malli.core/-function-schemas* atom based on their metadata.
 ;;
 
 (defn -collect! [env simple-name {:keys [meta] :as var-map}]
@@ -35,7 +35,9 @@
                                  (symbol (str full-ns) name-part)))
                              form))
             schema* (walk/postwalk -qualify-sym schema)
-            metadata (walk/postwalk -qualify-sym (m/-unlift-keys meta "malli"))]
+            metadata     (assoc
+                           (walk/postwalk -qualify-sym (m/-unlift-keys meta "malli"))
+                           :metadata-schema? true)]
         (m/-register-function-schema! ns simple-name schema* metadata :cljs identity)
         `(do
            (m/-register-function-schema! '~ns '~simple-name ~schema* ~metadata :cljs identity)


### PR DESCRIPTION
During development with instrumentation enabled function schemas declared
with metadata were never deregistered once they were collected.
Thus if a developer removed a schema on a function it would always be instrumented.
This commit adds a flag on metadata schemas to distinguish them from => style schemas
and then removes them before running collection again in malli.dev.cljs/start!

This resolves
https://github.com/metosin/malli/issues/744

demo of metadata schema being added and removed (this is in the sample app in the malli codebase)

https://user-images.githubusercontent.com/467827/186705378-fa0336f6-1010-4540-b848-7868e7801584.mov

Edit:
I realized the same issue will happen with `=>` function schemas: once it is registered and instrumented it would always be instrumented. For this use-case I added a dev-time helper `malli.dev.cljs/deregister-function-schemas!` which will allow a user to remove all registered schemas to get a clean instrumentation state.