### PR TITLE
Fix #758: generate alphanumeric strings with :min/:max

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -91,10 +91,10 @@
 (defn- -string-gen [schema options]
   (let [{:keys [min max]} (-min-max schema options)]
     (cond
-      (and min (= min max)) (gen/fmap str/join (gen/vector gen/char min))
-      (and min max) (gen/fmap str/join (gen/vector gen/char min max))
-      min (gen/fmap str/join (gen/sized #(gen/vector gen/char min (+ min %))))
-      max (gen/fmap str/join (gen/vector gen/char 0 max))
+      (and min (= min max)) (gen/fmap str/join (gen/vector gen/char-alphanumeric min))
+      (and min max) (gen/fmap str/join (gen/vector gen/char-alphanumeric min max))
+      min (gen/fmap str/join (gen/sized #(gen/vector gen/char-alphanumeric min (+ min %))))
+      max (gen/fmap str/join (gen/vector gen/char-alphanumeric 0 max))
       :else gen/string-alphanumeric)))
 
 (defn- -coll-gen [schema f options]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -825,3 +825,40 @@
                                        (gen/sized #(gen/vector rec 1 (+ 1 %)))]))
                         (gen/one-of [(gen/return nil)]))
                       {:seed 0})))))
+
+(defn alphanumeric-char? [c]
+  {:pre [(char? c)]}
+  (let [i (int c)]
+    (or (<= (int \a) i (int \z))
+        (<= (int \A) i (int \Z))
+        (<= (int \0) i (int \9)))))
+
+(defn alphanumeric-string? [s]
+  {:pre [(string? s)]}
+  (every? alphanumeric-char? s))
+
+(deftest string-gen-alphanumeric-test
+  (dotimes [seed 100]
+    (testing (pr-str seed)
+      (testing "(and min (= min max))"
+        (is (alphanumeric-string?
+              (mg/generate [:string {:min 10
+                                     :max 10}]
+                           {:seed seed}))))
+      (testing "(and min max)"
+        (is (alphanumeric-string?
+              (mg/generate [:string {:min 10
+                                     :max 20}]
+                           {:seed seed}))))
+      (testing "min"
+        (is (alphanumeric-string?
+              (mg/generate [:string {:min 10}]
+                           {:seed seed}))))
+      (testing "max"
+        (is (alphanumeric-string?
+              (mg/generate [:string {:max 20}]
+                           {:seed seed}))))
+      (testing ":else"
+        (is (alphanumeric-string?
+              (mg/generate [:string {}]
+                           {:seed seed})))))))


### PR DESCRIPTION
The generator for `:string` seems to be intended as a variant on `gen/string-alphanumeric`. If that's the case, we need to use `gen/char-alphanumeric` instead of `gen/char`.