### PR TITLE
Fix instrument! in dev.cljs/start! - pass cljs function schemas

### DIFF
--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -33,7 +33,7 @@
         (m/-deregister-metadata-function-schemas! :cljs)
         (malli.instrument/collect! {:ns ~(vec (ana-api/all-ns))})
         (js/console.groupCollapsed "Instrumentation done")
-        (malli.instrument/instrument! ~options)
+        (malli.instrument/instrument! (assoc ~options :data (m/function-schemas :cljs)))
         (js/console.groupEnd)))))
 
 ;; only used by deprecated malli.instrument.cljs implementation


### PR DESCRIPTION
I totally missed this oversight when updating the code to happen at runtime. 
Nothing was being instrumented in a cljs app I'm working on because `instrument!` is now shared with clojure which defaults to `:clj` schemas.
This fix passes the `:cljs` schemas to `instrument!`