### PR TITLE
Attach fn-name metadata to instrumented CLJS functions

### DIFF
--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -81,7 +81,8 @@
         replace-var-code (when (ana-api/resolve env fn-sym)
                            `(do
                               (swap! instrumented-vars #(assoc % '~fn-sym ~fn-sym))
-                              (set! ~fn-sym (m/-instrument ~schema-map-with-gen ~fn-sym))
+                              (set! ~fn-sym (meta-fn (m/-instrument ~schema-map-with-gen ~fn-sym)
+                                                     {:fn-name '~fn-sym}))
                               (.log js/console "..instrumented" '~fn-sym)
                               '~fn-sym))]
     (if filters

--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -82,7 +82,7 @@
                            `(do
                               (swap! instrumented-vars #(assoc % '~fn-sym ~fn-sym))
                               (set! ~fn-sym (meta-fn (m/-instrument ~schema-map-with-gen ~fn-sym)
-                                                     {:fn-name '~fn-sym}))
+                                                     {:instrumented-symbol '~fn-sym}))
                               (.log js/console "..instrumented" '~fn-sym)
                               '~fn-sym))]
     (if filters

--- a/src/malli/instrument/cljs.cljs
+++ b/src/malli/instrument/cljs.cljs
@@ -7,5 +7,14 @@
 (defn -filter-var [f] (fn [_ s _] (f s)))
 (defn -filter-ns [& ns] (fn [n _ _] ((set ns) n)))
 
+(defn meta-fn
+  ;; Taken from https://clojure.atlassian.net/browse/CLJS-3018
+  ;; Because the current MetaFn implementation can cause quirky errors in CLJS
+  [f m]
+  (let [new-f (goog/bind f #js{})]
+    (goog/mixin new-f f)
+    (specify! new-f IMeta #_:clj-kondo/ignore (-meta [_] m))
+    new-f))
+
 (defn perform-check [schema f]
   (mg/check schema f))


### PR DESCRIPTION
Our app uses function values for looking up their original name/symbol from a registry. It is not something we can or want to change, and using malli instrumentation for CLJS breaks this. The reason is that after instrumentation, the anonymous wrapper has a different identity than the original function.

If malli could attach the original symbol as metadata, we are able to use this as an alternative way of obtaining the same thing.

I used the key `:fn-name` as that was used elsewhere in the same code. Possible alternatives:
- `:instrumented-symbol`
- `:instrumented-var`
- `:instrumented-fn`