### PR TITLE
Refactor cljs fn instrumentation to happen at runtime

### DIFF
--- a/app/malli/helpers.cljs
+++ b/app/malli/helpers.cljs
@@ -4,3 +4,8 @@
   [:int {:max 6}])
 
 (def int-schema :int)
+
+(defn x+y
+  {:malli/schema [:=> [:cat float? float?] :double]}
+  [x y]
+  (+ x y))

--- a/app/malli/instrument_app.cljs
+++ b/app/malli/instrument_app.cljs
@@ -1,17 +1,20 @@
 (ns malli.instrument-app
   (:require
-    [malli.clj-kondo :as mari]
+    [malli.instrument :as mi-new]
+    ;[malli.clj-kondo :as mari]
     ;[malli.helpers2 :as h2]
+    malli.helpers
     [malli.core :as m]
     [malli.dev.cljs :as dev]
     [malli.dev.pretty :as pretty]
     [malli.generator :as mg]
-    [malli.dev.cljs :as md]
+    ;[malli.dev.cljs :as md]
+
+    [malli.instrument.cljs :as mi.old]
     [malli.experimental :as mx]
-    [malli.instrument.cljs :as mi]))
+    ))
 
 (defn init [] (js/console.log "INIT!"))
-
 (defn x+y
   {:malli/schema [:=> [:cat float? float?] :double]}
   [x y]
@@ -24,49 +27,57 @@
                   :report (pretty/reporter)}
     sum))
 
-(m/=> sum [:=> [:cat :int :int] :int])
+;(m/=> sum [:=> [:cat :int :int] :int])
 
 (set! sum
   (m/-instrument {:schema (m/schema [:=> [:cat :int :int] :int])
                   :report (pretty/reporter)}
     sum))
 
+
 (defn minus
   "a normal clojure function, no dependencies to malli"
-  {:malli/schema [:=> [:cat :int] [:int {:min 6}]]
-   :malli/gen    true
-   :malli/scope  #{:input :output}}
+  ;{:malli/schema [:=> [:cat :int] [:int {:min 6}]]
+  ; :malli/gen    true
+  ; :malli/scope  #{:input :output}}
   [x]
   (dec x))
+
 
 (defn plus-gen
-  {:malli/schema [:=> [:cat :int] [:int {:min 6}]]}
+  ;{:malli/schema [:=> [:cat :int] [:int {:min 6}]]}
   [x]
   (dec x))
 
-(comment
-  @mi/instrumented-vars
-  ((get @mi/instrumented-vars `sum) 1 "2"))
+;(comment
+;  @mi/instrumented-vars
+;  ((get @mi/instrumented-vars `sum) 1 "2"))
+
 
 (defn plus1 [a] (inc a))
-(m/=> plus1 [:=> [:cat :int] :int])
+;(m/=> plus1 [:=> [:cat :int] :int])
 
 (defn plus2
   {:validate? true}
   [a b]
   (+ a b))
-(m/=> plus2 [:=> [:cat :string :int] :int])
+;(m/=> plus2 [:=> [:cat :string :int] :int])
 
 ;; multi-arity function
+
 (defn plus-many
+  {:malli/schema
+   [:function
+    [:=> [:cat :int] :int]
+    [:=> [:cat :int :int [:* :int]] :int]]}
   ([a] (inc a))
   ([a b & others]
    (apply + a b others)))
 
-(m/=> plus-many
-  [:function
-   [:=> [:cat :int] :int]
-   [:=> [:cat :int :int [:* :int]] :int]])
+;(m/=> plus-many
+;  [:function
+;   [:=> [:cat :int] :int]
+;   [:=> [:cat :int :int [:* :int]] :int]])
 
 (def pow-gen
   (m/-instrument
@@ -74,6 +85,7 @@
               [:=> [:cat :int] [:int {:max 6}]]
               [:=> [:cat :int :int] [:int {:max 6}]]]
      :gen mg/generate}))
