### PR TITLE
infer :enum and := transformers from int? or keyword? values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * **BREAKING**: Change default of `:malli.provider/map-of-threshold` from 3 to 8
 * New `malli.core/coercer` and `malli.core/coerce` to decode and validate a value, throws on validation error.
 * New `malli.core/-no-op-transformer`
+* both `mt/json-transformer` and `mt/string-transformer` support auto type-detection of `:enum` and `:=` child type (detects homogenous `:keyword`, `:symbol`, `:int` or `:double`)
 
 ## 0.9.2 (2022-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * **BREAKING**: Change default of `:malli.provider/map-of-threshold` from 3 to 8
 * New `malli.core/coercer` and `malli.core/coerce` to decode and validate a value, throws on validation error.
 * New `malli.core/-no-op-transformer`
-* both `mt/json-transformer` and `mt/string-transformer` support auto type-detection of `:enum` and `:=` child type (detects homogenous `:keyword`, `:symbol`, `:int` or `:double`)
+* both `mt/json-transformer` and `mt/string-transformer` support auto type-detection of `:enum` and `:=` child type (detects homogenous `:keyword`, `:symbol`, `:int` or `:double`), [#782](https://github.com/metosin/malli/pull/782)
 
 ## 0.9.2 (2022-10-18)
 

--- a/README.md
+++ b/README.md
@@ -808,7 +808,7 @@ Coercion can be applied without transformer, doing just validation:
 ; =throws=> :malli.core/invalid-input {:value "42", :schema :int, :explain {:schema :int, :value "42", :errors ({:path [], :in [], :schema :int, :value "42"})}}
 ```
 
-### Advanced 
+### Advanced Transformations
 
 Transformations are recursive:
 
@@ -848,6 +848,13 @@ Transform map keys:
 ;            "city" "Tampere"
 ;            "zip" 33100
 ;            "lonlat" [61.4858322 23.7854658]}}
+```
+
+Transforming homogenous `:enum` or `:=`s (supports automatic type detection of `:keyword`, `:symbol`, `:int` and `:double`):
+
+```clojure
+(m/decode [:enum :kikka :kukka] "kukka" mt/string-transformer)
+; => :kukka
 ```
 
 Transformers can be composed with `mt/transformer`:

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -75,7 +75,7 @@
 
 (defprotocol Transformer
   (-transformer-chain [this] "returns transformer chain as a vector of maps with :name, :encoders, :decoders and :options")
-  (-value-transformer [this schema method options] "returns an value transforming interceptor for the given schema and method"))
+  (-value-transformer [this schema method options] "returns a value transforming interceptor for the given schema and method"))
 
 (defprotocol RegexSchema
   (-regex-op? [this] "is this a regex operator (e.g. :cat, :*...)")

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -197,6 +197,10 @@
     (set? x) (seq x)
     :else x))
 
+(defn -infer-child-decoder-compiler [schema _]
+  (cond (every? keyword? (m/children schema)) -string->keyword
+        (every? int? (m/children schema)) -string->long))
+
 ;;
 ;; decoders
 ;;
@@ -217,6 +221,9 @@
    'uuid? -string->uuid
    'double? -number->double
    'inst? -string->date
+
+   :enum {:compile -infer-child-decoder-compiler}
+   := {:compile -infer-child-decoder-compiler}
 
    :double -number->double
    :keyword -string->keyword
@@ -267,7 +274,6 @@
     :>= -string->long
     :< -string->long
     :<= -string->long
-    := -string->long
     :not= -string->long
 
     'number? -string->double

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -198,8 +198,11 @@
     :else x))
 
 (defn -infer-child-decoder-compiler [schema _]
-  (cond (every? keyword? (m/children schema)) -string->keyword
-        (every? int? (m/children schema)) -string->long))
+  (let [children (m/children schema)]
+    (cond (every? keyword? children) -string->keyword
+          (every? symbol? children) -string->symbol
+          (every? int? children) -string->long
+          (every? float? children) -string->double)))
 
 ;;
 ;; decoders

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -889,7 +889,7 @@
              (m/encode schema $ mt/string-transformer)
              (m/decode schema $ mt/string-transformer))))))
 
