### PR TITLE
Fix report-fn fn-name symbol constructor in instrument

### DIFF
--- a/src/malli/instrument.clj
+++ b/src/malli/instrument.clj
@@ -20,7 +20,7 @@
          (case mode
            :instrument (let [original-fn (or (-original v) (deref v))
                              dgen (as-> (merge (select-keys options [:scope :report :gen]) d) $
-                                    (cond-> $ report (update :report (fn [r] (fn [t data] (r t (assoc data :fn-name (symbol n s)))))))
+                                    (cond-> $ report (update :report (fn [r] (fn [t data] (r t (assoc data :fn-name (symbol (name n) (name s))))))))
                                     (cond (and gen (true? (:gen d))) (assoc $ :gen gen)
                                           (true? (:gen d)) (dissoc $ :gen)
                                           :else $))]


### PR DESCRIPTION
This  worked for the cljs instrumentation but breaks in clojure. Fixed to support both environments.

Works in cljs:
```clojure
(symbol 'hello 'world)
=> hello/world
```
and breaks in clojure:
```clojure
(symbol 'hello 'world)
=> class clojure.lang.Symbol cannot be cast to class java.lang.String
```