+
 
 (defn minus2
   "kukka"
@@ -85,20 +97,22 @@
 (defn minus-test [x] (dec x))
 
 (defn plus-it [x] (inc x))
-(m/=> plus-it [:=> [:cat :int] [:int {:max 6}]])
+;(m/=> plus-it [:=> [:cat :int] [:int {:max 6}]])
 
 (defn sum3 [a b] (+ a b))
+(comment (meta sum3))
+
 (m/=> sum3 [:=> [:cat :int :int] :int])
+
 
 (def small-int [:int {:max 6}])
 
 (def MyInt (m/-simple-schema {:type 'MyInt, :pred #(and (int? %) (< 100 %))}))
-
-(defn plus [x] (inc x))
-(m/=> plus [:=> [:cat :int] small-int])
+;(defn plus [x] (inc x))
+;(m/=> plus [:=> [:cat :int] small-int])
 
 (defn plusX [x] (inc x))
-(m/=> plusX [:=> [:cat :int] MyInt])
+;(m/=> plusX [:=> [:cat :int] MyInt])
 
 (defn my-function-bad
   {:malli/schema [:=> [:cat :int [:* :int]] :any]}
@@ -115,31 +129,84 @@
      [:function
       ;[:=> [:cat] [:int]]
       [:=> [:cat :int] [:int]]
-      ;[:=> [:cat :string :string] [:string]]
+      [:=> [:cat :string :string] [:string]]
       [:=> [:cat :string :string :string [:* :string]] [:string]]]}
   ([] 500)
   ([a] (inc a))
   ([a b] (str a b))
   ([a b c & more] (str a b c more)))
 
+(defn plus [x] (inc x))
+(m/=> plus [:=> [:cat :int] [:int {:max 6}]])
+
 (defn try-it []
-  (println "minus2")
+  (println "in try-it")
   ;(minus2 1)
   (plus-many 5 8 1 0 20)
+  ;(pure-vary "hi" 50)
+  ;(malli.helpers/x+y "hi" 5)
+  ;(plus-many 5 8 1 "0" 20)
+  ;(mi-new/unstrument!)
+  ;(plus "2")
+  ;(str-join-mx2 [2])
+  (println "after ")
+
+  ;(plus-many 5 8 1 "0" 20)
   ;(plus-many "hi")
   (my-function-bad 1)
+
   (my-function-bad 1 5)
-  ;(my-function-bad 1 nil)
+  (my-function-bad 1 nil)
   ;(pure-vary "hi" 5)
+
   (multi-arity-variadic-fn "a" "b")
   ;; works b/c there is no schema for this arity:
-  (multi-arity-variadic-fn 'a "b" )
+  ;(multi-arity-variadic-fn 'a "b" )
+
   ;; fails as it hits the last fn schema
   (multi-arity-variadic-fn 'a "b" "b")
   ;(multi-arity-variadic-fn "a" "b" "c" :x)
+
   )
 
+(macroexpand '(mi-new/collect! {:ns ['malli.instrument-app 'malli.instrument-test 'malli.instrument.fn-schemas
+                                     ]}))
 (defn ^:dev/after-load x []
   (println "AFTER LOAD - malli.dev.cljs/start!")
-  (md/start!)
+  ;(m/-deregister-metadata-function-schemas! :cljs)
+  ;(dev/collect-all!)
+  ;(mi-new/collect!)
+  ;(mi-new/collect! {:ns [
+  ;                       'malli.instrument-app
+  ;                       'malli.instrument-test 'malli.instrument.fn-schemas]})
+  ;
+  ;(mi-new/unstrument!)
+  ;(mi-new/instrument! {:filters [
+  ;                               (mi-new/-filter-ns 'malli.instrument-test 'malli.instrument.fn-schemas 'malli.instrument-app)
+  ;                               ;(mi-new/-filter-schema (fn [s] (println "FILTER SCHEMA: " s)))
+  ;                               ;(mi-new/-filter-var
+  ;                               ;  #{#'str-join}
+  ;                               ;  ;(fn [x] (= x #'str-join))
+  ;                               ;  )
+  ;                               ]
+  ;                     ;:skip-instrumented? true
+  ;
+  ;                 :report (pretty/thrower)})
+  (dev/start!)
+  ;(mi.old/instrument!)
   (js/setTimeout try-it 100))
+
+
+(comment
+  (macroexpand
+    '(dev/start!))
+  (m/function)
+  (@(Var. (constantly str-join) 'str-join {:metadata 'here}) [1 2])
+  (= (Var. (constantly str-join) `str-join {:metadata 'here})
+    #'str-join)
+  (macroexpand '(dev/collect-all!))
+
+  (macroexpand '(mi-new/collect-all!))
+  (mi-new/-pure-variadic? plus-many)
+  (mi-new/-pure-variadic? pure-vary)
+  (mi-new/-pure-variadic? my-function-bad))

--- a/bin/node
+++ b/bin/node
@@ -6,4 +6,4 @@ echo 'Running CLJS test in Node with optimizations :none'
 clojure -M:test:cljs-test-runner -c '{:optimizations :none, :preloads [sci.core]}' "$@"
 
 echo 'Running CLJS test in Node with optimizations :advanced'
-clojure -M:test:cljs-test-runner -c '{:optimizations :advanced, :preloads [sci.core]}' "$@"
+clojure -M:test:cljs-test-runner -c '{:optimizations :advanced, :preloads [sci.core]}' -e :simple "$@"

--- a/docs/clojurescript-function-instrumentation.md
+++ b/docs/clojurescript-function-instrumentation.md
@@ -2,10 +2,10 @@
 
 Function instrumentation is also supported when developing ClojureScript browser applications.
 
-Things work differently from the Clojure version of instrumentation because there are no runtime Vars in ClojureScript and thus the 
-instrumentation must happen at compile-time using macros.
-The macro will emit code that `set!`s the function at runtime with a version that validates the function's inputs and outputs
-against its declared malli schema.
+The implementation works by collecting function schemas using a ClojureScript macro which registers the function schemas
+available in the application.
+
+Instrumentation happens at runtime in a JavaScript runtime. The functions to instrument are replaced by instrumented versions.
 
 # Dev Setup
 
@@ -59,29 +59,6 @@ To instrument the newly loaded code with shadow-cljs we can use the [lifecylce h
   (md/start!)
   (my-app/mount!))
 ```
-
-It is useful to understand what is happening when you invoke `(malli.dev.cljs/start!)`
-
-The line where `start!` lives in your code will be replaced by a block of code that looks something like:
-
-```clojure
-(set! your-app-ns/a-function
-   (fn [& args] 
-   :; validate the args against the input schema
-   ;; invoke the function your-app-ns/a-function and validate the output against the output schema
-   ;; return the output
-   )
-;; assuming an implementation in your-app-ns like:
-(defn a-function 
-  {:malli/schema [:=> [:cat :int] :string]}
-  [x] 
-  (str x))
-```
-
-(you can see what is actually output here: https://github.com/metosin/malli/blob/400dc0c79805028a6d85413086d4d6d627231940/src/malli/instrument/cljs.clj#L69)
-
-And this is why the order of loaded code will affect the instrumented functions. If the code for `your-app-ns/a-function`
-is hot-reloaded and the `start!` call is never invoked again, the function will no longer be instrumented.
 
 ## Errors in the browser console
 

--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -1,44 +1,42 @@
 (ns malli.dev.cljs
   #?(:cljs (:require-macros [malli.dev.cljs]))
-  #?(:cljs (:require [malli.instrument.cljs]
+  #?(:cljs (:require [malli.instrument :as mi]
+                     [malli.core :as m]
                      [malli.dev.pretty :as pretty]))
-  #?(:clj (:require [malli.clj-kondo :as clj-kondo]
-                    [malli.dev.pretty :as pretty]
-                    [malli.instrument.cljs :as mi]
-                    [malli.core :as m])))
+  #?(:clj (:require [cljs.analyzer.api :as ana-api]
+                    [malli.clj-kondo :as clj-kondo]
+                    [malli.core :as m]
+                    [malli.instrument])))
 
 #?(:clj (defmacro stop!
           "Stops instrumentation for all functions vars and removes clj-kondo type annotations."
           []
           `(do
-             ~(mi/-unstrument &env nil)
+             (malli.instrument/unstrument! nil)
              ~(do (clj-kondo/save! {}) nil))))
 
+#?(:clj (defmacro collect-all! [] (malli.instrument/collect! {:ns (ana-api/all-ns)})))
+
 #?(:clj
-   (defn start!* [env options]
-     `(do
+   (defmacro start!
+     "Collects defn schemas from all loaded namespaces and starts instrumentation for
+      a filtered set of function Vars (e.g. `defn`s). See [[malli.core/-instrument]] for possible options.
+      Differences from Clojure `malli.dev/start!`:
+      - Does not unstrument functions - this is handled by hot reloading.
+      - Does not emit clj-kondo type annotations. See `malli.clj-kondo/print-cljs!` to print clj-kondo config.
+      - Does not re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
+     ([] `(start! {:report (malli.dev.pretty/thrower) :skip-instrumented? true}))
+     ([options]
+      ;; register all function schemas and instrument them based on the options
+      ;; first clear out all metadata schemas to support dev-time removal of metadata schemas on functions - they should not be instrumented
+      `(do
+        (m/-deregister-metadata-function-schemas! :cljs)
+        (malli.instrument/collect! {:ns ~(vec (ana-api/all-ns))})
         (js/console.groupCollapsed "Instrumentation done")
-        ;; register all function schemas and instrument them based on the options
-        ;; first clear out all metadata schemas to support dev-time removal of metadata schemas on functions - they should not be instrumented
-        ~(m/-deregister-metadata-function-schemas! :cljs)
-        ~(mi/-collect-all-ns env)
-        ~(mi/-instrument env options)
-        (js/console.groupEnd))))
+        (malli.instrument/instrument! ~options)
+        (js/console.groupEnd)))))
 
