### PR TITLE
Infer real schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * New `malli.core/-no-op-transformer`
 * automatic type inferring with `:enum` and `:=` with `malli.transform` and `malli.json-schema` - detects homogenous `:string`, `:keyword`, `:symbol`, `:int` and `:double`), [#782](https://github.com/metosin/malli/pull/782) & [#784](https://github.com/metosin/malli/pull/784)
 * **BREAKING**: Prefer to real Schemas instead of predicates (e.g. `:int` over `'int?`)
+* New `:some` schema (like `some?`)
 
 ## 0.9.2 (2022-10-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * New `malli.core/coercer` and `malli.core/coerce` to decode and validate a value, throws on validation error.
 * New `malli.core/-no-op-transformer`
 * automatic type inferring with `:enum` and `:=` with `malli.transform` and `malli.json-schema` - detects homogenous `:string`, `:keyword`, `:symbol`, `:int` and `:double`), [#782](https://github.com/metosin/malli/pull/782) & [#784](https://github.com/metosin/malli/pull/784)
+* **BREAKING**: Prefer to real Schemas instead of predicates (e.g. `:int` over `'int?`)
 
 ## 0.9.2 (2022-10-18)
 

--- a/README.md
+++ b/README.md
@@ -1685,15 +1685,15 @@ Inspired by [F# Type providers](https://docs.microsoft.com/en-us/dotnet/fsharp/t
 
 (mp/provide samples)
 ;[:map
-; [:id string?]
-; [:tags [:set keyword?]]
+; [:id :string]
+; [:tags [:set :keyword]]
 ; [:address
 ;  [:map
-;   [:street string?]
-;   [:city string?]
-;   [:zip number?]
-;   [:lonlat [:vector double?]]]]
-; [:description {:optional true} string?]]
+;   [:street :string]
+;   [:city :string]
+;   [:zip :int]
+;   [:lonlat [:vector :double]]]]
+; [:description {:optional true} :string]]
 ```
 
 All samples are valid against the inferred schema:
@@ -1718,14 +1718,19 @@ For better performance, use `mp/provider`:
 
 ### :map-of inferring
 
-Inferring `:map-of` requires 3 identical key & value schemas:
+Inferring `:map-of` requires 8 identical key & value schemas:
 
 ```clojure
 (mp/provide
   [{:a [1]
     :b [1 2]
-    :c [1 2 3]}])
-; [:map-of keyword? [:vector int?]]
+    :c [1 2 3]
+    :d [1 2]
+    :e [1 2 3]
+    :f [1]
+    :g [1]
+    :h [1 2 3 4]}])
+; [:map-of :keyword [:vector :int]]
 ```
 
 This can be configured via `::mp/map-of-threshold` options:
@@ -1735,7 +1740,7 @@ This can be configured via `::mp/map-of-threshold` options:
   [{:a [1]
     :b [1 2]}]
   {::mp/map-of-threshold 2})
-; [:map-of keyword? [:vector int?]]
+; [:map-of :keyword [:vector :int]]
 ```
 
 Sample-data can be type-hinted with `::mp/hint`:
@@ -1747,11 +1752,11 @@ Sample-data can be type-hinted with `::mp/hint`:
     :b {:b 2, :c 1}
     :c {:b 3}
     :d nil}])
-;[:map-of
-; keyword?
-; [:maybe [:map
-;          [:b int?]
-;          [:c {:optional true} int?]]]]
+;[:map-of 
+; :keyword 
+; [:maybe [:map 
+;          [:b :int] 
+;          [:c {:optional true} :int]]]]
 ```
 
 ### :tuple inferring
@@ -1774,7 +1779,7 @@ There is `::mp/tuple-threshold` option:
    [2 "kukka" true]
    [3 "kakka" false]]
   {::mp/tuple-threshold 3})
-; [:tuple int? string? boolean?]
+; [:tuple :int :string :boolean]
 ```
 
 Sample-data can be type-hinted with `::mp/hint`:

--- a/README.md
+++ b/README.md
@@ -1768,7 +1768,7 @@ By default, tuples are not inferred:
   [[1 "kikka" true]
    [2 "kukka" true]
    [3 "kakka" true]])
