### PR TITLE
Add malli.dev.cljs-noop namespace and docs for release builds

### DIFF
--- a/docs/clojurescript-function-instrumentation.md
+++ b/docs/clojurescript-function-instrumentation.md
@@ -79,3 +79,90 @@ and if you click the arrow highlighted in this above image you will see the stra
 the instrumented function is the one with the red rectangle around it in the image above.
 
 If you click the filename (`instrument_app.cljs` in this example) the browser devtools will open a file viewer at the problematic call-site.
+
+# Releaes builds
+
+For optimized ClojureScript release builds which produce only the required JavaScript for your production release it is advised
+to use the included `malli.dev.cljs-noop` namespace which will result in adding 9 bytes to your production build instead 
+of pulling in all the instrumentation code.
+
+With shadow-cljs you can configure this like so using the `ns-aliases` build option:
+
+```clojure
+,,,
+ {:main
+  {:target          :browser
+   :output-dir      "resources/public/js/main"
+   :asset-path      "js/main"
+   :modules         {:main {:init-fn com.my-org.client.entry/init}}
+   :closure-defines {malli.registry/type "custom"}
+   :release         {:build-options {:ns-aliases
+                                     {malli.dev.cljs                   malli.dev.cljs-noop
+                                      com.my-org.client.malli-registry com.my-org.client.malli-registry-release}}}
+,,,
+```
+This example also shows how you can include a separate malli registry with only the schemas you need for your production
+release.
+
+This way you can include schemas that are only used for instrumenting functions during development, for example, but for a release include
+only the schemas needed to power functionality of your application.
+
+It should be noted also that metadata declared on function vars in ClojureScript is excluded by default by the ClojureScript
+compiler. The function var metadata is only included in a build if you explicitly invoke a static call to it such as:
+```clojure
+(meta (var com.my-org.some.ns/a-fn))
+```
+Unless you explicitly ask for it, function var metadata will not be included in your compiled JS, so annotating functions
+with malli schemas in metadata has no costs to your builds.
+
+---
+
+Another strategy to get optimal CLJS releases is by having a completely separate entry namespace for release builds.
+
+Then you have to either include a separate shadow-cljs config entry or use a Clojure build script like the following to compile
+your build which will let you have one config build entry in `shadow-cljs.edn` for your app:
+
+```clojure
+(ns fe-build
+  (:require
+    [shadow.cljs.devtools.config :as config]
+    [shadow.cljs.build-report :as report]
+    [shadow.cljs.devtools.api :as sh]))
+
+;; this code was figured out by inspecting the source of the shadow.cljs.devtools.api and related namespaces.
+
+;; replace the entry namespace
+(defn get-config [build-id]
+  (get-in
+    (assoc-in
+      (config/load-cljs-edn!)
+      [:builds build-id :modules :main :init-fn] 'com.my-org.client.release-entry/init)
+    ;; ^ note the :main module name may be different for your app
+    [:builds build-id]))
+
+(defn release-build [{:keys [id] :or {id :main}}]
+  (sh/with-runtime
+    (let [build-config (get-config id)]
+      (sh/release* build-config {})))
+  :done)
+
+(defn build-report [{:keys [id] :or {id :main}}]
+  (report/generate (get-config id)
+    {:print-table true
+     :report-file "fe-report.html"})
+  :done)
+```
+You would include this somewhere on your classpath (like under `src/build`) and then invoke it from the command line or via a REPL:
+
+```bash
+clojure -X:fe-build fe-build/release-build :id :main
+
+# and for the build report:
+
+clojure -X:fe-build fe-build/build-report :id :main
+```
+where `:fe-build` alias has:
+
+```clojure
+:fe-build {:extra-paths ["src/build"]}
+```

--- a/docs/function-schemas.md
+++ b/docs/function-schemas.md
@@ -15,6 +15,7 @@
   * [Defn Instrumentation](#defn-instrumentation)
   * [Defn Checking](#defn-checking)
 * [Development Instrumentation](#development-instrumentation)
+  * [ClojureScript Support](#clojurescript-support)
   * [Static Type Checking](#static-type-checking)
   * [Pretty Errors](#pretty-errors)
 * [Defn Schemas via metadata](#defn-schemas-via-metadata)
@@ -621,6 +622,10 @@ It's main entry points is `dev/start!`, taking same options as `mi/instrument!`.
 ; =prints=> ..unstrumented #'user/plus1
 ; =prints=> stopped instrumentation
 ```
+
+## ClojureScript support
+
+See the document: [docs/clojurescript-function-instrumentation.md](clojurescript-function-instrumentation.md)
 
 ### Static Type Checking
 

--- a/src/malli/dev/cljs_noop.cljc
+++ b/src/malli/dev/cljs_noop.cljc
@@ -1,0 +1,7 @@
+(ns malli.dev.cljs-noop
+  #?(:cljs (:require-macros [malli.dev.cljs-noop])))
+
+#?(:clj (defmacro stop! []))
+#?(:clj (defmacro collect-all! []))
+#?(:clj (defmacro start! ([]) ([options])))
+#?(:clj (defmacro deregister-function-schemas! []))


### PR DESCRIPTION
- Add `malli.dev.cljs-noop` namespace
- Add documentation on getting optimal cljs releases