-#?(:clj (defmacro start!
-          "Collects defn schemas from all loaded namespaces and starts instrumentation for
-           a filtered set of function Vars (e.g. `defn`s). See [[malli.core/-instrument]] for possible options.
-           Differences from Clojure `malli.dev/start!`:
-
-           - Does not unstrument functions - this is handled by hot reloading.
-           - Does not emit clj-kondo type annotations. See `malli.clj-kondo/print-cljs!` to print clj-kondo config.
-           - Does not re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
-          ([] (start!* &env {:report `(pretty/thrower)}))
-          ([options] (start!* &env options))))
-
-#?(:clj (defmacro collect-all! [] (mi/-collect-all-ns &env)))
-
-
+;; only used by deprecated malli.instrument.cljs implementation
 #?(:clj (defmacro deregister-function-schemas! []
           (m/-deregister-function-schemas! :cljs)
           nil))

--- a/src/malli/dev/pretty.cljc
+++ b/src/malli/dev/pretty.cljc
@@ -43,7 +43,7 @@
   {:body
    [:group
     (-block "Invalid function arguments:" (v/-visit args printer) printer) :break :break
-    #?(:cljs (-block "Function Var:" (v/-visit fn-name printer) printer)) :break :break
+    (-block "Function Var:" (v/-visit fn-name printer) printer) :break :break
     (-block "Input Schema:" (v/-visit input printer) printer) :break :break
     (-block "Errors:" (-explain input args printer) printer) :break :break
     (-block "More information:" (-link "https://cljdoc.org/d/metosin/malli/CURRENT/doc/function-schemas" printer) printer)]})
@@ -52,7 +52,7 @@
   {:body
    [:group
     (-block "Invalid function return value:" (v/-visit value printer) printer) :break :break
-    #?(:cljs (-block "Function Var:" (v/-visit fn-name printer) printer)) :break :break
+    (-block "Function Var:" (v/-visit fn-name printer) printer) :break :break
     (-block "Function arguments:" (v/-visit args printer) printer) :break :break
     (-block "Output Schema:" (v/-visit output printer) printer) :break :break
     (-block "Errors:" (-explain output value printer) printer) :break :break

--- a/src/malli/instrument.cljs
+++ b/src/malli/instrument.cljs
@@ -1,0 +1,152 @@
+(ns malli.instrument
+  (:require-macros [malli.instrument])
+  (:require [clojure.string :as str]
+            [goog.object :as g]
+            [malli.core :as m]
+            [malli.generator :as mg]))
+
+(defn ^:private -ns-js-path [ns] (into-array (map munge (str/split (str ns) #"\."))))
+(defn ^:private -prop-js-path [ns prop] (into-array (map munge (conj (str/split (str ns) #"\.") (name prop)))))
+(defn ^:private -get-prop [ns prop] (g/getValueByKeys goog/global (-prop-js-path ns prop)))
+(defn ^:private -get-ns [ns] (g/getValueByKeys goog/global (-ns-js-path ns)))
+(defn ^:private -find-var [n s] (-get-prop n s))
+(defn ^:private -sequential [x] (cond (set? x) x (sequential? x) x :else [x]))
+(defn ^:private -original [f] (g/get f "malli$instrument$original"))
+(defn ^:private -instrumented? [f] (true? (g/get f "malli$instrument$instrumented?")))
+
+(defn ^:private meta-fn
+  ;; Taken from https://clojure.atlassian.net/browse/CLJS-3018
+  ;; Because the current MetaFn implementation can cause quirky errors in CLJS
+  [f m]
+  (let [new-f (goog/bind f #js{})]
+    (goog/mixin new-f f)
+    (specify! new-f IMeta #_:clj-kondo/ignore (-meta [_] m))
+    new-f))
+
+(defn -filter-ns [& ns] (fn [n _ _] ((set ns) n)))
+(defn -filter-var [f] (fn [n s d] (f (Var. (constantly (-find-var n s)) (symbol n s) d))))
+(defn -filter-schema [f] (fn [_ _ {:keys [schema]}] (f schema)))
+
+(defn -arity->schema
+  [fn-schema]
+  (into {} (map (fn [schema] [(:arity (m/-function-info (m/schema schema))) schema])
+             (rest fn-schema))))
+
+(defn -variadic? [f] (g/get f "cljs$core$IFn$_invoke$arity$variadic"))
+(defn -max-fixed-arity [f] (g/get f "cljs$lang$maxFixedArity"))
+(defn -pure-variadic? [f]
+  (let [max-fixed-arity (-max-fixed-arity f)]
+    (and max-fixed-arity (-variadic? f)
+      (every? #(not (fn? (g/get f (str "cljs$core$IFn$_invoke$arity$" %)))) (range 20)))))
+
+(defn -replace-variadic-fn [original-fn n s opts]
+  (let [accessor "cljs$core$IFn$_invoke$arity$variadic"
+        arity-fn (g/get original-fn accessor)]
+    (g/set original-fn "malli$instrument$instrumented?" true)
+    ;; the shape of the argument in the following apply calls are needed to match the call style of the cljs compiler
+    ;; so the user's function gets the arguments as expected
+    (let [max-fixed-arity          (-max-fixed-arity original-fn)
+          instrumented-variadic-fn (m/-instrument opts (fn [& args]
+                                                         (let [[fixed-args rest-args] (split-at max-fixed-arity (vec args))
+                                                               final-args (into (vec fixed-args) [(not-empty rest-args)])]
+                                                           (apply arity-fn final-args))))
+          instrumented-wrapper     (fn [& args]
+                                     (let [[fixed-args rest-args] (split-at max-fixed-arity (vec args))
+                                           final-args (vec (apply list* (into (vec fixed-args) (not-empty rest-args))))]
+                                       (apply instrumented-variadic-fn final-args)))]
+      (g/set instrumented-wrapper "malli$instrument$original" arity-fn)
+      (g/set (-get-prop n s) "malli$instrument$instrumented?" true)
+      (g/set (-get-prop n s) accessor instrumented-wrapper)
+      (g/set (-get-ns n) s (meta-fn original-fn {:instrumented-symbol (symbol n s)})))))
+
+(defn -replace-multi-arity [original-fn n s opts]
+  (let [schema (:schema opts)]
+    (g/set original-fn "malli$instrument$instrumented?" true)
+    (g/set (-get-ns n) s (meta-fn original-fn {:instrumented-symbol (symbol n s)}))
+    (doseq [[arity f-schema] (-arity->schema schema)]
+      (if (= arity :varargs)
+        (-replace-variadic-fn original-fn n s opts)
+        (let [accessor        (str "cljs$core$IFn$_invoke$arity$" arity)
+              arity-fn        (g/get original-fn accessor)
+              instrumented-fn (m/-instrument (assoc opts :schema f-schema) arity-fn)]
+          (g/set instrumented-fn "malli$instrument$original" arity-fn)
+          (g/set instrumented-fn "malli$instrument$instrumented?" true)
+          (g/set (-get-prop n s) accessor instrumented-fn))))))
+
+(defn -replace-fn [original-fn n s opts]
+  (cond
+    (-pure-variadic? original-fn) (-replace-variadic-fn original-fn n s opts)
+    (-max-fixed-arity original-fn) (-replace-multi-arity original-fn n s opts)
+    :else (let [instrumented-fn (meta-fn (m/-instrument opts original-fn) {:instrumented-symbol (symbol n s)})]
+            (g/set original-fn "malli$instrument$instrumented?" true)
+            (g/set instrumented-fn "malli$instrument$instrumented?" true)
+            (g/set instrumented-fn "malli$instrument$original" original-fn)
+            (g/set (-get-ns n) (munge (name s)) instrumented-fn))))
+
+(defn -strument!
+  ([] (-strument! nil))
+  ([{:keys [mode data filters gen report skip-instrumented?] :or {skip-instrumented? false
+                                                                  mode :instrument, data (m/function-schemas :cljs)} :as options}]
+   (doseq [[n d] data, [s d] d]
+     (when (or (not filters) (some #(% n s d) filters))
+       (when-let [v (-find-var n s)]
+         (case mode
+           :instrument (let [original-fn (or (-original v) v)
+                             dgen        (as-> (select-keys options [:scope :report :gen]) $
+                                           (cond-> $ report (update :report (fn [r] (fn [t data] (r t (assoc data :fn-name (symbol n s)))))))
+                                           (merge $ d)
+                                           (cond (and gen (true? (:gen d))) (assoc $ :gen gen)
+                                                 (true? (:gen d)) (dissoc $ :gen)
+                                                 :else $))]
+                         (if (and skip-instrumented? (-instrumented? v))
+                           (println "skipping" (symbol n s) "already instrumented")
+                           (do (-replace-fn original-fn n s dgen)
+                               (println "..instrumented" (symbol n s)))))
+
+           :unstrument (when (-instrumented? v)
+                         (let [original-fn (or (-original v) v)]
+                           (cond
+                             (-pure-variadic? original-fn)
+                             (let [accessor         "cljs$core$IFn$_invoke$arity$variadic"
+                                   variadic-fn      (g/get v accessor)
+                                   orig-variadic-fn (g/get variadic-fn "malli$instrument$original")]
+                               (g/set original-fn accessor orig-variadic-fn))
+
+                             (-max-fixed-arity original-fn)
+                             (doseq [arity (conj (range 20) "variadic")
+                                     :let [accessor (str "cljs$core$IFn$_invoke$arity$" arity)
+                                           arity-fn (g/get original-fn accessor)]
+                                     :when arity-fn]
+                               (let [orig (g/get arity-fn "malli$instrument$original")]
+                                 (g/set original-fn accessor orig)))
+
+                             :else (g/set (-get-ns n) (munge (name s)) original-fn)))
+                         (println "..unstrumented" (symbol n s)))
+           (mode v d)))))))
+
+;;
+;; public api
+;;
+
+(defn check
+  "Checks all registered function schemas using generative testing.
+   Returns nil or a map of symbol -> explanation in case of errors."
+  ([] (check nil))
+  ([options]
+   (let [res* (atom {})]
+     (-strument! (assoc options :mode (fn [v {:keys [schema ns name]}]
+                                        (some->> (mg/check schema (-original v))
+                                          (swap! res* assoc (symbol ns name))))))
+     (not-empty @res*))))
+
+(defn instrument!
+  "Applies instrumentation for a filtered set of function Vars (e.g. `defn`s).
+   See [[malli.core/-instrument]] for possible options."
+  ([] (instrument! nil))
+  ([options] (-strument! (assoc options :mode :instrument))))
+
+(defn unstrument!
+  "Removes instrumentation from a filtered set of function Vars (e.g. `defn`s).
+   See [[malli.core/-instrument]] for possible options."
+  ([] (unstrument! nil))
+  ([options] (-strument! (assoc options :mode :unstrument))))

--- a/test/malli/instrument_test.cljs
+++ b/test/malli/instrument_test.cljs
@@ -1,0 +1,199 @@
+(ns malli.instrument-test
+  (:require [cljs.test :refer [deftest is testing]]
+            [malli.instrument.fn-schemas :as schemas :refer [VecOfInts sum-nums sum-nums2 str-join str-join2 str-join3 str-join4]]
+            [malli.instrument.fn-schemas2 :as schemas-2]
+            [malli.core :as m]
+            [malli.experimental :as mx]
+            [malli.instrument :as mi]))
+
+(defn plus [x] (inc x))
+(m/=> plus [:=> [:cat :int] [:int {:max 6}]])
+
+(def small-int [:int {:max 6}])
+
+(defn minus
+  "kukka"
+  {:malli/schema [:=> [:cat :int] [:int {:min 6}]]
+   :malli/scope  #{:input :output}}
+  [x] (dec x))
+
+(defn multi-arity-fn
+  {:malli/schema
+   [:function
+    [:=> [:cat] [:int]]
+    [:=> [:cat :int] [:int]]
+    [:=> [:cat :string :string] [schemas-2/string]]]}
+  ([] 500)
+  ([a] (inc a))
+  ([a b] (str a b)))
+
+(defn multi-arity-variadic-fn
+  {:malli/schema
+   [:function
+    [:=> [:cat] [:int]]
+    [:=> [:cat :int] [schemas-2/int-arg]]
+    [:=> [:cat :string :string] [:string]]
+    [:=> [:cat :string :string [:* :string]] [:string]]]}
+  ([] 500)
+  ([a] (inc a))
+  ([a b] (str a b))
+  ([a b c & more] (str a b c more)))
+
+(defn variadic-fn1
+  {:malli/schema [:=> [:cat [:* :int]] [:int]]}
+  [& vs] (apply + vs))
+
+(defn variadic-fn2
+  {:malli/schema [:=> [:cat :int [:* :int]] [:int]]}
+  [a & vs] (apply + a vs))
+
+(defn minus-small-int
+  "kukka"
+  {:malli/schema [:=> [:cat :int] small-int]
+   :malli/scope  #{:input :output}}
+  [x] (dec x))
+
+(defn plus-small-int [x] (inc x))
+(m/=> plus-small-int [:=> [:cat :int] small-int])
+
+(def Over100 (m/-simple-schema {:type 'Over100, :pred #(and (int? %) (< 100 %))}))
+
+(defn plus-over-100 [x] (inc x))
+(m/=> plus-over-100 [:=> [:cat :int] Over100])
+
+(mx/defn power :- [:int {:max 6}]
+  "inlined schema power"
+  [x :- :int] (* x x))
+
+(mx/defn str-join-mx :- int?
+  [args :- VecOfInts]
+  (apply str args))
+
+(deftest ^:simple instrument!-test
+    (testing "with instrumentation"
+      (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument-test 'malli.instrument.fn-schemas)]})
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (plus "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (plus 6)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (plus-small-int "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (plus-small-int 8)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (plus-over-100 "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (plus-over-100 8)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (power "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (power 6)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join-mx ["2"])))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (str-join-mx [6])))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (schemas/str-join-mx2 ["2"])))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (schemas/str-join-mx2 [6])))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (schemas/power-ret-refer "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (schemas/power-ret-refer 6)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (schemas/power-ret-ns "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (schemas/power-ret-ns 6)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (schemas/power-arg-refer "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (schemas/power-arg-refer 6)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (schemas/power-arg-ns "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (schemas/power-arg-ns 6)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (schemas/power-full "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (schemas/power-full 6)))
+
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (schemas/power-int? "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (schemas/power-int? 6))))
+
+    (testing "without instrumentation"
+      (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument-test 'malli.instrument.fn-schemas)]})
+
+      (is (= "21" (plus "2")))
+      (is (= 7 (plus 6)))
+
+      (is (= (plus-small-int 8) 9))
+      (is (= (plus-over-100 8) 9))
+
+      (is (= 4 (power "2")))
+      (is (= 36 (power 6)))
+
+      (is (= "2" (str-join-mx ["2"])))
+      (is (= "6" (str-join-mx [6])))
+
+      (is (= "2" (schemas/str-join-mx2 ["2"])))
+      (is (= "6" (schemas/str-join-mx2 [6])))
+
+      (is (= 4 (schemas/power-ret-refer "2")))
+      (is (= 36 (schemas/power-ret-refer 6)))
+
+      (is (= 4 (schemas/power-ret-ns "2")))
+      (is (= 36 (schemas/power-ret-ns 6)))
+
+      (is (= 4 (schemas/power-arg-refer "2")))
+      (is (= 36 (schemas/power-arg-refer 6)))
+
+      (is (= 4 (schemas/power-arg-ns "2")))
+      (is (= 36 (schemas/power-arg-ns 6)))
+
+      (is (= 4 (schemas/power-full "2")))
+      (is (= 36 (schemas/power-full 6)))))
+
+(mi/collect! {:ns ['malli.instrument-test 'malli.instrument.fn-schemas]})
+
+(deftest ^:simple collect!-test
+
+  (testing "with instrumentation"
+    (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument-test 'malli.instrument.fn-schemas)]})
+    (println "calling instrumented fn str-join")
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join2 [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join3 [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join4 [1 "2"])))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (sum-nums "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (sum-nums2 "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (minus "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus 6)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (minus-small-int "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-output" (minus-small-int 10)))
+
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (variadic-fn1 1 "2")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (variadic-fn2 1 "2")))
+    (is (= 3 (variadic-fn1 1 2)))
+    (is (= 3 (variadic-fn2 1 2)))
+    (is (= 500 (multi-arity-fn)))
+    (is (= 2 (multi-arity-fn 1)))
+    (is (= "ab" (multi-arity-fn "a" "b")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (multi-arity-fn "a")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (multi-arity-fn 1 2)))
+
+    (is (= 500 (multi-arity-variadic-fn)))
+    (is (= 2 (multi-arity-variadic-fn 1)))
+    (is (= "ab" (multi-arity-variadic-fn "a" "b")))
+    (is (= "abc(\"d\")" (multi-arity-variadic-fn "a" "b" "c" "d")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (multi-arity-variadic-fn "a")))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (multi-arity-variadic-fn 1 2)))
+    (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (multi-arity-variadic-fn 1 2 :c))))
+
+  (testing "without instrumentation"
+    (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument-test 'malli.instrument.fn-schemas)]})
+
+    (is (= 1 (minus "2")))
+    (is (= 5 (minus 6)))
+    (is (= (sum-nums [2 "3" 4 5]) "2345"))
+    (is (= (sum-nums2 [2 "3" 4 5]) "2345"))
+    (is (= (str-join [1 "2"]) "12"))
+    (is (= (str-join2 [1 "2"]) "12"))
+    (is (= (str-join3 [1 "2"]) "12"))
+    (is (= (str-join4 [1 "2"]) "12"))
+
+    (is (= 1 (minus-small-int "2")))
+    (is (= 9 (minus-small-int 10)))))
+
+(deftest ^:simple check-test
+  (let [results (mi/check)]
+    (is (map? results))))


### PR DESCRIPTION
Based on feedback from Thomas Heller (in https://github.com/metosin/malli/pull/754) this PR moves function instrumentation to occur in the JS runtime instead of via macros which emit code to replace the JS functions. The only part that happens at compile time is schema collection. This results in a much closer match to the Clojure implementation.
One downside of this approach is that instrumentation will not work under advanced compilation, but since its intended use is during development this tradeoff makes sense.

I excluded the instrumentation tests from running under advanced compilation.

I left in the namespace `malli.instrument.cljs` for backwards compatibility but it should likely be removed in the future after some grace period.