### PR TITLE
Add tests for malli.dev and malli.dev.cljs

### DIFF
--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -22,6 +22,7 @@
      "Collects defn schemas from all loaded namespaces and starts instrumentation for
       a filtered set of function Vars (e.g. `defn`s). See [[malli.core/-instrument]] for possible options.
       Differences from Clojure `malli.dev/start!`:
+      - The :ns option must be a compile-time literal as the namespace symbol(s) must be available at compile time, not runtime.
       - Does not unstrument functions - this is handled by hot reloading.
       - Does not emit clj-kondo type annotations. See `malli.clj-kondo/print-cljs!` to print clj-kondo config.
       - Does not re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
@@ -30,11 +31,13 @@
       ;; register all function schemas and instrument them based on the options
       ;; first clear out all metadata schemas to support dev-time removal of metadata schemas on functions - they should not be instrumented
       `(do
-        (m/-deregister-metadata-function-schemas! :cljs)
-        (malli.instrument/collect! {:ns ~(vec (ana-api/all-ns))})
-        (js/console.groupCollapsed "Instrumentation done")
-        (malli.instrument/instrument! (assoc ~options :data (m/function-schemas :cljs)))
-        (js/console.groupEnd)))))
+         (m/-deregister-metadata-function-schemas! :cljs)
+         (malli.instrument/collect! {:ns ~(if (:ns options)
+                                            (:ns options)
+                                            (vec (ana-api/all-ns)))})
+         (js/console.groupCollapsed "Instrumentation done")
+         (malli.instrument/instrument! (assoc ~options :data (m/function-schemas :cljs)))
+         (js/console.groupEnd)))))
 
 ;; only used by deprecated malli.instrument.cljs implementation
 #?(:clj (defmacro deregister-function-schemas! []

--- a/src/malli/instrument/cljs.clj
+++ b/src/malli/instrument/cljs.clj
@@ -157,7 +157,7 @@
         replace-var-code (when-let [fn-var (ana-api/resolve env fn-sym)]
                            (-emit-replace-var-code fn-sym (:meta fn-var) schema-map-with-gen schema))]
     (if filters
-      `(when (some #(% '~ns-sym (var ~fn-sym) ~schema-map) ~filters)
+      `(when (some #(% '~ns-sym (resolve '~fn-sym) ~schema-map) ~filters)
          ~replace-var-code)
       replace-var-code)))
 
@@ -187,7 +187,7 @@
                                (.log js/console "..unstrumented" '~fn-sym)
                                '~fn-sym))]
     (if filters
-      `(when (some #(% '~ns-sym (var ~fn-sym) ~opts) ~filters)
+      `(when (some #(% '~ns-sym (resolve '~fn-sym) ~opts) ~filters)
          ~replace-with-orig)
       replace-with-orig)))
 

--- a/test/malli/dev/cljs_test.cljs
+++ b/test/malli/dev/cljs_test.cljs
@@ -1,0 +1,32 @@
+(ns malli.dev.cljs-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [malli.core :as m]
+            [malli.dev.cljs :as md]
+            [malli.instrument :as mi]
+            [malli.dev.pretty :as pretty]))
+
+(defn plus
+  {:malli/schema [:=> [:cat :int] [:int {:max 6}]]}
+  [x] (inc x))
+
+(defn ->plus [] plus)
+
+(deftest ^:simple start!-test
+  (testing "malli.dev.cljs/start!"
+    (testing "without starting"
+      (is (= "21" ((->plus) "2")))
+      (is (= 7 ((->plus) 6))))
+
+    (testing "instrumentation after starting"
+      (md/start! {:ns 'malli.dev.cljs-test :filters [(mi/-filter-ns 'malli.dev.cljs-test)]})
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-input" ((->plus) "2")))
+      (is (thrown-with-msg? js/Error #":malli.core/invalid-output" ((->plus) 6)))
+      (m/-deregister-metadata-function-schemas! :cljs)
+      (mi/unstrument! {:filters [(mi/-filter-ns 'malli.dev.cljs-test)]}))
+
+    (testing "instrumentation after starting with reporter"
+      (md/start! {:ns 'malli.dev.cljs-test :report (pretty/thrower) :filters [(mi/-filter-ns 'malli.dev.cljs-test)]})
+      (is (thrown-with-msg? js/Error #"Invalid function arguments" ((->plus) "2")))
+      (is (thrown-with-msg? js/Error #"Invalid function return value" ((->plus) 6)))
+      (m/-deregister-metadata-function-schemas! :cljs)
+      (mi/unstrument! {:filters [(mi/-filter-ns 'malli.dev.cljs-test)]}))))

--- a/test/malli/dev_test.clj
+++ b/test/malli/dev_test.clj
@@ -1,0 +1,28 @@
+(ns malli.dev-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [malli.dev :as md]
+            [malli.dev.pretty :as pretty]))
+
+(defn plus
+  {:malli/schema [:=> [:cat :int] [:int {:max 6}]]}
+  [x] (inc x))
+
+(defn ->plus [] plus)
+
+(deftest start!-test
+  (testing "malli.dev/start!"
+    (testing "without starting"
+      (is (thrown? ClassCastException ((->plus) "2")))
+      (is (= 7 ((->plus) 6))))
+
+    (testing "instrumentation after starting"
+      (md/start! {:ns *ns*})
+      (is (thrown-with-msg? Exception #":malli.core/invalid-input" ((->plus) "2")))
+      (is (thrown-with-msg? Exception #":malli.core/invalid-output" ((->plus) 6)))
+      (md/stop!))
+
+    (testing "instrumentation after starting with reporter"
+      (md/start! {:ns *ns* :report (pretty/thrower)})
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid function arguments" ((->plus) "2")))
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Invalid function return value" ((->plus) 6)))
+      (md/stop!))))

--- a/test/malli/instrument/cljs_test.cljs
+++ b/test/malli/instrument/cljs_test.cljs
@@ -121,7 +121,6 @@
     (is (= 4 (power "2")))
     (is (= 36 (power 6)))
 
-
     (is (= "2" (str-join-mx ["2"])))
     (is (= "6" (str-join-mx [6])))
 
@@ -146,7 +145,6 @@
 (mi/collect! {:ns ['malli.instrument.cljs-test 'malli.instrument.fn-schemas]})
 
 (deftest collect!-test
-
   (testing "with instrumentation"
     (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument.cljs-test 'malli.instrument.fn-schemas)]})
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join [1 "2"])))

--- a/test/malli/instrument_test.cljs
+++ b/test/malli/instrument_test.cljs
@@ -142,13 +142,12 @@
       (is (= 4 (schemas/power-full "2")))
       (is (= 36 (schemas/power-full 6)))))
 
-(mi/collect! {:ns ['malli.instrument-test 'malli.instrument.fn-schemas]})
-
 (deftest ^:simple collect!-test
+
+  (mi/collect! {:ns ['malli.instrument-test 'malli.instrument.fn-schemas]})
 
   (testing "with instrumentation"
     (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument-test 'malli.instrument.fn-schemas)]})
-    (println "calling instrumented fn str-join")
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join [1 "2"])))
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join2 [1 "2"])))
     (is (thrown-with-msg? js/Error #":malli.core/invalid-input" (str-join3 [1 "2"])))


### PR DESCRIPTION
Adding tests for `malli.dev/start!` and `malli.dev.cljs/start!`.

This resulted in cleaning up some some of the cljs code to ensure the functions exist before they are instrumented and using `resolve` instead of `var` when passing vars to the filter functions, which will return `nil` instead of throwing if a var is missing.

This was discovered from having multiple shadow-cljs builds running, the collection happens at compile time so if you collect all namespaces their vars may not be available in all builds.

In `malli.dev.cljs/start!` the `:ns` argument wasn't properly supported, this PR fixes that.