-; [:vector some?]
+; [:vector :some]
 ```
 
 There is `::mp/tuple-threshold` option:
@@ -1789,7 +1789,7 @@ Sample-data can be type-hinted with `::mp/hint`:
   [^{::mp/hint :tuple}
    [1 "kikka" true]
    ["2" "kukka" true]])
-; [:tuple some? string? boolean?]
+; [:tuple :some string? boolean?]
 ```
 
 ### value decoding in inferring
@@ -2920,7 +2920,7 @@ Comparator functions as keywords: `:>`, `:>=`, `:<`, `:<=`, `:=` and `:not=`.
 
 #### `malli.core/type-schemas`
 
-Type-like schemas: `:any`, `:nil`, `:string`, `:int`, `:double`, `:boolean`, `:keyword`, `:qualified-keyword`, `:symbol`, `:qualified-symbol`, and `:uuid`.
+Type-like schemas: `:any`, `:some`, `:nil`, `:string`, `:int`, `:double`, `:boolean`, `:keyword`, `:qualified-keyword`, `:symbol`, `:qualified-symbol`, and `:uuid`.
 
 ### `malli.core/sequence-schemas`
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -663,6 +663,7 @@
 
 (defn -nil-schema [] (-simple-schema {:type :nil, :pred nil?}))
 (defn -any-schema [] (-simple-schema {:type :any, :pred any?}))
+(defn -some-schema [] (-simple-schema {:type :some, :pred some?}))
 (defn -string-schema [] (-simple-schema {:type :string, :pred string?, :property-pred (-min-max-pred count)}))
 (defn -int-schema [] (-simple-schema {:type :int, :pred int?, :property-pred (-min-max-pred nil)}))
 (defn -double-schema [] (-simple-schema {:type :double, :pred double?, :property-pred (-min-max-pred nil)}))
@@ -2323,6 +2324,7 @@
 
 (defn type-schemas []
   {:any (-any-schema)
+   :some (-some-schema)
    :nil (-nil-schema)
    :string (-string-schema)
    :int (-int-schema)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -398,6 +398,7 @@
       (-never-gen options))))
 #?(:clj (defmethod -schema-generator :re [schema options] (-re-gen schema options)))
 (defmethod -schema-generator :any [_ _] (ga/gen-for-pred any?))
+(defmethod -schema-generator :some [_ _] gen/any-printable)
 (defmethod -schema-generator :nil [_ _] (gen/return nil))
 (defmethod -schema-generator :string [schema options] (-string-gen schema options))
 (defmethod -schema-generator :int [schema options] (gen/large-integer* (-min-max schema options)))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -138,6 +138,7 @@
 (defmethod accept :fn [_ _ _ _] {})
 
 (defmethod accept :any [_ _ _ _] {})
+(defmethod accept :some [_ _ _ _] {})
 (defmethod accept :nil [_ _ _ _] {:type "null"})
 
 (defmethod accept :string [_ schema _ _]

--- a/src/malli/provider.cljc
+++ b/src/malli/provider.cljc
@@ -2,8 +2,8 @@
   (:require [malli.core :as m]
             [malli.registry :as mr]))
 
