### PR TITLE
Fix recursive `:+` generators

### DIFF
--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -1,0 +1,27 @@
+(ns malli.generator-ast
+  "For inspecting a malli's generator as data. See `generator-ast`"
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.walk :as walk]
+            [malli.generator :as mg]))
+
+(let [s (-> (slurp (io/resource "malli/generator.cljc"))
+            ;; change the namespace
+            (str/replace-first "(ns malli.generator" "(ns malli.generator-ast")
+            ;; change the `gen` alias to the AST version
+            (str/replace-first "clojure.test.check.generators" "malli.generator-debug"))]
+  ;; eval ns form first so keywords can be resolved in the right namespace
+  (eval (read-string {:read-cond :allow :features #{:clj}} s))
+  (eval (read-string {:read-cond :allow :features #{:clj}} (str "(do " s ")"))))
+
+(defn generator-ast
+  "Return a malli schema's generator as an AST."
+  ([?schema]
+   (generator-ast ?schema nil))
+  ([?schema options]
+   (walk/postwalk
+     (fn [g]
+       (if (mg/-unreachable-gen? g)
+         {:op :unreachable}
+         g))
+     (generator ?schema (assoc options ::mg/generator-ast true)))))

--- a/test/malli/generator_ast_test.clj
+++ b/test/malli/generator_ast_test.clj
@@ -1,0 +1,74 @@
+(ns malli.generator-ast-test
+  (:require [clojure.pprint :refer [pprint]]
+            [clojure.test :refer [are deftest is testing]]
+            [malli.generator-ast :as ast]))
+
+(deftest generator-ast-test
+  (is (= '{:op :recursive-gen,
+           :rec-gen
+           {:op :one-of,
+            :generators
+            [{:op :boolean}
+             {:op :tuple,
+              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}
+             {:op :tuple,
+              :generators
+              [{:op :elements, :coll [:and]}
+               {:op :vector, :generator {:op :recur}}]}
+             {:op :tuple,
+              :generators
+              [{:op :elements, :coll [:or]}
+               {:op :vector, :generator {:op :recur}}]}]},
+           :scalar-gen
+           {:op :one-of,
+            :generators
+            [{:op :boolean}
+             {:op :tuple,
+              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}
+             {:op :tuple,
+              :generators
+              [{:op :elements, :coll [:and]} {:op :return, :value ()}]}
+             {:op :tuple,
+              :generators
+              [{:op :elements, :coll [:or]} {:op :return, :value ()}]}]}}
+         (ast/generator-ast
+           [:schema
+            {:registry
+             {::formula
+              [:or
+               :boolean
+               [:tuple [:enum :not] :boolean]
+               [:tuple [:enum :and] [:* [:ref ::formula]]]
+               [:tuple [:enum :or]  [:* [:ref ::formula]]]]}}
+            [:ref ::formula]])))
+  (is (= '{:op :recursive-gen,
+           :rec-gen
+           {:op :one-of,
+            :generators
+            [{:op :boolean}
+             {:op :tuple,
+              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}
+             {:op :tuple,
+              :generators
+              [{:op :elements, :coll [:and]}
+               {:op :not-empty, :gen {:op :vector, :generator {:op :recur}}}]}
+             {:op :tuple,
+              :generators
+              [{:op :elements, :coll [:or]}
+               {:op :not-empty, :gen {:op :vector, :generator {:op :recur}}}]}]},
+           :scalar-gen
+           {:op :one-of,
+            :generators
+            [{:op :boolean}
+             {:op :tuple,
+              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}]}}
+         (ast/generator-ast
+           [:schema
+            {:registry
+             {::formula
+              [:or
+               :boolean
+               [:tuple [:enum :not] :boolean]
+               [:tuple [:enum :and] [:+ [:ref ::formula]]]
+               [:tuple [:enum :or]  [:+ [:ref ::formula]]]]}}
+            [:ref ::formula]]))))

--- a/test/malli/generator_debug.cljc
+++ b/test/malli/generator_debug.cljc
@@ -1,0 +1,43 @@
+(ns malli.generator-debug
+  "Drop-in replacement for clojure.test.check.generators that returns AST's
+  instead of generators."
+  (:refer-clojure :exclude [vector char keyword boolean not-empty symbol]))
+
+(defmacro such-that [& args] (let [args (vec args)] `{:op :such-that :args-form '~args :args ~args}))
+(def any {:op :any})
+(def any-printable {:op :any-printable})
+(defn double* [& args] {:op :double* :args args})
+(defmacro fmap [& args] (let [args (vec args)] `{:op :fmap :args-form '~args :args ~args}))
+(defmacro vector
+  ([generator] {:op :vector :generator generator})
+  ([generator num-elements] {:op :vector :generator generator :num-elements num-elements})
+  ([generator min-elements max-elements]
+   {:op :vector :generator generator :min-elements min-elements :max-elements max-elements}))
+(defmacro vector-distinct [& args] (let [args (vec args)] `{:op :vector-distinct :args-form '~args :args ~args}))
+(def char {:op :char})
+(def nat {:op :nat})
+(def char-alphanumeric {:op :char-alphanumeric})
+(def string-alphanumeric {:op :string-alphanumeric})
+(defn sized [& args] {:op :sized :args args})
+(defn return [value] {:op :return :value value})
+(defn one-of [generators] {:op :one-of :generators generators})
+(defn tuple [& generators] {:op :tuple :generators (vec generators)})
+(defn recursive-gen [rec scalar]
+  {:op :recursive-gen
+   :rec-gen (rec {:op :recur})
+   :scalar-gen scalar})
+(def keyword {:op :keyword})
+(def keyword-ns {:op :keyword-ns})
+(def symbol {:op :symbol})
+(def symbol-ns {:op :symbol-ns})
+(def s-pos-int {:op :s-pos-int})
+(def s-neg-int {:op :s-neg-int})
+(defn elements [coll] {:op :elements :coll coll})
+(defn large-integer* [& args] {:op :large-integer* :args args})
+(def boolean {:op :boolean})
+(def uuid {:op :uuid})
+(defn not-empty [gen] {:op :not-empty :gen gen})
+(defn generator? [& args] (assert nil "no stub for generator?"))
+(defn call-gen [& args] (assert nil "no stub for call-gen"))
+(defn make-size-range-seq [& args] (assert nil "no stub for make-size-range-seq"))
+(defn lazy-random-states [& args] (assert nil "no stub for lazy-random-states"))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -624,6 +624,48 @@
                                               (gen/tuple (gen/return :B))
                                               (gen/tuple (gen/return :C))
                                               (gen/tuple (gen/return :D))])))
+                    {:seed 0})))
+  (is (= '([:not true] [:not false] [:and [[:not false]]] [:or [[:not false]]] false [:and [true [:not true]]] [:and ()] [:or [[:or ()] false]] [:not true] [:and [[:not true]]])
+         (mg/sample [:schema
+                     {:registry
+                      {::formula
+                       [:or
+                        :boolean
+                        [:tuple [:enum :not] :boolean]
+                        [:tuple [:enum :and] [:* [:ref ::formula]]]
+                        [:tuple [:enum :or]  [:* [:ref ::formula]]]]}}
+                     [:ref ::formula]]
+                    {:seed 0})
+         (mg/sample (gen/recursive-gen
+                      (fn [formula]
+                        (gen/one-of [gen/boolean
+                                     (gen/tuple (gen/elements [:not]) gen/boolean)
+                                     (gen/tuple (gen/elements [:and]) (gen/vector formula))
+                                     (gen/tuple (gen/elements [:or]) (gen/vector formula))]))
+                      (gen/one-of [gen/boolean
+                                   (gen/tuple (gen/elements [:not]) gen/boolean)
+                                   (gen/tuple (gen/elements [:and]) (gen/return ()))
+                                   (gen/tuple (gen/elements [:or]) (gen/return ()))]))
+                    {:seed 0})))
+  (is (= '([:not true] [:not false] [:and [true]] [:or [[:not false] true]] false [:and [[:not true]]] [:not false] [:or [[:not false] [:not true]]] [:not true] [:and [[:not false] [:and [[:not false] [:not true]]] [:and [[:not true]]]]])
+         (mg/sample [:schema
+                     {:registry
+                      {::formula
+                       [:or
+                        :boolean
+                        [:tuple [:enum :not] :boolean]
+                        [:tuple [:enum :and] [:+ [:ref ::formula]]]
+                        [:tuple [:enum :or]  [:+ [:ref ::formula]]]]}}
+                     [:ref ::formula]]
+                    {:seed 0})
+         (mg/sample (gen/recursive-gen
+                      (fn [formula]
+                        (gen/one-of [gen/boolean
+                                     (gen/tuple (gen/elements [:not]) gen/boolean)
+                                     (gen/tuple (gen/elements [:and]) (gen/not-empty (gen/vector formula)))
+                                     (gen/tuple (gen/elements [:or]) (gen/not-empty (gen/vector formula)))]))
+                      (gen/one-of [gen/boolean
+                                   (gen/tuple (gen/elements [:not]) gen/boolean)]))
                     {:seed 0}))))
 
 (deftest infinite-generator-test


### PR DESCRIPTION
`:+` generators with recursive variables can become `[:+ :UNREACHABLE]`, which corresponds to the impossible generator `(gen/not-empty (gen/return ()))`. In this case, it should reduce to `(-never-gen)`.

Added a useful debugging namespace that generates AST's for generators, which is how I found the root problem. Because of the way it's generated, I had to qualify some keywords using an alias instead of auto-namespacing.

--------------------

Original report: https://clojurians.slack.com/archives/CLDK6MFMK/p1670138741691259

```
Carlo:
A question about recursive generators and :+. Consider this recursive spec that describes a boolean formula:
(def formula
  [:schema
   {:registry
    {::formula
     [:or
      :boolean
      [:tuple [:enum :not] :boolean]
      [:tuple [:enum :and] [:* [:ref ::formula]]]
      [:tuple [:enum :or]  [:* [:ref ::formula]]]]}}
   [:ref ::formula]])
We can of course generate examples via:
(repeatedly 20 #(mg/generate formula))
But, if I change :* with :+ (rest in :thread:)

I now have:
(def formula
  [:schema
   {:registry
    {::formula
     [:or
      :boolean
      [:tuple [:enum :not] :boolean]
      [:tuple [:enum :and] [:+ [:ref ::formula]]]
      [:tuple [:enum :or]  [:+ [:ref ::formula]]]]}}
   [:ref ::formula]])

(repeatedly 20 #(mg/generate formula))
and the generator for this seems broken to me (for starters, it usually doesn't return 20 things. I suspect the reason is that it makes more difficult to generate values (as a naive sampling terminates more rarely). Is that correct?

By a brute force search, I saw that this problem is solved if I wrap :+ into a :schema. A more thorough explanation would be useful though
```
