### PR TITLE
Group instrumentation logging so it doesn't spam the browser console

### DIFF
--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -16,9 +16,11 @@
 #?(:clj
    (defn start!* [env options]
      `(do
+        (js/console.groupCollapsed "Instrumentation done")
         ;; register all function schemas and instrument them based on the options
         ~(mi/-collect-all-ns env)
-        ~(mi/-instrument env options))))
+        ~(mi/-instrument env options)
+        (js/console.groupEnd))))
 
 #?(:clj (defmacro start!
           "Collects defn schemas from all loaded namespaces and starts instrumentation for


### PR DESCRIPTION
When instrumenting tens or hundreds of CLJS functions, getting all those `.. instrumented my.ns` logged in the browser console is quite noisy. 

This makes it slightly better by grouping them collapsed.

A logging config would probably be ideal, but this does the trick for us.