-(deftest inferring-enum-and-:=schema-decoders-test
+(deftest inferring-child-decoders-test
   (let [schema [:map
                 [:enum1 [:enum :created :running :closed]]
                 [:enum2 [:enum 1 2 3]]
@@ -908,4 +908,3 @@
     (testing "works with json and string transformers"
       (is (= expected (m/decode schema value (mt/json-transformer))))
       (is (= expected (m/decode schema value (mt/string-transformer)))))))
-

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -173,7 +173,7 @@
             (is (= expected (m/decode schema value t)))
             (is (f (m/decode schema value t))))
 
-          [:set [:enum 1 2]] ["1" 2 "3"] #{"1" 2 "3"} set?
+          [:set [:enum 1 2 "3"]] ["1" 2 "3"] #{"1" 2 "3"} set?
 
           [:set keyword?] nil nil nil?
           [:set keyword?] ["1" 2 "3"] #{:1 2 :3} set?
@@ -888,3 +888,24 @@
            (as-> value $
              (m/encode schema $ mt/string-transformer)
              (m/decode schema $ mt/string-transformer))))))
+
+(deftest inferring-enum-and-:=schema-decoders-test
+  (let [schema [:map
+                [:enum1 [:enum :created :running :closed]]
+                [:enum2 [:enum 1 2 3]]
+                [:equals1 [:= :kikka]]
+                [:equals2 [:= 42]]]
+        value {:enum1 "created"
+               :enum2 "2"
+               :equals1 "kikka"
+               :equals2 "42"}
+        expected {:enum1 :created
+                  :enum2 2
+                  :equals1 :kikka
+                  :equals2 42}]
+    (testing "is not enabled by default"
+      (is (= value (m/decode schema value nil))))
+    (testing "works with json and string transformers"
+      (is (= expected (m/decode schema value (mt/json-transformer))))
+      (is (= expected (m/decode schema value (mt/string-transformer)))))))
+

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -891,18 +891,30 @@
 
 (deftest inferring-child-decoders-test
   (let [schema [:map
-                [:enum1 [:enum :created :running :closed]]
-                [:enum2 [:enum 1 2 3]]
+                [:enum1 [:enum :kikka :kukka]]
+                [:enum2 [:enum 'kikka 'kukka]]
+                [:enum3 [:enum 1 2]]
+                [:enum4 [:enum 1.1 2.2]]
                 [:equals1 [:= :kikka]]
-                [:equals2 [:= 42]]]
-        value {:enum1 "created"
-               :enum2 "2"
+                [:equals2 [:= 'kikka]]
+                [:equals3 [:= 1]]
+                [:equals4 [:= 1.1]]]
+        value {:enum1 "kikka"
+               :enum2 "kikka"
+               :enum3 "1"
+               :enum4 "1.1"
                :equals1 "kikka"
-               :equals2 "42"}
-        expected {:enum1 :created
-                  :enum2 2
+               :equals2 "kikka"
+               :equals3 "1"
+               :equals4 "1.1"}
+        expected {:enum1 :kikka
+                  :enum2 'kikka
+                  :enum3 1
+                  :enum4 1.1
                   :equals1 :kikka
-                  :equals2 42}]
+                  :equals2 'kikka
+                  :equals3 1
+                  :equals4 1.1}]
     (testing "is not enabled by default"
       (is (= value (m/decode schema value nil))))
     (testing "works with json and string transformers"


### PR DESCRIPTION
Similar to Plumatic [solution](https://github.com/plumatic/schema/blob/13725858557d247008c458b76841cba8546bd0de/src/cljc/schema/coerce.cljc#L74).

```clojure
;; uniform :enum type
(m/decode [:enum :A :B :C] "A" (mt/string-transformer))
; => :A

;; non-uniform :enum type
(m/decoder [:map [:x [:enum :A :B "C"]]] (mt/string-transformer))
; => #object[clojure.core$identity]
```