-(def -preferences (-> ['int? 'integer? 'double? 'number? 'qualified-keyword? 'keyword? 'symbol? 'string? 'boolean? 'uuid?]
-                      (reverse) (zipmap (drop 1 (range))) (assoc :any -13, :or -12, :and -11, 'any? -10, 'some? -9)))
+(def -preferences (-> [:int 'integer? :double 'number? :qualified-keyword :keyword :symbol :string :boolean :uuid 'inst?]
+                      (reverse) (zipmap (drop 1 (range))) (assoc 'any? -13, :or -12, :and -11, :any -10, 'some? -9)))
 
 (defn -safe? [f & args] (try (apply f args) (catch #?(:clj Exception, :cljs js/Error) _ false)))
 
@@ -78,7 +78,7 @@
                                                  (cond->> vs vp (-decoded t vp)))
                                         (:set :vector :sequential) (-sequential-schema stats type -schema options)
                                         :map (-map-schema (type types) -schema options)))
-         (nil? types) 'any?
+         (nil? types) :any
          :else (let [children (map (fn [[type]] (-schema (update stats :types select-keys [type]) options)) types)
                      without-nils (remove #(= % :nil) children)
                      [c1 c2] (map count [children without-nils])]

--- a/src/malli/provider.cljc
+++ b/src/malli/provider.cljc
@@ -3,7 +3,7 @@
             [malli.registry :as mr]))
 
 (def -preferences (-> [:int 'integer? :double 'number? :qualified-keyword :keyword :symbol :string :boolean :uuid 'inst?]
-                      (reverse) (zipmap (drop 1 (range))) (assoc 'any? -13, :or -12, :and -11, :any -10, 'some? -9)))
+                      (reverse) (zipmap (drop 1 (range))) (assoc 'any? -14 'some? -13, :or -12, :and -11, :any -10, :some -9)))
 
 (defn -safe? [f & args] (try (apply f args) (catch #?(:clj Exception, :cljs js/Error) _ false)))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1953,6 +1953,12 @@
                    :map-syntax {:type :any}
                    :ast {:type :any}
                    :form :any}
+             :some {:schema :some
+                    :validate {:success [1 "kikka"]
+                               :failure [nil]}
+                    :map-syntax {:type :some}
+                    :ast {:type :some}
+                    :form :some}
              :nil {:schema :nil
                    :validate {:success [nil], :failure [1 "kikka"]}
                    :map-syntax {:type :nil}

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -30,6 +30,7 @@
 
   (testing "simple schemas"
     (doseq [schema [:any
+                    :some
                     [:string {:min 1, :max 4}]
                     [:int {:min 1, :max 4}]
                     [:double {:min 0.0, :max 1.0}]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -67,6 +67,7 @@
    [[:re "^[a-z]+\\.[a-z]+$"] {:type "string", :pattern "^[a-z]+\\.[a-z]+$"}]
    [[:fn {:gen/elements [1]} int?] {}]
    [:any {}]
+   [:some {}]
    [:nil {:type "null"}]
    [[:string {:min 1, :max 4}] {:type "string", :minLength 1, :maxLength 4}]
    [[:int {:min 1, :max 4}] {:type "integer", :minimum 1, :maximum 4}]

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -20,7 +20,7 @@
    [[:vector :any] [[]]]
 
    [[:maybe :int] [1 nil 2 3]]
-   [[:maybe some?] [1 nil 2 "some"]]
+   [[:maybe :some] [1 nil 2 "some"]]
    [[:maybe [:map [:x :int]]] [{:x 1} nil]]
    [[:maybe [:or [:map [:x :int]] :string]] [{:x 1} nil "1"]]
 
@@ -75,13 +75,13 @@
       "8" {:name "8"}}]]
 
    ;; tuple-like without options
-   [[:vector some?]
+   [[:vector :some]
     [[1 "kikka" true]
      [2 "kukka" true]
      [3 "kakka" false]]]
 
    ;; tuple-like with threshold not reached
-   [[:vector some?]
+   [[:vector :some]
     [[1 "kikka" true]
      [2 "kukka" true]
      [3 "kakka" false]]
@@ -95,7 +95,7 @@
     {::mp/tuple-threshold 3}]
 
    ;; tuple-like with non-coherent data
-   [[:vector some?]
+   [[:vector :some]
     [[1 "kikka" true]
      [2 "kukka" true]
      [3 "kakka" "true"]]]
@@ -106,12 +106,12 @@
      [2 "kukka" true]]]
 
    ;; a hererogenous hinted tuple
-   [[:tuple :int :string some?]
+   [[:tuple :int :string :some]
     [^{::mp/hint :tuple} [1 "kikka" true]
      [2 "kukka" "true"]]]
 
    ;; invalid hinted tuple
-   [[:vector some?]
+   [[:vector :some]
     [^{::mp/hint :tuple} [1 "kikka" true]
      [2 "kukka" true "invalid tuple"]]]
 
@@ -166,3 +166,65 @@
 (deftest provider-test
   (doseq [[schema samples options] expectations]
     (is (= (m/form schema) (m/form (mp/provide samples options))))))
+
+(def samples
+  [{:id "Lillan"
+    :tags #{:artesan :coffee :hotel}
+    :address {:street "Ahlmanintie 29"
+              :city "Tampere"
+              :zip 33100
+              :lonlat [61.4858322, 23.7854658]}}
+   {:id "Huber",
+    :description "Beefy place"
+    :tags #{:beef :wine :beer}
+    :address {:street "Aleksis Kiven katu 13"
+              :city "Tampere"
+              :zip 33200
+              :lonlat [61.4963599 23.7604916]}}])
+
+(mp/provide samples)
+
+(mp/provide
+ [{:a [1]
+   :b [1 2]
+   :c [1 2 3]}])
+
+(mp/provide
+ [{:a [1]
+   :b [1 2]
+   :c [1 2 3]
+   :d [1 2]
+   :e [1 2 3]
+   :f [1]
+   :g [1]
+   :h [1 2 3 4]}])
+
+(mp/provide
+ [^{::mp/hint :map-of}
+  {:a {:b 1, :c 2}
+   :b {:b 2, :c 1}
+   :c {:b 3}
+   :d nil}])
+
+;[:map-of
+; :keyword
+; [:maybe [:map
+;          [:b :int]
+;          [:c {:optional true} :int]]]]
+
+
+(mp/provide
+ [[1 "kikka" true]
+  [2 "kukka" true]
+  [3 "kakka" true]])
+
+(mp/provide
+ [[1 "kikka" true]
+  [2 "kukka" true]
+  [3 "kakka" false]]
+ {::mp/tuple-threshold 3})
+
+(mp/provide
+ [^{::mp/hint :tuple}
+  [1 "kikka" true]
+  ["2" "kukka" true]])

--- a/test/malli/provider_test.cljc
+++ b/test/malli/provider_test.cljc
@@ -6,34 +6,34 @@
   #?(:clj (:import (java.util UUID Date))))
 
 (def expectations
-  [[int? [1 2 3]]
-   [keyword? [:kikka :kukka]]
-   [qualified-keyword? [::kikka ::kukka]]
-   [uuid? [#?(:clj (UUID/randomUUID) :cljs (random-uuid))]]
+  [[:int [1 2 3]]
+   [:keyword [:kikka :kukka]]
+   [:qualified-keyword [::kikka ::kukka]]
+   [:uuid [#?(:clj (UUID/randomUUID) :cljs (random-uuid))]]
    [inst? [#?(:clj (Date.) :cljs (js/Date.))]]
-   [any? []]
+   [:any []]
 
-   [[:vector keyword?] [[:kikka] [:kukka :kakka]]]
-   [[:sequential symbol?] [(seq ['kikka]) (seq ['kikka 'kakka])]]
-   [[:set string?] [#{"a" "b"} #{"c"}]]
-   [[:vector [:sequential [:set int?]]] [[(list #{1})]]]
-   [[:vector any?] [[]]]
+   [[:vector :keyword] [[:kikka] [:kukka :kakka]]]
+   [[:sequential :symbol] [(seq ['kikka]) (seq ['kikka 'kakka])]]
+   [[:set :string] [#{"a" "b"} #{"c"}]]
+   [[:vector [:sequential [:set :int]]] [[(list #{1})]]]
+   [[:vector :any] [[]]]
 
-   [[:maybe int?] [1 nil 2 3]]
+   [[:maybe :int] [1 nil 2 3]]
    [[:maybe some?] [1 nil 2 "some"]]
-   [[:maybe [:map [:x int?]]] [{:x 1} nil]]
-   [[:maybe [:or [:map [:x int?]] string?]] [{:x 1} nil "1"]]
+   [[:maybe [:map [:x :int]]] [{:x 1} nil]]
+   [[:maybe [:or [:map [:x :int]] :string]] [{:x 1} nil "1"]]
 
    ;; normal maps without type-hint
    [[:map
      [:a [:map
-          [:b int?]
-          [:c int?]]]
+          [:b :int]
+          [:c :int]]]
      [:b [:map
-          [:b int?]
-          [:c int?]]]
+          [:b :int]
+          [:c :int]]]
      [:c [:map
-          [:b int?]]]
+          [:b :int]]]
      [:d :nil]]
     [{:a {:b 1, :c 2}
       :b {:b 2, :c 1}
@@ -41,9 +41,9 @@
       :d nil}]]
 
    ;; :map-of type-hint
-   [[:map-of keyword? [:maybe [:map
-                               [:b int?]
-                               [:c {:optional true} int?]]]]
+   [[:map-of :keyword [:maybe [:map
+                               [:b :int]
+                               [:c {:optional true} :int]]]]
     [^{::mp/hint :map-of}
      {:a {:b 1, :c 2}
       :b {:b 2, :c 1}
@@ -52,19 +52,19 @@
 
    ;; too few samples for :map-of
    [[:map
-     ["1" [:map [:name string?]]]
-     ["2" [:map [:name string?]]]]
+     ["1" [:map [:name :string]]]
+     ["2" [:map [:name :string]]]]
     [{"1" {:name "1"}
       "2" {:name "2"}}]]
 
    ;; explicit sample count for :map-of
-   [[:map-of string? [:map [:name string?]]]
+   [[:map-of :string [:map [:name :string]]]
     [{"1" {:name "1"}
       "2" {:name "2"}}]
     {::mp/map-of-threshold 2}]
 
    ;; implicit sample count for :map-of
-   [[:map-of string? [:map [:name string?]]]
+   [[:map-of :string [:map [:name :string]]]
     [{"1" {:name "1"}
       "2" {:name "2"}}
      {"3" {:name "3"}}
@@ -88,7 +88,7 @@
     {::mp/tuple-threshold 4}]
 
    ;; tuple-like with threshold reached
-   [[:tuple int? string? boolean?]
+   [[:tuple :int :string :boolean]
     [[1 "kikka" true]
      [2 "kukka" true]
      [3 "kakka" false]]
@@ -101,12 +101,12 @@
      [3 "kakka" "true"]]]
 
    ;; a homogenous hinted tuple
-   [[:tuple int? string? boolean?]
+   [[:tuple :int :string :boolean]
     [^{::mp/hint :tuple} [1 "kikka" true]
      [2 "kukka" true]]]
 
    ;; a hererogenous hinted tuple
-   [[:tuple int? string? some?]
+   [[:tuple :int :string some?]
     [^{::mp/hint :tuple} [1 "kikka" true]
      [2 "kukka" "true"]]]
 
@@ -116,24 +116,24 @@
      [2 "kukka" true "invalid tuple"]]]
 
    ;; value-decoders
-   [[:map [:id string?]]
+   [[:map [:id :string]]
     [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
      {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]]
    [[:map [:id :uuid]]
     [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
      {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}]
-    {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}}]
+    {::mp/value-decoders {:string {:uuid mt/-string->uuid}}}]
    [[:map-of :uuid [:map [:id :uuid]]]
     [{"0423191a-5fee-11ec-bf63-0242ac130002" {:id "0423191a-5fee-11ec-bf63-0242ac130002"}
       "09e59de6-5fee-11ec-bf63-0242ac130002" {:id "09e59de6-5fee-11ec-bf63-0242ac130002"}
       "15511020-5fee-11ec-bf63-0242ac130002" {:id "15511020-5fee-11ec-bf63-0242ac130002"}}]
-    {::mp/value-decoders {'string? {:uuid mt/-string->uuid}}
+    {::mp/value-decoders {:string {:uuid mt/-string->uuid}}
      ::mp/map-of-threshold 3}]
-   [[:map-of inst? string?]
+   [[:map-of inst? :string]
     [{"1901-03-02T22:20:11.000Z" "123"
       "1902-04-03T22:20:11.000Z" "234"
       "1904-06-05T22:20:11.000Z" "456"}]
-    {::mp/value-decoders {'string? {'inst? mt/-string->date}}
+    {::mp/value-decoders {:string {'inst? mt/-string->date}}
      ::mp/map-of-threshold 3}]
    ;; value-hints
    [[:map [:name :string] [:gender [:enum "male" "female"]]]
@@ -141,15 +141,15 @@
      {:name (mp/-hinted "Tiina" :string), :gender "female"}]]
 
    [[:map
-     [:id string?]
-     [:tags [:set keyword?]]
+     [:id :string]
+     [:tags [:set :keyword]]
      [:address
       [:map
-       [:street string?]
-       [:city string?]
-       [:zip int?]
-       [:lonlat [:vector double?]]]]
-     [:description {:optional true} string?]] [{:id "Lillan"
+       [:street :string]
+       [:city :string]
+       [:zip :int]
+       [:lonlat [:vector :double]]]]
+     [:description {:optional true} :string]] [{:id "Lillan"
                                                 :tags #{:artesan :coffee :hotel}
                                                 :address {:street "Ahlmanintie 29"
                                                           :city "Tampere"


### PR DESCRIPTION
Prefer real schemas when inferring, no predicates:

```clojure
(mp/provide [{:a [1 2 3]
              :b "kikka"
              :c true}
             {:a nil
              :b "kikka"
              :c "true"}])
;[:map 
; [:a [:maybe [:vector :int]]] 
; [:b :string] 
; [:c :some]]
```

Add `:some` schemas