### PR TITLE
Minor generator optimizations, add generator code generator

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -397,7 +397,10 @@
 (defmethod -schema-generator :vector [schema options] (-coll-gen schema identity options))
 (defmethod -schema-generator :sequential [schema options] (-coll-gen schema identity options))
 (defmethod -schema-generator :set [schema options] (-coll-distinct-gen schema set options))
-(defmethod -schema-generator :enum [schema options] (gen/elements (m/children schema options)))
+(defmethod -schema-generator :enum [schema options] (let [es (m/children schema options)]
+                                                      (if (= 1 (count es))
+                                                        (gen/return (first es))
+                                                        (gen/elements es))))
 
 (defmethod -schema-generator :maybe [schema options]
   (let [g (-> schema (m/children options) first (generator options) -not-unreachable)]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -417,9 +417,9 @@
 (defmethod -schema-generator :enum [schema options] (gen-elements (m/children schema options)))
 
 (defmethod -schema-generator :maybe [schema options]
-  (if-some [g (-> schema (m/children options) first (generator options) -not-unreachable)]
-    (gen/one-of [(gen/return nil) g])
-    (gen/return nil)))
+  (let [g (-> schema (m/children options) first (generator options) -not-unreachable)]
+    (gen-one-of (cond-> [(gen/return nil)]
+                  g (conj g)))))
 
 (defmethod -schema-generator :tuple [schema options]
   (let [gs (map #(generator % options) (m/children schema options))]

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -48,7 +48,9 @@
   (list (qualify-in-ns `tcgen/one-of) (mapv #(-generator-code % options) generators)))
 (defmethod -generator-code :return [{:keys [value]} _]
   (list (qualify-in-ns `tcgen/return)
-        value))
+        (if ((some-fn keyword? nil? boolean? number?))
+          value
+          (list 'quote value))))
 (defmethod -generator-code :recursive-gen [{:keys [target rec-gen scalar-gen]} options]
   (list (qualify-in-ns `tcgen/recursive-gen)
         (list (qualify-in-ns `fn) [(symbol target)] (-generator-code rec-gen options))
@@ -60,6 +62,8 @@
          (mapv #(-generator-code % options) generators)))
 
 (defn generator-code 
+  "Return pretty code that can be evaluated in this namespace
+  to create a generator for schema."
   ([?schema] (generator-code ?schema nil))
   ([?schema options]
    (-> ?schema

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -3,6 +3,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]
             [clojure.walk :as walk]
+            [clojure.test.check.generators :as tcgen]
             [malli.generator :as mg]))
 
 (let [s (-> (slurp (io/resource "malli/generator.cljc"))
@@ -26,3 +27,37 @@
          (or (-> g meta ::mg/generator-ast)
              g)))
      (generator ?schema (assoc options ::mg/generator-ast true)))))
+
+(defn- qualify-in-ns [q]
+  {:pre [(qualified-symbol? q)]}
+  (or (when-some [v (resolve q)]
+        (when (var? v)
+          (when (= q (symbol v))
+            (symbol (name q)))))
+      (when-some [nsym (some (fn [[asym ns]]
+                               (when (= (symbol (namespace q))
+                                        (ns-name ns))
+                                 (ns-name ns)))
+                             (ns-aliases *ns*))]
+        (symbol (name nsym) (name q)))
+      q))
+
+(defn- explicate [form]
+  (walk/postwalk (fn [form]
+                   (cond-> form
+                     (qualified-symbol? form) qualify-in-ns))))
+
+(defmulti -generator-code (fn [ast _options] (:op ast)))
+(defmethod -generator-code :any [_ _] (explicate `tcgen/any))
+(defmethod -generator-code :some [_ _] (explicate `tcgen/any-printable))
+(defmethod -generator-code :nil [_ _] (explicate `(tcgen/return nil)))
+(defmethod -generator-code :recursive-gen [{:keys [rec-gen scalar-gen]} options]
+  (explicate `(tcgen/recursive-fn (fn [rec#]
+                                    (-generator-code rec-gen options))
+                                  ~(-generator-code scalar-gen options))))
+
+(defn generator-code 
+  ([?schema] (generator-code ?schema nil))
+  ([?schema options]
+   (let [ast (-> (generator-ast ?schema options))]
+     (-generator-code ast))))

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -65,7 +65,7 @@
          (mapv #(-generator-code % options) generators)))
 
 (defn generator-code 
-  "Return pretty code that can be evaluated in this namespace
+  "Return pretty code that can be evaluated in the current namespace
   to create a generator for schema."
   ([?schema] (generator-code ?schema nil))
   ([?schema options]

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -53,6 +53,7 @@
   (list (qualify-in-ns `tcgen/recursive-gen)
         (list (qualify-in-ns `fn) [(symbol target)] (-generator-code rec-gen options))
         (-generator-code scalar-gen options)))
+;; TODO infer pretty name from :ref schema
 (defmethod -generator-code :recur [{:keys [target]} options] (symbol target))
 (defmethod -generator-code :tuple [{:keys [generators]} options]
   (list* (qualify-in-ns `tcgen/tuple)

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -30,7 +30,10 @@
 
 (defn- qualify-in-ns [q]
   {:pre [(qualified-symbol? q)]}
-  (or (when-some [v (get (ns-map *ns*) (symbol (name q)))]
+  (or (when (.startsWith (name q) "recur")
+        ;; prevent recursive-gen bindings from shadowing globals
+        q)
+      (when-some [v (get (ns-map *ns*) (symbol (name q)))]
         (when (var? v)
           (when (= q (symbol v))
             (symbol (name q)))))

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -48,9 +48,9 @@
   (list (qualify-in-ns `tcgen/one-of) (mapv #(-generator-code % options) generators)))
 (defmethod -generator-code :return [{:keys [value]} _]
   (list (qualify-in-ns `tcgen/return)
-        (if ((some-fn keyword? nil? boolean? number?))
-          value
-          (list 'quote value))))
+        (cond->> value
+          (not ((some-fn string? keyword? nil? boolean? number?) value))
+          (list 'quote))))
 (defmethod -generator-code :recursive-gen [{:keys [target rec-gen scalar-gen]} options]
   (list (qualify-in-ns `tcgen/recursive-gen)
         (list (qualify-in-ns `fn) [(symbol target)] (-generator-code rec-gen options))

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -23,5 +23,6 @@
      (fn [g]
        (if (mg/-unreachable-gen? g)
          {:op :unreachable}
-         g))
+         (or (-> g meta ::mg/generator-ast)
+             g)))
      (generator ?schema (assoc options ::mg/generator-ast true)))))

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -30,13 +30,13 @@
 
 (defn- qualify-in-ns [q]
   {:pre [(qualified-symbol? q)]}
-  (or (when (.startsWith (name q) "recur")
-        ;; prevent recursive-gen bindings from shadowing globals
-        q)
-      (when-some [v (get (ns-map *ns*) (symbol (name q)))]
+  (or (when-some [v (get (ns-map *ns*) (symbol (name q)))]
         (when (var? v)
           (when (= q (symbol v))
-            (symbol (name q)))))
+            (let [uq (symbol (name q))]
+              ;; prevent recursive-gen bindings from shadowing globals
+              (when (not (re-matches #"recur\d+" uq))
+                uq)))))
       (when-some [nsym (some (fn [[asym ns]]
                                (when (= (symbol (namespace q))
                                         (ns-name ns))

--- a/test/malli/generator_ast.clj
+++ b/test/malli/generator_ast.clj
@@ -35,7 +35,7 @@
           (when (= q (symbol v))
             (let [uq (symbol (name q))]
               ;; prevent recursive-gen bindings from shadowing globals
-              (when (not (re-matches #"recur\d+" uq))
+              (when (not (re-matches #"recur\d+" (name uq)))
                 uq)))))
       (when-some [nsym (some (fn [[asym ns]]
                                (when (= (symbol (namespace q))

--- a/test/malli/generator_ast_test.clj
+++ b/test/malli/generator_ast_test.clj
@@ -1,6 +1,7 @@
 (ns malli.generator-ast-test
   (:require [clojure.pprint :refer [pprint]]
             [clojure.test :refer [are deftest is testing]]
+            [clojure.test.check.generators :as tcgen]
             [malli.generator-ast :as ast]))
 
 (deftest generator-ast-test
@@ -78,14 +79,242 @@
                [:tuple [:enum :and] [:+ [:ref ::formula]]]
                [:tuple [:enum :or]  [:+ [:ref ::formula]]]]}}
             [:ref ::formula]])))
-  #_
-  (is (= nil
+  (is (= '{:op :recursive-gen,
+           :target :recur0,
+           :rec-gen
+           {:op :tuple,
+            :generators
+            [{:op :return, :value "A"}
+             {:op :one-of,
+              :generators
+              [{:op :return, :value nil}
+               {:op :one-of,
+                :generators
+                [{:op :recursive-gen,
+                  :target :recur1,
+                  :rec-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "B"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :one-of,
+                       :generators
+                       [{:op :tuple,
+                         :generators
+                         [{:op :return, :value "C"}
+                          {:op :one-of,
+                           :generators
+                           [{:op :return, :value nil}
+                            {:op :one-of,
+                             :generators
+                             [{:op :recur, :target :recur0}
+                              {:op :recur, :target :recur1}]}]}]}
+                        {:op :recur, :target :recur0}]}]}]},
+                  :scalar-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "B"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :one-of,
+                       :generators
+                       [{:op :tuple,
+                         :generators
+                         [{:op :return, :value "C"}
+                          {:op :one-of,
+                           :generators
+                           [{:op :return, :value nil}
+                            {:op :recur, :target :recur0}]}]}
+                        {:op :recur, :target :recur0}]}]}]}}
+                 {:op :recursive-gen,
+                  :target :recur1,
+                  :rec-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "C"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :one-of,
+                       :generators
+                       [{:op :recur, :target :recur0}
+                        {:op :tuple,
+                         :generators
+                         [{:op :return, :value "B"}
+                          {:op :one-of,
+                           :generators
+                           [{:op :return, :value nil}
+                            {:op :one-of,
+                             :generators
+                             [{:op :recur, :target :recur1}
+                             {:op :recur, :target :recur0}]}]}]}]}]}]},
+                  :scalar-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "C"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :one-of,
+                       :generators
+                       [{:op :recur, :target :recur0}
+                        {:op :tuple,
+                         :generators
+                         [{:op :return, :value "B"}
+                          {:op :one-of,
+                           :generators
+                           [{:op :return, :value nil}
+                            {:op :recur, :target :recur0}]}]}]}]}]}}]}]}]},
+           :scalar-gen
+           {:op :tuple,
+            :generators
+            [{:op :return, :value "A"}
+             {:op :one-of,
+              :generators
+              [{:op :return, :value nil}
+               {:op :one-of,
+                :generators
+                [{:op :recursive-gen,
+                  :target :recur0,
+                  :rec-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "B"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :tuple,
+                       :generators
+                       [{:op :return, :value "C"}
+                        {:op :one-of,
+                         :generators
+                         [{:op :return, :value nil}
+                          {:op :recur, :target :recur0}]}]}]}]},
+                  :scalar-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "B"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :tuple,
+                       :generators
+                       [{:op :return, :value "C"}
+                        {:op :return, :value nil}]}]}]}}
+                 {:op :recursive-gen,
+                  :target :recur0,
+                  :rec-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "C"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :tuple,
+                       :generators
+                       [{:op :return, :value "B"}
+                        {:op :one-of,
+                         :generators
+                         [{:op :return, :value nil}
+                          {:op :recur, :target :recur0}]}]}]}]},
+                  :scalar-gen
+                  {:op :tuple,
+                   :generators
+                   [{:op :return, :value "C"}
+                    {:op :one-of,
+                     :generators
+                     [{:op :return, :value nil}
+                      {:op :tuple,
+                       :generators
+                       [{:op :return, :value "B"}
+                        {:op :return, :value nil}]}]}]}}]}]}]}}
          (ast/generator-ast
            [:schema
             {:registry {::A [:tuple [:= "A"] [:maybe [:or [:ref ::B] [:ref ::C]]]]
                         ::B [:tuple [:= "B"] [:maybe [:or [:ref ::C] [:ref ::A]]]]
                         ::C [:tuple [:= "C"] [:maybe [:or [:ref ::A] [:ref ::B]]]]}}
             [:ref ::A]]))))
+
+(def this-ns *ns*)
+
+(deftest generator-code-test
+  (is (= '(tcgen/recursive-gen
+            (fn [recur0]
+              (tcgen/tuple (tcgen/return "A")
+                           (tcgen/one-of
+                             [(tcgen/return nil)
+                              (tcgen/one-of
+                                [(tcgen/recursive-gen
+                                   (fn [recur1]
+                                     (tcgen/tuple (tcgen/return "B")
+                                                  (tcgen/one-of
+                                                    [(tcgen/return nil)
+                                                     (tcgen/one-of
+                                                       [(tcgen/tuple
+                                                          (tcgen/return "C")
+                                                          (tcgen/one-of [(tcgen/return nil)
+                                                                         (tcgen/one-of [recur0 recur1])]))
+                                                        recur0])])))
+                                   (tcgen/tuple (tcgen/return "B")
+                                                (tcgen/one-of [(tcgen/return nil)
+                                                               (tcgen/one-of
+                                                                 [(tcgen/tuple (tcgen/return "C")
+                                                                               (tcgen/one-of [(tcgen/return nil)
+                                                                                              recur0]))
+                                                                  recur0])])))
+                                 (tcgen/recursive-gen
+                                   (fn [recur1]
+                                     (tcgen/tuple (tcgen/return "C")
+                                                  (tcgen/one-of [(tcgen/return nil)
+                                                                 (tcgen/one-of
+                                                                   [recur0
+                                                                    (tcgen/tuple
+                                                                      (tcgen/return "B")
+                                                                      (tcgen/one-of [(tcgen/return nil)
+                                                                                     (tcgen/one-of [recur1 recur0])]))])])))
+                                   (tcgen/tuple (tcgen/return "C")
+                                                (tcgen/one-of [(tcgen/return nil)
+                                                               (tcgen/one-of
+                                                                 [recur0
+                                                                  (tcgen/tuple (tcgen/return "B")
+                                                                               (tcgen/one-of [(tcgen/return nil)
+                                                                                              recur0]))])])))])])))
+            (tcgen/tuple (tcgen/return "A")
+                         (tcgen/one-of [(tcgen/return nil)
+                                        (tcgen/one-of
+                                          [(tcgen/recursive-gen
+                                             (fn [recur0]
+                                               (tcgen/tuple (tcgen/return "B")
+                                                            (tcgen/one-of [(tcgen/return nil)
+                                                                           (tcgen/tuple
+                                                                             (tcgen/return "C")
+                                                                             (tcgen/one-of [(tcgen/return nil)
+                                                                                            recur0]))])))
+                                             (tcgen/tuple (tcgen/return "B")
+                                                          (tcgen/one-of [(tcgen/return nil)
+                                                                         (tcgen/tuple (tcgen/return "C")
+                                                                                      (tcgen/return nil))])))
+                                           (tcgen/recursive-gen
+                                             (fn [recur0]
+                                               (tcgen/tuple (tcgen/return "C")
+                                                            (tcgen/one-of [(tcgen/return nil)
+                                                                           (tcgen/tuple (tcgen/return "B")
+                                                                                        (tcgen/one-of [(tcgen/return nil)
+                                                                                                       recur0]))])))
+                                             (tcgen/tuple (tcgen/return "C")
+                                                          (tcgen/one-of [(tcgen/return nil)
+                                                                         (tcgen/tuple (tcgen/return "B")
+                                                                                      (tcgen/return nil))])))])])))
+         (binding [*ns* this-ns]
+           (ast/generator-code
+             [:schema
+              {:registry {::A [:tuple [:= "A"] [:maybe [:or [:ref ::B] [:ref ::C]]]]
+                          ::B [:tuple [:= "B"] [:maybe [:or [:ref ::C] [:ref ::A]]]]
+                          ::C [:tuple [:= "C"] [:maybe [:or [:ref ::A] [:ref ::B]]]]}}
+              [:ref ::A]])))))
 
 (deftest maybe-ast-test
   (is (ast/generator-ast [:maybe :boolean])))

--- a/test/malli/generator_ast_test.clj
+++ b/test/malli/generator_ast_test.clj
@@ -51,11 +51,15 @@
              {:op :tuple,
               :generators
               [{:op :return, :value :and}
-               {:op :not-empty, :gen {:op :vector, :generator {:op :recur}}}]}
+               {:op :vector-min
+                :generator {:op :recur}
+                :min 1}]}
              {:op :tuple,
               :generators
               [{:op :return, :value :or}
-               {:op :not-empty, :gen {:op :vector, :generator {:op :recur}}}]}]},
+               {:op :vector-min
+                :generator {:op :recur}
+                :min 1}]}]},
            :scalar-gen
            {:op :one-of,
             :generators

--- a/test/malli/generator_ast_test.clj
+++ b/test/malli/generator_ast_test.clj
@@ -10,27 +10,27 @@
             :generators
             [{:op :boolean}
              {:op :tuple,
-              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}
+              :generators [{:op :return, :value :not} {:op :boolean}]}
              {:op :tuple,
               :generators
-              [{:op :elements, :coll [:and]}
+              [{:op :return, :value :and}
                {:op :vector, :generator {:op :recur}}]}
              {:op :tuple,
               :generators
-              [{:op :elements, :coll [:or]}
+              [{:op :return, :value :or}
                {:op :vector, :generator {:op :recur}}]}]},
            :scalar-gen
            {:op :one-of,
             :generators
             [{:op :boolean}
              {:op :tuple,
-              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}
+              :generators [{:op :return, :value :not} {:op :boolean}]}
              {:op :tuple,
               :generators
-              [{:op :elements, :coll [:and]} {:op :return, :value ()}]}
+              [{:op :return, :value :and} {:op :return, :value ()}]}
              {:op :tuple,
               :generators
-              [{:op :elements, :coll [:or]} {:op :return, :value ()}]}]}}
+              [{:op :return, :value :or} {:op :return, :value ()}]}]}}
          (ast/generator-ast
            [:schema
             {:registry
@@ -47,21 +47,21 @@
             :generators
             [{:op :boolean}
              {:op :tuple,
-              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}
+              :generators [{:op :return, :value :not} {:op :boolean}]}
              {:op :tuple,
               :generators
-              [{:op :elements, :coll [:and]}
+              [{:op :return, :value :and}
                {:op :not-empty, :gen {:op :vector, :generator {:op :recur}}}]}
              {:op :tuple,
               :generators
-              [{:op :elements, :coll [:or]}
+              [{:op :return, :value :or}
                {:op :not-empty, :gen {:op :vector, :generator {:op :recur}}}]}]},
            :scalar-gen
            {:op :one-of,
             :generators
             [{:op :boolean}
              {:op :tuple,
-              :generators [{:op :elements, :coll [:not]} {:op :boolean}]}]}}
+              :generators [{:op :return, :value :not} {:op :boolean}]}]}}
          (ast/generator-ast
            [:schema
             {:registry

--- a/test/malli/generator_ast_test.clj
+++ b/test/malli/generator_ast_test.clj
@@ -5,6 +5,7 @@
 
 (deftest generator-ast-test
   (is (= '{:op :recursive-gen,
+           :target :recur0
            :rec-gen
            {:op :one-of,
             :generators
@@ -14,11 +15,11 @@
              {:op :tuple,
               :generators
               [{:op :return, :value :and}
-               {:op :vector, :generator {:op :recur}}]}
+               {:op :vector, :generator {:op :recur :target :recur0}}]}
              {:op :tuple,
               :generators
               [{:op :return, :value :or}
-               {:op :vector, :generator {:op :recur}}]}]},
+               {:op :vector, :generator {:op :recur :target :recur0}}]}]},
            :scalar-gen
            {:op :one-of,
             :generators
@@ -42,6 +43,7 @@
                [:tuple [:enum :or]  [:* [:ref ::formula]]]]}}
             [:ref ::formula]])))
   (is (= '{:op :recursive-gen,
+           :target :recur0
            :rec-gen
            {:op :one-of,
             :generators
@@ -52,13 +54,13 @@
               :generators
               [{:op :return, :value :and}
                {:op :vector-min
-                :generator {:op :recur}
+                :generator {:op :recur :target :recur0}
                 :min 1}]}
              {:op :tuple,
               :generators
               [{:op :return, :value :or}
                {:op :vector-min
-                :generator {:op :recur}
+                :generator {:op :recur :target :recur0}
                 :min 1}]}]},
            :scalar-gen
            {:op :one-of,
@@ -75,4 +77,15 @@
                [:tuple [:enum :not] :boolean]
                [:tuple [:enum :and] [:+ [:ref ::formula]]]
                [:tuple [:enum :or]  [:+ [:ref ::formula]]]]}}
-            [:ref ::formula]]))))
+            [:ref ::formula]])))
+  #_
+  (is (= nil
+         (ast/generator-ast
+           [:schema
+            {:registry {::A [:tuple [:= "A"] [:maybe [:or [:ref ::B] [:ref ::C]]]]
+                        ::B [:tuple [:= "B"] [:maybe [:or [:ref ::C] [:ref ::A]]]]
+                        ::C [:tuple [:= "C"] [:maybe [:or [:ref ::A] [:ref ::B]]]]}}
+            [:ref ::A]]))))
+
+(deftest maybe-ast-test
+  (is (ast/generator-ast [:maybe :boolean])))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -509,7 +509,7 @@
                                                                                   (gen/return nil))]))]))))
                    {:seed 0})))
   ;; linked list of ABC that never repeats
-  (is (= '(["A" ["B" nil]] ["A" nil] ["A" nil] ["A" ["C" ["B" nil]]] ["A" ["C" nil]] ["A" nil] ["A" ["C" ["B" ["C" nil]]]] ["A" nil] ["A" ["B" nil]] ["A" nil])
+  (is (= '(["A" ["B" nil]] ["A" nil] ["A" nil] ["A" ["C" ["B" nil]]] ["A" ["C" nil]] ["A" nil] ["A" ["C" ["B" ["C" ["B" nil]]]]] ["A" nil] ["A" ["B" nil]] ["A" nil])
          (mg/sample [:schema
                      {:registry {::A [:tuple [:= "A"] [:maybe [:or [:ref ::B] [:ref ::C]]]]
                                  ::B [:tuple [:= "B"] [:maybe [:or [:ref ::C] [:ref ::A]]]]
@@ -528,9 +528,7 @@
                                                                                (gen/one-of
                                                                                  [(gen/tuple (gen/return "C")
                                                                                              (gen/one-of [(gen/return nil)
-                                                                                                          (gen/one-of
-                                                                                                            [A
-                                                                                                             B])]))
+                                                                                                          (gen/one-of [A B])]))
                                                                                   A])])))
                                                      (gen/tuple (gen/return "B")
                                                                 (gen/one-of [(gen/return nil)
@@ -547,9 +545,7 @@
                                                                                  [A
                                                                                   (gen/tuple (gen/return "B")
                                                                                              (gen/one-of [(gen/return nil)
-                                                                                                          (gen/one-of
-                                                                                                            [C
-                                                                                                             A])]))])])))
+                                                                                                          (gen/one-of [C A])]))])])))
                                                      (gen/tuple (gen/return "C")
                                                                 (gen/one-of [(gen/return nil)
                                                                              (gen/one-of

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -639,13 +639,13 @@
          (mg/sample (gen/recursive-gen
                       (fn [formula]
                         (gen/one-of [gen/boolean
-                                     (gen/tuple (gen/elements [:not]) gen/boolean)
-                                     (gen/tuple (gen/elements [:and]) (gen/vector formula))
-                                     (gen/tuple (gen/elements [:or]) (gen/vector formula))]))
+                                     (gen/tuple (gen/return :not) gen/boolean)
+                                     (gen/tuple (gen/return :and) (gen/vector formula))
+                                     (gen/tuple (gen/return :or) (gen/vector formula))]))
                       (gen/one-of [gen/boolean
-                                   (gen/tuple (gen/elements [:not]) gen/boolean)
-                                   (gen/tuple (gen/elements [:and]) (gen/return ()))
-                                   (gen/tuple (gen/elements [:or]) (gen/return ()))]))
+                                   (gen/tuple (gen/return :not) gen/boolean)
+                                   (gen/tuple (gen/return :and) (gen/return ()))
+                                   (gen/tuple (gen/return :or) (gen/return ()))]))
                     {:seed 0})))
   (is (= '([:not true] [:not false] [:and [true]] [:or [[:not false] true]] false [:and [[:not true]]] [:not false] [:or [[:not false] [:not true]]] [:not true] [:and [[:not false] [:and [[:not false] [:not true]]] [:and [[:not true]]]]])
          (mg/sample [:schema
@@ -661,11 +661,11 @@
          (mg/sample (gen/recursive-gen
                       (fn [formula]
                         (gen/one-of [gen/boolean
-                                     (gen/tuple (gen/elements [:not]) gen/boolean)
-                                     (gen/tuple (gen/elements [:and]) (gen/not-empty (gen/vector formula)))
-                                     (gen/tuple (gen/elements [:or]) (gen/not-empty (gen/vector formula)))]))
+                                     (gen/tuple (gen/return :not) gen/boolean)
+                                     (gen/tuple (gen/return :and) (gen/not-empty (gen/vector formula)))
+                                     (gen/tuple (gen/return :or) (gen/not-empty (gen/vector formula)))]))
                       (gen/one-of [gen/boolean
-                                   (gen/tuple (gen/elements [:not]) gen/boolean)]))
+                                   (gen/tuple (gen/return :not) gen/boolean)]))
                     {:seed 0}))))
 
 (deftest infinite-generator-test

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -647,7 +647,7 @@
                                    (gen/tuple (gen/return :and) (gen/return ()))
                                    (gen/tuple (gen/return :or) (gen/return ()))]))
                     {:seed 0})))
-  (is (= '([:not true] [:not false] [:and [true]] [:or [[:not false] true]] false [:and [[:not true]]] [:not false] [:or [[:not false] [:not true]]] [:not true] [:and [[:not false] [:and [[:not false] [:not true]]] [:and [[:not true]]]]])
+  (is (= '([:not true] [:not false] [:and [true true]] [:or [true [:not true]]] false [:and [true [:not true] [:not true]]] [:not false] [:or [[:not true] [:not true] false]] [:not true] [:and [[:and [[:not false]]] [:not true]]])
          (mg/sample [:schema
                      {:registry
                       {::formula
@@ -662,8 +662,8 @@
                       (fn [formula]
                         (gen/one-of [gen/boolean
                                      (gen/tuple (gen/return :not) gen/boolean)
-                                     (gen/tuple (gen/return :and) (gen/not-empty (gen/vector formula)))
-                                     (gen/tuple (gen/return :or) (gen/not-empty (gen/vector formula)))]))
+                                     (gen/tuple (gen/return :and) (#'mg/gen-vector-min formula 1 {}))
+                                     (gen/tuple (gen/return :or) (#'mg/gen-vector-min formula 1 {}))]))
                       (gen/one-of [gen/boolean
                                    (gen/tuple (gen/return :not) gen/boolean)]))
                     {:seed 0}))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -537,8 +537,7 @@
                                                                              (gen/one-of
                                                                                [(gen/tuple (gen/return "C")
                                                                                            (gen/one-of [(gen/return nil)
-                                                                                                        (gen/one-of
-                                                                                                          [A])]))
+                                                                                                        A]))
                                                                                 A])])))
                                                    (gen/recursive-gen
                                                      (fn [C]
@@ -557,8 +556,7 @@
                                                                                [A
                                                                                 (gen/tuple (gen/return "B")
                                                                                            (gen/one-of [(gen/return nil)
-                                                                                                        (gen/one-of
-                                                                                                          [A])]))])])))])])))
+                                                                                                        A]))])])))])])))
                       (gen/tuple (gen/return "A")
                                  (gen/one-of [(gen/return nil)
                                               (gen/one-of
@@ -566,30 +564,24 @@
                                                    (fn [B]
                                                      (gen/tuple (gen/return "B")
                                                                 (gen/one-of [(gen/return nil)
-                                                                             (gen/one-of
-                                                                               [(gen/tuple (gen/return "C")
-                                                                                           (gen/one-of [(gen/return nil)
-                                                                                                        (gen/one-of
-                                                                                                          [B])]))])])))
+                                                                             (gen/tuple (gen/return "C")
+                                                                                        (gen/one-of [(gen/return nil)
+                                                                                                     B]))])))
                                                    (gen/tuple (gen/return "B")
                                                               (gen/one-of [(gen/return nil)
-                                                                           (gen/one-of
-                                                                             [(gen/tuple (gen/return "C")
-                                                                                         (gen/one-of [(gen/return nil)]))])])))
+                                                                           (gen/tuple (gen/return "C")
+                                                                                      (gen/return nil))])))
                                                  (gen/recursive-gen
                                                    (fn [C]
                                                      (gen/tuple (gen/return "C")
                                                                 (gen/one-of [(gen/return nil)
-                                                                             (gen/one-of
-                                                                               [(gen/tuple (gen/return "B")
-                                                                                           (gen/one-of [(gen/return nil)
-                                                                                                        (gen/one-of
-                                                                                                          [C])]))])])))
+                                                                             (gen/tuple (gen/return "B")
+                                                                                        (gen/one-of [(gen/return nil)
+                                                                                                     C]))])))
                                                    (gen/tuple (gen/return "C")
                                                               (gen/one-of [(gen/return nil)
-                                                                           (gen/one-of
-                                                                             [(gen/tuple (gen/return "B")
-                                                                                         (gen/one-of [(gen/return nil)]))])])))])])))
+                                                                           (gen/tuple (gen/return "B")
+                                                                                      (gen/return nil))])))])])))
                     {:seed 0})))
   (is (= '([:E [:B]] [:E [:G [:D]]] [:E [:B]] [:E [:C]] [:E [:F [:D]]] [:E [:G [:B]]] [:E [:C]] [:E [:G [:C]]] [:E [:A]] [:E [:B]])
          (mg/sample [:schema {:registry {::A [:tuple [:= :A]]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -368,6 +368,7 @@
                                       [:ref ::foo]]
                                      {:size 1000})))))
 
+;; note: use malli.generator-ast/generator-code to regenerate the raw test.check code in this test
 (deftest recursive-gen-test
   (is (= '([] [] [] [] nil nil [[1 nil]] nil [[1 nil]] nil)
          (mg/sample [:schema {:registry {::cons [:maybe [:vector [:tuple pos-int? [:ref ::cons]]]]}}


### PR DESCRIPTION
Perhaps these little optimizations might be significant in large cases. `generator-ast` made at least their ugliness painfully obvious, as you can see in the updated tests (this is more obvious in `test/malli/generator_test.cljc` after whitespace changes are hidden).

1. Use `gen/return` for singleton `gen/elements` calls.
2. Use constrained `gen/vector` instead of `(gen/not-empty (gen/vector ..))`.

Add dev helper `generator-code` to help generate the large `recursive-gen` test cases.