### PR TITLE
Adds `:pred` option to `m/-map-schema`

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -942,7 +942,7 @@
 
 (defn -map-schema
   ([]
-   (-map-schema {:naked-keys true :pred map?}))
+   (-map-schema {:naked-keys true}))
   ([opts] ;; :naked-keys, :lazy, :pred
    ^{:type ::into-schema}
    (reify
@@ -954,7 +954,7 @@
      (-properties-schema [_ _])
      (-children-schema [_ _])
      (-into-schema [parent {:keys [closed] :as properties} children options]
-       (let [pred? (:pred opts)
+       (let [pred? (:pred opts map?)
              entry-parser (-create-entry-parser children opts options)
              form (delay (-create-entry-form parent properties entry-parser options))
              cache (-create-cache options)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -942,7 +942,7 @@
 
 (defn -map-schema
   ([]
-   (-map-schema {:naked-keys true}))
+   (-map-schema {:naked-keys true :pred map?}))
   ([opts] ;; :naked-keys, :lazy, :pred
    ^{:type ::into-schema}
    (reify
@@ -954,7 +954,7 @@
      (-properties-schema [_ _])
      (-children-schema [_ _])
      (-into-schema [parent {:keys [closed] :as properties} children options]
-       (let [pred? (:pred opts map?)
+       (let [pred? (:pred opts)
              entry-parser (-create-entry-parser children opts options)
              form (delay (-create-entry-form parent properties entry-parser options))
              cache (-create-cache options)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2693,39 +2693,34 @@
               :error/message))))))
 
 (deftest -map-schema-test
-  (testing "returns map schema with map? as default :pred fn"
-    (let [DefaultMapSchema (m/-map-schema)
-          data-schema (m/schema [DefaultMapSchema
-                                 [:id uuid?]
-                                 [:name string?]
-                                 [:code {:optional true} int?]
-                                 [:organization [DefaultMapSchema
-                                                 [:id uuid?]
-                                                 [:name {:optional true} string?]
-                                                 [:code int?]]]])
-          test-data {:id (random-uuid)
-                     :name "baz"
-                     :code (rand-int 100)
-                     :organization {:id (random-uuid)
-                                    :code (rand-int 100)}}]
-      (is (m/validate data-schema test-data))))
+  (let [test-data (array-map :id (random-uuid)
+                             :name "baz"
+                             :code (rand-int 100)
+                             :organization (hash-map :id (random-uuid)
+                                                     :code (rand-int 100)))]
+    (testing "returns map schema with map? as default :pred fn"
+      (let [DefaultMapSchema (m/-map-schema)
+            data-schema (m/schema [DefaultMapSchema
+                                   [:id uuid?]
+                                   [:name string?]
+                                   [:code {:optional true} int?]
+                                   [:organization [DefaultMapSchema
+                                                   [:id uuid?]
+                                                   [:name {:optional true} string?]
+                                                   [:code int?]]]])]
+        (is (m/validate data-schema test-data))))
 
-  (testing "returns map schema with custom :pred fn as provided in opts"
-    (let [persistent-array-map? #(instance? PersistentArrayMap %)
-          ArrayMapSchema (m/-map-schema {:pred persistent-array-map?})
-          persistent-hash-map? #(instance? PersistentHashMap %)
-          HashMapSchema (m/-map-schema {:pred persistent-hash-map?})
-          data-schema (m/schema [ArrayMapSchema
-                                 [:id uuid?]
-                                 [:name string?]
-                                 [:code {:optional true} int?]
-                                 [:organization [HashMapSchema
-                                                 [:id uuid?]
-                                                 [:name {:optional true} string?]
-                                                 [:code int?]]]])
-          test-data (array-map :id (random-uuid)
-                               :name "baz"
-                               :code (rand-int 100)
-                               :organization (hash-map :id (random-uuid)
-                                                       :code (rand-int 100)))]
-      (is (m/validate data-schema test-data)))))
+    (testing "returns map schema with custom :pred fn as provided in opts"
+      (let [persistent-array-map? #(instance? PersistentArrayMap %)
+            ArrayMapSchema (m/-map-schema {:pred persistent-array-map?})
+            persistent-hash-map? #(instance? PersistentHashMap %)
+            HashMapSchema (m/-map-schema {:pred persistent-hash-map?})
+            data-schema (m/schema [ArrayMapSchema
+                                   [:id uuid?]
+                                   [:name string?]
+                                   [:code {:optional true} int?]
+                                   [:organization [HashMapSchema
+                                                   [:id uuid?]
+                                                   [:name {:optional true} string?]
+                                                   [:code int?]]]])]
+        (is (m/validate data-schema test-data))))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -10,7 +10,7 @@
             [malli.registry :as mr]
             [malli.transform :as mt]
             [malli.util :as mu])
-  #?(:clj (:import (clojure.lang IFn))))
+  #?(:clj (:import (clojure.lang IFn PersistentArrayMap PersistentHashMap))))
 
 (defn with-schema-forms [result]
   (some-> result
@@ -2691,3 +2691,41 @@
               (m/deref)
               (m/properties)
               :error/message))))))
+
+(deftest -map-schema-test
+  (testing "returns map schema with map? as default :pred fn"
+    (let [DefaultMapSchema (m/-map-schema)
+          data-schema (m/schema [DefaultMapSchema
+                                 [:id uuid?]
+                                 [:name string?]
+                                 [:code {:optional true} int?]
+                                 [:organization [DefaultMapSchema
+                                                 [:id uuid?]
+                                                 [:name {:optional true} string?]
+                                                 [:code int?]]]])
+          test-data {:id (random-uuid)
+                     :name "baz"
+                     :code (rand-int 100)
+                     :organization {:id (random-uuid)
+                                    :code (rand-int 100)}}]
+      (is (m/validate data-schema test-data))))
+
+  (testing "returns map schema with custom :pred fn as provided in opts"
+    (let [persistent-array-map? #(instance? PersistentArrayMap %)
+          ArrayMapSchema (m/-map-schema {:pred persistent-array-map?})
+          persistent-hash-map? #(instance? PersistentHashMap %)
+          HashMapSchema (m/-map-schema {:pred persistent-hash-map?})
+          data-schema (m/schema [ArrayMapSchema
+                                 [:id uuid?]
+                                 [:name string?]
+                                 [:code {:optional true} int?]
+                                 [:organization [HashMapSchema
+                                                 [:id uuid?]
+                                                 [:name {:optional true} string?]
+                                                 [:code int?]]]])
+          test-data (array-map :id (random-uuid)
+                               :name "baz"
+                               :code (rand-int 100)
+                               :organization (hash-map :id (random-uuid)
+                                                       :code (rand-int 100)))]
+      (is (m/validate data-schema test-data)))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2699,7 +2699,7 @@
                              :organization (hash-map :id (random-uuid)
                                                      :code (rand-int 100)))]
     (testing "returns map schema with map? as default :pred fn"
-      (let [DefaultMapSchema (m/-map-schema)
+      (let [DefaultMapSchema (m/-map-schema {:naked-keys true})
             data-schema (m/schema [DefaultMapSchema
                                    [:id uuid?]
                                    [:name string?]


### PR DESCRIPTION
Context:
* Add ability to validate custom map-like datatype e.g. `datomic.query.EntityMap`
* This PR is product of @ikitommi suggestion on [slack thread](https://clojurians.slack.com/archives/CLDK6MFMK/p1665933799819349?thread_ts=1665598460.220999&cid=CLDK6MFMK)
```clojure
;;Would it help if the malli.core/-map-schema took an extra option for the predicate? e.g. on could just do:

(def EntityMap (m/-map-schema {:pred entity?}))

(m/validate EntityMap ...)

```
* `:pred` key-value is optional, just like `:lazy` and `:naked-keys`. In absence of explicit value, `map?` is used as default predicate (referred to as `pred?` in code)


Usage with PR:
```clojure
;; regular usage still works just fine
(m/validate
  (m/schema [:map
             [:member/id uuid?]
             [:member/organization [:map
                                    [:organization/id uuid?]]]])
  {:db/id 409018325533822,
   :member/id #uuid"ff995e8b-77c0-4c03-a8a8-c5db609a2f16",
   :member/organization {:db/id 17592186045562, :organization/id #uuid"25dd7d64-6f83-49fe-bd36-253e985b3e00"}})
=> true

;; a custom predicate fn
(defn entity?
  [entity]
  (instance? datomic.query.EntityMap entity))

;; example member entity
member-entity
=>
{:db/id 409018325533822,
 :member/id #uuid"ff995e8b-77c0-4c03-a8a8-c5db609a2f16",
 :member/organization {:db/id 17592186045562, :organization/id #uuid"25dd7d64-6f83-49fe-bd36-253e985b3e00"}}

;; validation of entity

(m/validate
  (m/schema [:entity-map
             [:member/id uuid?]
             [:member/organization [:entity-map
                                    [:organization/id uuid?]]]]
            {:registry (assoc (m/default-schemas) :entity-map (m/-map-schema {:pred entity?}))})
  mmm)
=> true

```