### PR TITLE
Improve generator distribution for sized schemas

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -93,7 +93,7 @@
     (cond
       (and min (= min max)) (gen/fmap str/join (gen/vector gen/char min))
       (and min max) (gen/fmap str/join (gen/vector gen/char min max))
-      min (gen/fmap str/join (gen/sized (fn [size] (gen/vector gen/char min (clojure.core/max size min)))))
+      min (gen/fmap str/join (gen/sized #(gen/vector gen/char min (+ min %))))
       max (gen/fmap str/join (gen/vector gen/char 0 max))
       :else gen/string-alphanumeric)))
 
@@ -108,7 +108,7 @@
       (gen/fmap f (cond
                     (and min (= min max)) (gen/vector gen min)
                     (and min max) (gen/vector gen min max)
-                    min (gen/sized (fn [size] (gen/vector gen min (clojure.core/max size min))))
+                    min (gen/sized #(gen/vector gen min (+ min %)))
                     max (gen/vector gen 0 max)
                     :else (gen/vector gen))))))
 

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -816,12 +816,12 @@
                         (gen/return []))
                       {:seed 0}))))
   (testing "no empty vectors allowed"
-    (is (= '(nil nil [nil nil] [nil] nil [nil nil] nil [nil nil] nil [[nil nil]])
+    (is (= [nil nil [nil nil nil] [nil] nil [nil nil] nil [nil nil nil] nil [[nil nil nil]]]
            (mg/sample [:schema {:registry {::rec [:maybe [:vector {:min 1} [:ref ::rec]]]}} [:ref ::rec]]
                       {:seed 0})
            (mg/sample (gen/recursive-gen
                         (fn [rec]
                           (gen/one-of [(gen/return nil)
-                                       (gen/sized #(gen/vector rec 1 %))]))
+                                       (gen/sized #(gen/vector rec 1 (+ 1 %)))]))
                         (gen/one-of [(gen/return nil)]))
                       {:seed 0})))))


### PR DESCRIPTION
We want the same distribution for `gen/vector` for both
these cases:
1. only :min is provided
2. no min-max opts are passed.

This fixes generation for 1 by using + to shift the length
distribution instead of squashing it via clojure.core/max.

Same approach as clojure.test.check.generators/coll-distinct-by:
  https://github.com/clojure/test.check/blob/b6a318af92e836f1f20960f38a5944168b88d60d/src/main/clojure/clojure/test/check/generators.cljc#L799