### PR TITLE
Fix enum ast losing properties and options

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1307,7 +1307,7 @@
         ^{:type ::schema}
         (reify
           AST
-          (-to-ast [_ _] {:type :enum, :values children})
+          (-to-ast [_ _] (-ast {:type :enum :values children} properties options))
           Schema
           (-validator [_]
             (fn [x] (contains? schema x)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -504,6 +504,8 @@
       (testing "ast"
         (is (= {:type :enum, :values [1 2]}
                (m/ast schema)))
+        (is (= {:type :enum :properties {:optional true} :values [1 2]}
+               (m/ast (mu/update-properties schema assoc :optional true))))
         (is (true? (m/validate (m/from-ast (m/ast schema)) 1))))
 
       (is (= [:enum 1 2] (m/form schema)))))


### PR DESCRIPTION
With the following enum schema 
```clojure
(def enum-example
    [:enum {:encode/json name :decode/json keyword} :e-1 :e-2])
```
`(properties (from-ast (ast enum-example)))` returns `nil` rather than `{:encode/json name :decode/json keyword}`.

The fix persists the properties and options from the schema into the ast.