### PR TITLE
Add initial implementation for java time types schemas

### DIFF
--- a/src/malli/experimental/time.clj
+++ b/src/malli/experimental/time.clj
@@ -1,90 +1,26 @@
 (ns malli.experimental.time
+  (:refer-clojure :exclude [<=])
   (:require
    [malli.core :as m]
    [malli.experimental.time :as time])
   (:import
-   (java.time.temporal TemporalQuery)
-   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)
-   (java.time.format DateTimeFormatter)))
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)))
 
 (set! *warn-on-reflection* true)
 
-(def default-formats
-  {:time/instant DateTimeFormatter/ISO_INSTANT
-   :time/local-date DateTimeFormatter/ISO_LOCAL_DATE
-   :time/local-date-time DateTimeFormatter/ISO_LOCAL_DATE_TIME
-   :time/local-time DateTimeFormatter/ISO_LOCAL_TIME
-   :time/offset-date-time DateTimeFormatter/ISO_OFFSET_DATE_TIME
-   :time/zoned-date-time DateTimeFormatter/ISO_ZONED_DATE_TIME})
-
-(def queries
-  {:time/instant #(Instant/from %)
-   :time/local-time #(LocalTime/from %)
-   :time/local-date #(LocalDate/from %)
-   :time/local-date-time #(LocalDateTime/from %)
-   :time/offset-date-time #(OffsetDateTime/from %)
-   :time/zoned-date-time #(ZonedDateTime/from %)})
-
-(defn ->temporal-query
-  ^TemporalQuery [f]
-  (reify TemporalQuery
-    (queryFrom [_ t]
-      (f t))))
-
-(defn ->parser
-  [formatter qf]
-  (let [query (->temporal-query qf)]
-    (fn [^CharSequence s]
-      (if (instance? CharSequence s)
-        (.parse ^DateTimeFormatter formatter s query)
-        s))))
-
-(def default-parsers
-  (reduce-kv
-   (fn [m k v] (assoc m k (->parser v (get queries k))))
-   {:time/duration #(Duration/parse %)
-    :time/zone-id #(ZoneId/of %)}
-   default-formats))
-
-(defn ->formatter
-  [x]
-  (cond
-    (instance? DateTimeFormatter x) x
-    (instance? String x) (DateTimeFormatter/ofPattern x)
-    :else (throw (ex-info "Invalid formatter" {:formatter x :type (type x)}))))
-
-(defn safe-fn
-  [f]
-  (fn safe [x]
-    (try
-      (f x)
-      (catch Exception _
-        x))))
-
-(defn t<=
+(defn <=
   [^Comparable x ^Comparable y]
   (if (pos? (.compareTo x y))
     false
     true))
 
-(defn compile-parser
-  [type formatter pattern]
-  (safe-fn
-   (or
-    (when-let [formatter (when-let [x (or formatter pattern)]
-                           (->formatter x))]
-      (->parser formatter (get queries type)))
-    (get default-parsers type))))
-
-(defn -min-max-pred [type]
-  (fn [{:keys [min max formatter pattern]}]
-    (let [f (compile-parser type formatter pattern)
-          min (f min) max (f max)]
-      (cond
-        (not (or min max)) nil
-        (and min max) (fn [x] (and (t<= x max) (t<= min x)))
-        min (fn [x] (t<= min x))
-        max (fn [x] (t<= x max))))))
+(defn -min-max-pred [_]
+  (fn [{:keys [min max]}]
+    (cond
+      (not (or min max)) nil
+      (and min max) (fn [x] (and (<= x max) (<= min x)))
+      min (fn [x] (<= min x))
+      max (fn [x] (<= x max)))))
 
 (defn -temporal-schema
   [{:keys [type class type-properties]}]
@@ -92,7 +28,7 @@
    (cond->
        {:type type
         :pred (fn pred [x] (.isInstance ^Class class x))
-        :property-pred (-min-max-pred type)}
+        :property-pred (-min-max-pred nil)}
      type-properties
      (assoc :type-properties type-properties))))
 

--- a/src/malli/experimental/time.clj
+++ b/src/malli/experimental/time.clj
@@ -34,9 +34,9 @@
 
 (defn duration-schema [] (-temporal-schema {:type :time/duration :class Duration}))
 (defn instant-schema [] (-temporal-schema {:type :time/instant :class Instant}))
-(defn local-date-schema [] (-temporal-schema {:type :time/local-date :class LocalDate}))
+(defn local-date-schema [] (-temporal-schema {:type :time/local-date :class LocalDate :type-properties {:min LocalDate/MIN :max LocalDate/MAX}}))
 (defn local-time-schema [] (-temporal-schema {:type :time/local-time :class LocalTime :type-properties {:min LocalTime/MIN :max LocalTime/MAX}}))
-(defn local-date-time-schema [] (-temporal-schema {:type :time/local-date-time :class LocalDateTime}))
+(defn local-date-time-schema [] (-temporal-schema {:type :time/local-date-time :class LocalDateTime :type-properties {:min LocalDateTime/MIN :max LocalDateTime/MAX}}))
 (defn offset-date-time-schema [] (-temporal-schema {:type :time/offset-date-time :class OffsetDateTime}))
 (defn zoned-date-time-schema [] (-temporal-schema {:type :time/zoned-date-time :class ZonedDateTime}))
 (defn zone-id-schema [] (m/-simple-schema {:type :time/zone-id :pred #(instance? ZoneId %)}))

--- a/src/malli/experimental/time.clj
+++ b/src/malli/experimental/time.clj
@@ -1,0 +1,117 @@
+(ns malli.experimental.time
+  (:require
+   [malli.core :as m]
+   [malli.experimental.time :as time])
+  (:import
+   (java.time.temporal TemporalQuery)
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)
+   (java.time.format DateTimeFormatter)))
+
+(set! *warn-on-reflection* true)
+
+(def default-formats
+  {:time/instant DateTimeFormatter/ISO_INSTANT
+   :time/local-date DateTimeFormatter/ISO_LOCAL_DATE
+   :time/local-date-time DateTimeFormatter/ISO_LOCAL_DATE_TIME
+   :time/local-time DateTimeFormatter/ISO_LOCAL_TIME
+   :time/offset-date-time DateTimeFormatter/ISO_OFFSET_DATE_TIME
+   :time/zoned-date-time DateTimeFormatter/ISO_ZONED_DATE_TIME})
+
+(def queries
+  {:time/instant #(Instant/from %)
+   :time/local-time #(LocalTime/from %)
+   :time/local-date #(LocalDate/from %)
+   :time/local-date-time #(LocalDateTime/from %)
+   :time/offset-date-time #(OffsetDateTime/from %)
+   :time/zoned-date-time #(ZonedDateTime/from %)})
+
+(defn ->temporal-query
+  ^TemporalQuery [f]
+  (reify TemporalQuery
+    (queryFrom [_ t]
+      (f t))))
+
+(defn ->parser
+  [formatter qf]
+  (let [query (->temporal-query qf)]
+    (fn [^CharSequence s]
+      (if (instance? CharSequence s)
+        (.parse ^DateTimeFormatter formatter s query)
+        s))))
+
+(def default-parsers
+  (reduce-kv
+   (fn [m k v] (assoc m k (->parser v (get queries k))))
+   {:time/duration #(Duration/parse %)
+    :time/zone-id #(ZoneId/of %)}
+   default-formats))
+
+(defn ->formatter
+  [x]
+  (cond
+    (instance? DateTimeFormatter x) x
+    (instance? String x) (DateTimeFormatter/ofPattern x)
+    :else (throw (ex-info "Invalid formatter" {:formatter x :type (type x)}))))
+
+(defn safe-fn
+  [f]
+  (fn safe [x]
+    (try
+      (f x)
+      (catch Exception _
+        x))))
+
+(defn t<=
+  [^Comparable x ^Comparable y]
+  (if (pos? (.compareTo x y))
+    false
+    true))
+
+(defn compile-parser
+  [type formatter pattern]
+  (safe-fn
+   (or
+    (when-let [formatter (when-let [x (or formatter pattern)]
+                           (->formatter x))]
+      (->parser formatter (get queries type)))
+    (get default-parsers type))))
+
+(defn -min-max-pred [type]
+  (fn [{:keys [min max formatter pattern]}]
+    (let [f (compile-parser type formatter pattern)
+          min (f min) max (f max)]
+      (cond
+        (not (or min max)) nil
+        (and min max) (fn [x] (and (t<= x max) (t<= min x)))
+        min (fn [x] (t<= min x))
+        max (fn [x] (t<= x max))))))
+
+(defn -temporal-schema
+  [{:keys [type class type-properties]}]
+  (m/-simple-schema
+   (cond->
+       {:type type
+        :pred (fn pred [x] (.isInstance ^Class class x))
+        :property-pred (-min-max-pred type)}
+     type-properties
+     (assoc :type-properties type-properties))))
+
+(defn duration-schema [] (-temporal-schema {:type :time/duration :class Duration}))
+(defn instant-schema [] (-temporal-schema {:type :time/instant :class Instant}))
+(defn local-date-schema [] (-temporal-schema {:type :time/local-date :class LocalDate}))
+(defn local-time-schema [] (-temporal-schema {:type :time/local-time :class LocalTime :type-properties {:min LocalTime/MIN :max LocalTime/MAX}}))
+(defn local-date-time-schema [] (-temporal-schema {:type :time/local-date-time :class LocalDateTime}))
+(defn offset-date-time-schema [] (-temporal-schema {:type :time/offset-date-time :class OffsetDateTime}))
+(defn zoned-date-time-schema [] (-temporal-schema {:type :time/zoned-date-time :class ZonedDateTime}))
+(defn zone-id-schema [] (m/-simple-schema {:type :time/zone-id :pred #(instance? ZoneId %)}))
+
+(defn -time-schemas
+  []
+  {:time/zone-id (zone-id-schema)
+   :time/instant (instant-schema)
+   :time/duration (duration-schema)
+   :time/zoned-date-time (zoned-date-time-schema)
+   :time/offset-date-time (offset-date-time-schema)
+   :time/local-date (local-date-schema)
+   :time/local-time (local-time-schema)
+   :time/local-date-time (local-date-time-schema)})

--- a/src/malli/experimental/time.clj
+++ b/src/malli/experimental/time.clj
@@ -4,7 +4,7 @@
    [malli.core :as m]
    [malli.experimental.time :as time])
   (:import
-   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)))
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId OffsetTime ZoneOffset)))
 
 (set! *warn-on-reflection* true)
 
@@ -38,8 +38,10 @@
 (defn local-time-schema [] (-temporal-schema {:type :time/local-time :class LocalTime :type-properties {:min LocalTime/MIN :max LocalTime/MAX}}))
 (defn local-date-time-schema [] (-temporal-schema {:type :time/local-date-time :class LocalDateTime :type-properties {:min LocalDateTime/MIN :max LocalDateTime/MAX}}))
 (defn offset-date-time-schema [] (-temporal-schema {:type :time/offset-date-time :class OffsetDateTime}))
+(defn offset-time-schema [] (-temporal-schema {:type :time/offset-time :class OffsetTime :type-properties {:min OffsetTime/MIN :max OffsetTime/MAX}}))
 (defn zoned-date-time-schema [] (-temporal-schema {:type :time/zoned-date-time :class ZonedDateTime}))
 (defn zone-id-schema [] (m/-simple-schema {:type :time/zone-id :pred #(instance? ZoneId %)}))
+(defn zone-offset-schema [] (m/-simple-schema {:type :time/zone-offset :pred #(instance? ZoneOffset %) :type-properties {:min ZoneOffset/MIN :max ZoneOffset/MAX}}))
 
 (defn -time-schemas
   []
@@ -50,4 +52,6 @@
    :time/offset-date-time (offset-date-time-schema)
    :time/local-date (local-date-schema)
    :time/local-time (local-time-schema)
+   :time/offset-time (offset-time-schema)
+   :time/zone-offset (zone-offset-schema)
    :time/local-date-time (local-date-time-schema)})

--- a/src/malli/experimental/time/generator.clj
+++ b/src/malli/experimental/time/generator.clj
@@ -1,0 +1,95 @@
+(ns malli.experimental.time.generator
+  (:require
+   [clojure.test.check.generators :as gen]
+   [clojure.spec.gen.alpha :as ga]
+   [malli.core :as m]
+   [malli.generator :as mg]
+   [malli.experimental.time :as time])
+  (:import
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant OffsetTime ZonedDateTime OffsetDateTime ZoneId)))
+
+(set! *warn-on-reflection* true)
+
+(def zone-id-gen
+  (mg/generator (into [:enum] (map #(ZoneId/of ^String %)) (ZoneId/getAvailableZoneIds))))
+
+(defmethod mg/-schema-generator :time/zone-id [_schema _options] zone-id-gen)
+
+(def ^:const seconds-in-day 86400)
+
+(defn -to-long
+  ^long [o]
+  (cond
+    (instance? Instant o) (.toEpochMilli ^Instant o)
+    (instance? LocalDate o) (.toEpochDay ^LocalDate o)
+    (instance? LocalTime o) (.toSecondOfDay ^LocalTime o)
+    (instance? LocalDateTime o)
+    (unchecked-add
+     (unchecked-multiply (.toEpochDay (.toLocalDate ^LocalDateTime o)) seconds-in-day)
+     (.toLocalTime ^LocalDateTime o))
+    (instance? OffsetDateTime o) (.toEpochMilli (.toInstant ^OffsetDateTime o))
+    (instance? ZonedDateTime o) (.toEpochMilli (.toInstant ^ZonedDateTime o))
+    (int? o) (long o)))
+
+(defn to-long [o] (when o (-to-long o)))
+
+(defn -min-max [schema options]
+  (let [{:keys [min max] gen-min :gen/min gen-max :gen/max}
+        (merge
+         (m/type-properties schema options)
+         (m/properties schema options))
+        min (to-long min) max (to-long max) gen-min (to-long gen-min) gen-max (to-long gen-max)]
+    (when (and min gen-min (< gen-min min))
+      (m/-fail! ::mg/invalid-property {:key :gen/min, :value gen-min, :min min}))
+    (when (and max gen-max (> gen-max max))
+      (m/-fail! ::mg/invalid-property {:key :gen/max, :value gen-min, :max min}))
+    {:min (or gen-min min)
+     :max (or gen-max max)}))
+
+(defn -instant-gen
+  [schema options]
+  (ga/fmap #(Instant/ofEpochMilli %) (gen/large-integer* (-min-max schema options))))
+
+(defmethod mg/-schema-generator :time/instant [schema options]
+  (-instant-gen schema options))
+
+(comment
+  (gen/sample (mg/-schema-generator (time/instant-schema) nil)))
+
+(defmethod mg/-schema-generator :time/local-date [schema options]
+  (ga/fmap #(LocalDate/ofEpochDay %) (gen/large-integer* (-min-max schema options))))
+
+(defmethod mg/-schema-generator :time/local-time [schema options]
+  (ga/fmap #(LocalTime/ofSecondOfDay %) (gen/large-integer* (-min-max schema options))))
+
+(comment
+  (gen/sample (mg/-schema-generator (time/local-time-schema) nil)))
+
+(defmethod mg/-schema-generator :time/local-date-time [schema options]
+  (gen/fmap
+   (fn [n]
+     (LocalDateTime/of
+      (LocalDate/ofEpochDay (quot n seconds-in-day))
+      (LocalTime/ofSecondOfDay (mod n seconds-in-day))))
+   (gen/large-integer* (-min-max schema options))))
+
+(comment
+  (gen/sample (mg/-schema-generator (time/local-date-time-schema) nil) 1000))
+
+(defn -zoned-date-time-gen [schema options]
+  (gen/bind
+   (-instant-gen schema options)
+   (fn [instant]
+     (gen/fmap #(ZonedDateTime/ofInstant instant %) zone-id-gen))))
+
+(defmethod mg/-schema-generator :time/zoned-date-time [schema options]
+  (-zoned-date-time-gen schema options))
+
+(comment
+  (gen/sample (mg/-schema-generator (time/zoned-date-time-schema) nil) 100))
+
+(defn -offset-date-time-gen [schema options]
+  (gen/fmap #(OffsetDateTime/from %) (-zoned-date-time-gen schema options)))
+
+(defmethod mg/-schema-generator :time/offset-date-time [schema options]
+  (-offset-date-time-gen schema options))

--- a/src/malli/experimental/time/generator.clj
+++ b/src/malli/experimental/time/generator.clj
@@ -15,7 +15,7 @@
 
 (defmethod mg/-schema-generator :time/zone-id [_schema _options] zone-id-gen)
 
-(def ^:const seconds-in-day 86400)
+(def ^:const ^:private seconds-in-day 86400)
 
 (defn -to-long
   ^long [o]

--- a/src/malli/experimental/time/generator.clj
+++ b/src/malli/experimental/time/generator.clj
@@ -26,7 +26,7 @@
     (instance? LocalDateTime o)
     (unchecked-add
      (unchecked-multiply (.toEpochDay (.toLocalDate ^LocalDateTime o)) seconds-in-day)
-     (.toLocalTime ^LocalDateTime o))
+     (-to-long (.toLocalTime ^LocalDateTime o)))
     (instance? OffsetDateTime o) (.toEpochMilli (.toInstant ^OffsetDateTime o))
     (instance? ZonedDateTime o) (.toEpochMilli (.toInstant ^ZonedDateTime o))
     (int? o) (long o)))

--- a/src/malli/experimental/time/generator.clj
+++ b/src/malli/experimental/time/generator.clj
@@ -29,6 +29,7 @@
      (-to-long (.toLocalTime ^LocalDateTime o)))
     (instance? OffsetDateTime o) (.toEpochMilli (.toInstant ^OffsetDateTime o))
     (instance? ZonedDateTime o) (.toEpochMilli (.toInstant ^ZonedDateTime o))
+    (instance? Duration o) (.toNanos ^Duration o)
     (int? o) (long o)))
 
 (defn to-long [o] (when o (-to-long o)))

--- a/src/malli/experimental/time/generator.clj
+++ b/src/malli/experimental/time/generator.clj
@@ -94,3 +94,6 @@
 
 (defmethod mg/-schema-generator :time/offset-date-time [schema options]
   (-offset-date-time-gen schema options))
+
+(defmethod mg/-schema-generator :time/duration [schema options]
+  (gen/fmap #(Duration/ofNanos %) (gen/large-integer* (-min-max schema options))))

--- a/src/malli/experimental/time/json_schema.clj
+++ b/src/malli/experimental/time/json_schema.clj
@@ -1,0 +1,60 @@
+(ns malli.experimental.time.json-schema
+  (:require
+   [malli.experimental.time]
+   [malli.json-schema :as json]))
+
+;; date-time: A string instance is valid against this attribute if it is
+;; a valid representation according to the "date-time' ABNF rule
+;; (referenced above)
+
+;; date: A string instance is valid against this attribute if it is a
+;; valid representation according to the "full-date" ABNF rule
+;; (referenced above)
+
+;; time: A string instance is valid against this attribute if it is a
+;; valid representation according to the "full-time" ABNF rule
+;; (referenced above)
+
+;; duration: A string instance is valid against this attribute if it is
+;; a valid representation according to the "duration" ABNF rule
+;; (referenced above)
+
+;; Implementations MAY support additional attributes using the other
+;; format names defined anywhere in that RFC. If "full-date" or
+;; "full-time" are implemented, the corresponding short form ("date" or
+;; "time" respectively) MUST be implemented, and MUST behave
+;; identically. Implementations SHOULD NOT define extension attributes
+;; with any name matching an RFC 3339 format unless it validates
+;; according to the rules of that format. There is not currently
+;; consensus on the need for supporting all RFC 3339 formats, so this
+;; approach of reserving the namespace will encourage experimentation
+;; without committing to the entire set. Either the format
+;; implementation requirements will become more flexible in general, or
+;; these will likely either be promoted to fully specified attributes or
+;; dropped.
+
+
+;; date-fullyear   = 4DIGIT
+;; date-month      = 2DIGIT  ; 01-12
+;; date-mday       = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on
+;;                                         ; month/year
+;; time-hour       = 2DIGIT  ; 00-23
+;; time-minute     = 2DIGIT  ; 00-59
+;; time-second     = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second
+;;                                         ; rules
+;; time-secfrac    = "." 1*DIGIT
+;; time-numoffset  = ("+" / "-") time-hour ":" time-minute
+;; time-offset     = "Z" / time-numoffset
+
+;; partial-time    = time-hour ":" time-minute ":" time-second
+;; [time-secfrac]
+;; full-date       = date-fullyear "-" date-month "-" date-mday
+;; full-time       = partial-time time-offset
+
+;; date-time       = full-date "T" full-time
+
+
+(defmethod json/accept :time/local-date [_ _ _ _] {:type "string" :format "date"})
+(defmethod json/accept :time/offset-time [_ _ _ _] {:type "string" :format "time"})
+(defmethod json/accept :time/offset-date-time [_ _ _ _] {:type "string" :format "date-time"})
+(defmethod json/accept :time/duration [_ _ _ _] {:type "string" :format "duration"})

--- a/src/malli/experimental/time/transform.clj
+++ b/src/malli/experimental/time/transform.clj
@@ -12,7 +12,7 @@
 (defn time-decoders
   [formats]
   (into
-   {}
+   time/default-parsers
    (for [k (keys formats)]
      [k {:compile
          (fn [schema opts]
@@ -23,7 +23,8 @@
 (defn time-encoders
   [formats]
   (into
-   {}
+   {:time/duration str
+    :time/zone-id str}
    (for [k (keys formats)]
      [k {:compile
          (fn [schema opts]

--- a/src/malli/experimental/time/transform.clj
+++ b/src/malli/experimental/time/transform.clj
@@ -1,6 +1,6 @@
 (ns malli.experimental.time.transform
   (:import
-   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId OffsetTime ZoneOffset)
    (java.time.temporal TemporalAccessor TemporalQuery)
    (java.time.format DateTimeFormatter))
   (:require
@@ -43,6 +43,7 @@
    :time/local-date DateTimeFormatter/ISO_LOCAL_DATE
    :time/local-date-time DateTimeFormatter/ISO_LOCAL_DATE_TIME
    :time/local-time DateTimeFormatter/ISO_LOCAL_TIME
+   :time/offset-time DateTimeFormatter/ISO_OFFSET_TIME
    :time/offset-date-time DateTimeFormatter/ISO_OFFSET_DATE_TIME
    :time/zoned-date-time DateTimeFormatter/ISO_ZONED_DATE_TIME})
 
@@ -52,20 +53,16 @@
    :time/local-date #(LocalDate/from %)
    :time/local-date-time #(LocalDateTime/from %)
    :time/offset-date-time #(OffsetDateTime/from %)
+   :time/offset-time #(OffsetTime/from %)
    :time/zoned-date-time #(ZonedDateTime/from %)})
 
 (def default-parsers
   (reduce-kv
    (fn [m k v] (assoc m k (safe-fn (->parser v (get queries k)))))
    {:time/duration (safe-fn #(Duration/parse %))
+    :time/zone-offset (safe-fn #(ZoneOffset/of ^String %))
     :time/zone-id (safe-fn #(ZoneId/of %))}
    default-formats))
-
-(defn t<=
-  [^Comparable x ^Comparable y]
-  (if (pos? (.compareTo x y))
-    false
-    true))
 
 (defn compile-parser
   [type formatter pattern]

--- a/src/malli/experimental/time/transform.clj
+++ b/src/malli/experimental/time/transform.clj
@@ -1,0 +1,48 @@
+(ns malli.experimental.time.transform
+  (:import
+   (java.time.format DateTimeFormatter)
+   (java.time.temporal TemporalAccessor))
+  (:require
+   [malli.experimental.time :as time]
+   [malli.transform :as mt]
+   [malli.core :as m]))
+
+(set! *warn-on-reflection* true)
+
+(defn time-decoders
+  [formats]
+  (into
+   {}
+   (for [k (keys formats)]
+     [k {:compile
+         (fn [schema opts]
+           (let [t (m/type schema opts)
+                 {:keys [formatter pattern]} (m/properties schema)]
+             (time/compile-parser t formatter pattern)))}])))
+
+(defn time-encoders
+  [formats]
+  (into
+   {}
+   (for [k (keys formats)]
+     [k {:compile
+         (fn [schema opts]
+           (let [t (m/type schema opts)
+                 {:keys [formatter pattern]} (m/properties schema)
+                 formatter (time/->formatter (or formatter pattern (get time/default-formats t)))]
+             (time/safe-fn
+              (fn [^TemporalAccessor ta]
+                (if (instance? TemporalAccessor ta)
+                  (.format ^DateTimeFormatter formatter ta)
+                  ta)))))}])))
+
+(defn time-transformer
+  ([] (time-transformer time/default-formats))
+  ([formats]
+   (mt/transformer
+    {:name :time
+     :decoders (time-decoders formats)
+     :encoders (time-encoders formats)})))
+
+#_(m/decode (time/local-date-schema) "2020-01-01" (time-transformer))
+#_(m/decode (time/local-time-schema) "18:00:01" (time-transformer))

--- a/src/malli/experimental/time/transform.clj
+++ b/src/malli/experimental/time/transform.clj
@@ -1,24 +1,91 @@
 (ns malli.experimental.time.transform
   (:import
-   (java.time.format DateTimeFormatter)
-   (java.time.temporal TemporalAccessor))
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)
+   (java.time.temporal TemporalAccessor TemporalQuery)
+   (java.time.format DateTimeFormatter))
   (:require
-   [malli.experimental.time :as time]
    [malli.transform :as mt]
    [malli.core :as m]))
 
 (set! *warn-on-reflection* true)
 
+(def default-formats
+  {:time/instant DateTimeFormatter/ISO_INSTANT
+   :time/local-date DateTimeFormatter/ISO_LOCAL_DATE
+   :time/local-date-time DateTimeFormatter/ISO_LOCAL_DATE_TIME
+   :time/local-time DateTimeFormatter/ISO_LOCAL_TIME
+   :time/offset-date-time DateTimeFormatter/ISO_OFFSET_DATE_TIME
+   :time/zoned-date-time DateTimeFormatter/ISO_ZONED_DATE_TIME})
+
+(def queries
+  {:time/instant #(Instant/from %)
+   :time/local-time #(LocalTime/from %)
+   :time/local-date #(LocalDate/from %)
+   :time/local-date-time #(LocalDateTime/from %)
+   :time/offset-date-time #(OffsetDateTime/from %)
+   :time/zoned-date-time #(ZonedDateTime/from %)})
+
+(defn ->temporal-query
+  ^TemporalQuery [f]
+  (reify TemporalQuery
+    (queryFrom [_ t]
+      (f t))))
+
+(defn ->parser
+  [formatter qf]
+  (let [query (->temporal-query qf)]
+    (fn [^CharSequence s]
+      (if (instance? CharSequence s)
+        (.parse ^DateTimeFormatter formatter s query)
+        s))))
+
+(def default-parsers
+  (reduce-kv
+   (fn [m k v] (assoc m k (->parser v (get queries k))))
+   {:time/duration #(Duration/parse %)
+    :time/zone-id #(ZoneId/of %)}
+   default-formats))
+
+(defn ->formatter
+  [x]
+  (cond
+    (instance? DateTimeFormatter x) x
+    (instance? String x) (DateTimeFormatter/ofPattern x)
+    :else (throw (ex-info "Invalid formatter" {:formatter x :type (type x)}))))
+
+(defn safe-fn
+  [f]
+  (fn safe [x]
+    (try
+      (f x)
+      (catch Exception _
+        x))))
+
+(defn t<=
+  [^Comparable x ^Comparable y]
+  (if (pos? (.compareTo x y))
+    false
+    true))
+
+(defn compile-parser
+  [type formatter pattern]
+  (safe-fn
+   (or
+    (when-let [formatter (when-let [x (or formatter pattern)]
+                           (->formatter x))]
+      (->parser formatter (get queries type)))
+    (get default-parsers type))))
+
 (defn time-decoders
   [formats]
   (into
-   time/default-parsers
+   default-parsers
    (for [k (keys formats)]
      [k {:compile
          (fn [schema opts]
            (let [t (m/type schema opts)
                  {:keys [formatter pattern]} (m/properties schema)]
-             (time/compile-parser t formatter pattern)))}])))
+             (compile-parser t formatter pattern)))}])))
 
 (defn time-encoders
   [formats]
@@ -30,15 +97,15 @@
          (fn [schema opts]
            (let [t (m/type schema opts)
                  {:keys [formatter pattern]} (m/properties schema)
-                 formatter (time/->formatter (or formatter pattern (get time/default-formats t)))]
-             (time/safe-fn
+                 formatter (->formatter (or formatter pattern (get default-formats t)))]
+             (safe-fn
               (fn [^TemporalAccessor ta]
                 (if (instance? TemporalAccessor ta)
                   (.format ^DateTimeFormatter formatter ta)
                   ta)))))}])))
 
 (defn time-transformer
-  ([] (time-transformer time/default-formats))
+  ([] (time-transformer default-formats))
   ([formats]
    (mt/transformer
     {:name :time

--- a/test/malli/experimental/time/generator_test.clj
+++ b/test/malli/experimental/time/generator_test.clj
@@ -19,9 +19,11 @@
   (t/testing "simple schemas"
     (t/is (exercise :time/duration))
     (t/is (exercise :time/zone-id))
+    (t/is (exercise :time/zone-offset))
     (t/is (exercise :time/instant))
     (t/is (exercise :time/zoned-date-time))
     (t/is (exercise :time/offset-date-time))
+    (t/is (exercise :time/offset-time))
     (t/is (exercise :time/local-date))
     (t/is (exercise :time/local-time))
     (t/is (exercise :time/local-date-time)))

--- a/test/malli/experimental/time/generator_test.clj
+++ b/test/malli/experimental/time/generator_test.clj
@@ -1,0 +1,30 @@
+(ns malli.experimental.time.generator-test
+  (:require
+   [malli.generator :as mg]
+   [malli.core :as m]
+   [malli.experimental.time-test :refer [r]]
+   [malli.experimental.time.generator]
+   [clojure.test :as t])
+  (:import
+   (java.time LocalDate LocalTime)))
+
+(defn exercise
+  [schema]
+  (let [schema (m/schema schema {:registry r})
+        v (m/validator schema {:registry r})
+        g (mg/generator schema {:registry r})]
+    (every? v (mg/sample g {:size 1000 :registry r}))))
+
+(t/deftest generator-test
+  (t/testing "simple schemas"
+    (t/is (exercise :time/duration))
+    (t/is (exercise :time/zone-id))
+    (t/is (exercise :time/instant))
+    (t/is (exercise :time/zoned-date-time))
+    (t/is (exercise :time/offset-date-time))
+    (t/is (exercise :time/local-date))
+    (t/is (exercise :time/local-time))
+    (t/is (exercise :time/local-date-time)))
+  (t/testing "min max"
+    (t/is (exercise [:time/local-date {:min (LocalDate/parse "1980-01-02") :max (LocalDate/parse "1982-03-02")}]))
+    (t/is (exercise [:time/local-time {:min (LocalTime/parse "12:00:00") :max (LocalTime/parse "18:00:00")}]))))

--- a/test/malli/experimental/time/json_schema_test.clj
+++ b/test/malli/experimental/time/json_schema_test.clj
@@ -1,0 +1,28 @@
+(ns malli.experimental.time.json-schema-test
+  (:require
+   [malli.experimental.time-test :refer [r]]
+   [malli.experimental.time.json-schema]
+   [malli.json-schema :as json]
+   [clojure.test :as t]))
+
+(t/deftest time-formats
+  (t/is
+   (= {:type "object",
+       :properties
+       {:date {:$ref "#/definitions/:time/local-date"},
+        :time {:$ref "#/definitions/:time/offset-time"},
+        :date-time {:$ref "#/definitions/:time/offset-date-time"},
+        :duration {:$ref "#/definitions/:time/duration"}},
+       :required [:date :time :date-time :duration],
+       :definitions
+       #:time{:local-date {:type "string", :format "date"},
+              :offset-time {:type "string", :format "time"},
+              :offset-date-time {:type "string", :format "date-time"},
+              :duration {:type "string", :format "duration"}}}
+      (json/transform
+       [:map
+        [:date :time/local-date]
+        [:time :time/offset-time]
+        [:date-time :time/offset-date-time]
+        [:duration :time/duration]]
+       {:registry r}))))

--- a/test/malli/experimental/time/transform_test.clj
+++ b/test/malli/experimental/time/transform_test.clj
@@ -41,7 +41,9 @@
   (t/testing "offset date time"
     (t/is (validate :time/offset-date-time "2022-12-18T12:00:25.840823567Z"))
     (t/is (validate :time/offset-date-time "2022-12-18T06:00:25.840823567-06:00"))
-    (t/is (not (validate :time/offset-date-time "2_022-12-18T12:00:25.840823567Z")))))
+    (t/is (not (validate :time/offset-date-time "2_022-12-18T12:00:25.840823567Z"))))
+  (t/testing "Aggregates"
+    (t/is (validate [:map [:date :time/local-date]] {:date "2020-01-01"}))))
 
 (defn -decode
   [schema v]

--- a/test/malli/experimental/time/transform_test.clj
+++ b/test/malli/experimental/time/transform_test.clj
@@ -42,3 +42,22 @@
     (t/is (validate :time/offset-date-time "2022-12-18T12:00:25.840823567Z"))
     (t/is (validate :time/offset-date-time "2022-12-18T06:00:25.840823567-06:00"))
     (t/is (not (validate :time/offset-date-time "2_022-12-18T12:00:25.840823567Z")))))
+
+(defn -decode
+  [schema v]
+  (m/decode schema v {:registry r} time.transform/time-transformer))
+
+(defn -encode
+  [schema v]
+  (m/encode schema v {:registry r} time.transform/time-transformer))
+
+(t/deftest encode
+  (t/testing "Round trip with patterns"
+    (t/is (= "20200101" (->> "20200101"
+                             (-decode [:time/local-date {:pattern "yyyyMMdd"}])
+                             (-encode [:time/local-date {:pattern "yyyyMMdd"}]))))
+    (t/is (= "2020_01_01" (->> "20200101"
+                               (-decode [:time/local-date {:pattern "yyyyMMdd"}])
+                               (-encode [:time/local-date {:pattern "yyyy_MM_dd"}]))))))
+
+

--- a/test/malli/experimental/time/transform_test.clj
+++ b/test/malli/experimental/time/transform_test.clj
@@ -20,6 +20,9 @@
   (t/testing "zone id"
     (t/is (validate :time/zone-id "UTC"))
     (t/is (not (validate :time/zone-id "UTC'"))))
+  (t/testing "zone offset"
+    (t/is (validate :time/zone-offset "+15:00"))
+    (t/is (not (validate :time/zone-offset "UTC"))))
   (t/testing "local date"
     (t/is (validate :time/local-date "2020-01-01"))
     (t/testing "Pattern"

--- a/test/malli/experimental/time/transform_test.clj
+++ b/test/malli/experimental/time/transform_test.clj
@@ -1,0 +1,44 @@
+(ns malli.experimental.time.transform-test
+  (:require
+   [malli.core :as m]
+   [malli.experimental.time-test :refer [r]]
+   [malli.experimental.time.transform :as time.transform]
+   [clojure.test :as t]))
+
+(defn validate
+  ([schema v]
+   (validate schema v {:registry r}))
+  ([schema v options]
+   (validate schema v time.transform/time-transformer options))
+  ([schema v transformer options]
+   (m/validate schema (m/decode schema v options transformer) options)))
+
+(t/deftest decode
+  (t/testing "Duration"
+    (t/is (validate :time/duration "PT0.01S"))
+    (t/is (not (validate :time/duration 10))))
+  (t/testing "zone id"
+    (t/is (validate :time/zone-id "UTC"))
+    (t/is (not (validate :time/zone-id "UTC'"))))
+  (t/testing "local date"
+    (t/is (validate :time/local-date "2020-01-01"))
+    (t/testing "Pattern"
+      (t/is (validate [:time/local-date {:pattern "yyyyMMdd"}] "20200101")))
+    (t/is (not (validate :time/local-date "202001-01"))))
+  (t/testing "local time"
+    (t/is (validate :time/local-time "12:00:00"))
+    (t/is (not (validate :time/local-time "$12:00:00"))))
+  (t/testing "local date time"
+    (t/is (validate :time/local-date-time "2020-01-01T12:00:00"))
+    (t/is (not (validate :time/local-date-time "2x020-01-01T12:00:00"))))
+  (t/testing "instant"
+    (t/is (validate :time/instant "2022-12-18T12:00:25.840823567Z"))
+    (t/is (not (validate :time/instant "2022-12-ABC18T12:00:25.840823567Z"))))
+  (t/testing "zoned date time"
+    (t/is (validate :time/zoned-date-time "2022-12-18T12:00:25.840823567Z[UTC]"))
+    (t/is (validate :time/zoned-date-time "2022-12-18T06:00:25.840823567-06:00[America/Chicago]"))
+    (t/is (not (validate :time/zoned-date-time "20%22-12-18T12:00:25.840823567Z[UTC]"))))
+  (t/testing "offset date time"
+    (t/is (validate :time/offset-date-time "2022-12-18T12:00:25.840823567Z"))
+    (t/is (validate :time/offset-date-time "2022-12-18T06:00:25.840823567-06:00"))
+    (t/is (not (validate :time/offset-date-time "2_022-12-18T12:00:25.840823567Z")))))

--- a/test/malli/experimental/time_test.clj
+++ b/test/malli/experimental/time_test.clj
@@ -51,21 +51,37 @@
 
 (t/deftest min-max
   (t/testing "local date"
-    (t/is (m/validate [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}] (LocalDate/parse "2020-01-01") {:registry r}))
-    (t/is (not (m/validate [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}] (LocalDate/parse "2020-01-04") {:registry r})))
-    )
-  #_
+    (t/is (-> [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}]
+              (m/validate (LocalDate/parse "2020-01-01") {:registry r})))
+    (t/is (-> [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}]
+              (m/validate (LocalDate/parse "2020-01-04") {:registry r})
+              not)))
   (t/testing "local time"
-    (t/is (m/validate :time/local-time (LocalTime/parse "12:00:00") {:registry r}))
-    (t/is (not (m/validate :time/local-time "12:00:00" {:registry r}))))
-  #_
+    (t/is (-> [:time/local-time {:min "12:00:00" :max (LocalTime/parse "13:00:00")}]
+              (m/validate (LocalTime/parse "12:00:00") {:registry r})))
+    (t/is (-> [:time/local-time {:min "12:00:00" :max (LocalTime/parse "13:00:00")}]
+              (m/validate (LocalTime/parse "14:00:00") {:registry r})
+              not)))
   (t/testing "local date time"
-    (t/is (m/validate :time/local-date-time (LocalDateTime/parse "2020-01-01T12:00:00") {:registry r}))
-    (t/is (not (m/validate :time/local-date-time "2020-01-01T12:00:00" {:registry r}))))
-  #_
+    (t/is (m/validate [:time/local-date-time
+                       {:min "2020-01-01T11:30:00"
+                        :max "2020-01-01T12:30:00"}]
+                      (LocalDateTime/parse "2020-01-01T12:00:00") {:registry r}))
+    (t/is (-> [:time/local-date-time
+               {:min "2020-01-01T11:30:00"
+                :max "2020-01-01T12:30:00"}]
+              (m/validate (LocalDateTime/parse "2020-01-01T12:40:00") {:registry r})
+              not)))
   (t/testing "instant"
-    (t/is (m/validate :time/instant (Instant/parse "2022-12-18T12:00:25.840823567-00:00") {:registry r}))
-    (t/is (not (m/validate :time/instant "2022-12-18T12:00:25.840823567-00:00" {:registry r}))))
+    (t/is (-> [:time/instant
+               {:min "2022-12-18T11:30:25.840823567Z"
+                :max "2022-12-18T12:30:25.840823567Z"}]
+              (m/validate (Instant/parse "2022-12-18T12:00:25.840823567Z") {:registry r})))
+    (t/is (-> [:time/instant
+               {:min "2022-12-18T11:30:25.840823567Z"
+                :max "2022-12-18T12:30:25.840823567Z"}]
+              (m/validate (Instant/parse "2022-12-18T12:40:25.840823567Z") {:registry r})
+              not)))
   #_
   (t/testing "zoned date time"
     (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T12:00:25.840823567Z[UTC]") {:registry r}))

--- a/test/malli/experimental/time_test.clj
+++ b/test/malli/experimental/time_test.clj
@@ -38,8 +38,8 @@
     (t/is (m/validate :time/local-date-time (LocalDateTime/parse "2020-01-01T12:00:00") {:registry r}))
     (t/is (not (m/validate :time/local-date-time "2020-01-01T12:00:00" {:registry r}))))
   (t/testing "instant"
-    (t/is (m/validate :time/instant (Instant/parse "2022-12-18T12:00:25.840823567-00:00") {:registry r}))
-    (t/is (not (m/validate :time/instant "2022-12-18T12:00:25.840823567-00:00" {:registry r}))))
+    (t/is (m/validate :time/instant (Instant/parse "2022-12-18T12:00:25.840823567Z") {:registry r}))
+    (t/is (not (m/validate :time/instant "2022-12-18T12:00:25.840823567Z" {:registry r}))))
   (t/testing "zoned date time"
     (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T12:00:25.840823567Z[UTC]") {:registry r}))
     (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T06:00:25.840823567-06:00[America/Chicago]") {:registry r}))

--- a/test/malli/experimental/time_test.clj
+++ b/test/malli/experimental/time_test.clj
@@ -9,15 +9,15 @@
 
 (t/deftest compare-dates
   (t/is
-   (time/t<= (LocalDate/parse "2020-01-01")
-             (LocalDate/parse "2020-01-01")))
+   (time/<= (LocalDate/parse "2020-01-01")
+            (LocalDate/parse "2020-01-01")))
   (t/is
-   (time/t<= (LocalDate/parse "2020-01-01")
-             (LocalDate/parse "2020-01-02")))
+   (time/<= (LocalDate/parse "2020-01-01")
+            (LocalDate/parse "2020-01-02")))
   (t/is
    (not
-    (time/t<= (LocalDate/parse "2020-01-02")
-              (LocalDate/parse "2020-01-01")))))
+    (time/<= (LocalDate/parse "2020-01-02")
+             (LocalDate/parse "2020-01-01")))))
 
 (def r
   (mr/composite-registry
@@ -51,41 +51,48 @@
 
 (t/deftest min-max
   (t/testing "local date"
-    (t/is (-> [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}]
+    (t/is (-> [:time/local-date {:min (LocalDate/parse "2020-01-01") :max (LocalDate/parse "2020-01-03")}]
               (m/validate (LocalDate/parse "2020-01-01") {:registry r})))
-    (t/is (-> [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}]
+    (t/is (-> [:time/local-date {:min (LocalDate/parse "2020-01-01") :max (LocalDate/parse "2020-01-03")}]
               (m/validate (LocalDate/parse "2020-01-04") {:registry r})
               not)))
   (t/testing "local time"
-    (t/is (-> [:time/local-time {:min "12:00:00" :max (LocalTime/parse "13:00:00")}]
+    (t/is (-> [:time/local-time {:min (LocalTime/parse "12:00:00") :max (LocalTime/parse "13:00:00")}]
               (m/validate (LocalTime/parse "12:00:00") {:registry r})))
-    (t/is (-> [:time/local-time {:min "12:00:00" :max (LocalTime/parse "13:00:00")}]
+    (t/is (-> [:time/local-time {:min (LocalTime/parse "12:00:00") :max (LocalTime/parse "13:00:00")}]
               (m/validate (LocalTime/parse "14:00:00") {:registry r})
               not)))
   (t/testing "local date time"
     (t/is (m/validate [:time/local-date-time
-                       {:min "2020-01-01T11:30:00"
-                        :max "2020-01-01T12:30:00"}]
+                       {:min (LocalDateTime/parse "2020-01-01T11:30:00")
+                        :max (LocalDateTime/parse "2020-01-01T12:30:00")}]
                       (LocalDateTime/parse "2020-01-01T12:00:00") {:registry r}))
     (t/is (-> [:time/local-date-time
-               {:min "2020-01-01T11:30:00"
-                :max "2020-01-01T12:30:00"}]
+               {:min (LocalDateTime/parse "2020-01-01T11:30:00")
+                :max (LocalDateTime/parse "2020-01-01T12:30:00")}]
               (m/validate (LocalDateTime/parse "2020-01-01T12:40:00") {:registry r})
               not)))
   (t/testing "instant"
     (t/is (-> [:time/instant
-               {:min "2022-12-18T11:30:25.840823567Z"
-                :max "2022-12-18T12:30:25.840823567Z"}]
+               {:min (Instant/parse "2022-12-18T11:30:25.840823567Z")
+                :max (Instant/parse "2022-12-18T12:30:25.840823567Z")}]
               (m/validate (Instant/parse "2022-12-18T12:00:25.840823567Z") {:registry r})))
     (t/is (-> [:time/instant
-               {:min "2022-12-18T11:30:25.840823567Z"
-                :max "2022-12-18T12:30:25.840823567Z"}]
+               {:min (Instant/parse "2022-12-18T11:30:25.840823567Z")
+                :max (Instant/parse "2022-12-18T12:30:25.840823567Z")}]
               (m/validate (Instant/parse "2022-12-18T12:40:25.840823567Z") {:registry r})
               not)))
-  #_
   (t/testing "zoned date time"
-    (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T12:00:25.840823567Z[UTC]") {:registry r}))
-    (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T06:00:25.840823567-06:00[America/Chicago]") {:registry r}))
+    (t/is (-> [:time/zoned-date-time
+               {:min (ZonedDateTime/parse "2022-12-18T11:30:25.840823567Z[UTC]")
+                :max (ZonedDateTime/parse "2022-12-18T12:10:25.840823567Z[UTC]")}]
+              (m/validate (ZonedDateTime/parse "2022-12-18T12:00:25.840823567Z[UTC]") {:registry r})))
+    (t/is (-> [:time/zoned-date-time
+               {:min (ZonedDateTime/parse "2022-12-18T05:40:25.840823567-06:00[America/Chicago]")
+                :max (ZonedDateTime/parse "2022-12-18T12:10:25.840823567Z[UTC]")}]
+              (m/validate (ZonedDateTime/parse
+                           "2022-12-18T06:00:25.840823567-06:00[America/Chicago]") {:registry r})))
+    #_
     (t/is (not (m/validate :time/zoned-date-time "2022-12-18T12:00:25.840823567Z[UTC]" {:registry r}))))
   #_
   (t/testing "offset date time"

--- a/test/malli/experimental/time_test.clj
+++ b/test/malli/experimental/time_test.clj
@@ -5,7 +5,7 @@
    [malli.experimental.time :as time]
    [clojure.test :as t])
   (:import
-   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)))
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId OffsetTime)))
 
 (t/deftest compare-dates
   (t/is
@@ -40,6 +40,9 @@
   (t/testing "local time"
     (t/is (m/validate :time/local-time (LocalTime/parse "12:00:00") {:registry r}))
     (t/is (not (m/validate :time/local-time "12:00:00" {:registry r}))))
+  (t/testing "offset time"
+    (t/is (m/validate :time/offset-time (OffsetTime/parse "12:00:00+00:00") {:registry r}))
+    (t/is (not (m/validate :time/offset-time "12:00:00" {:registry r}))))
   (t/testing "local date time"
     (t/is (m/validate :time/local-date-time (LocalDateTime/parse "2020-01-01T12:00:00") {:registry r}))
     (t/is (not (m/validate :time/local-date-time "2020-01-01T12:00:00" {:registry r}))))

--- a/test/malli/experimental/time_test.clj
+++ b/test/malli/experimental/time_test.clj
@@ -1,0 +1,78 @@
+(ns malli.experimental.time-test
+  (:require
+   [malli.core :as m]
+   [malli.registry :as mr]
+   [malli.experimental.time :as time]
+   [clojure.test :as t])
+  (:import
+   (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId)))
+
+(t/deftest compare-dates
+  (t/is
+   (time/t<= (LocalDate/parse "2020-01-01")
+             (LocalDate/parse "2020-01-01")))
+  (t/is
+   (time/t<= (LocalDate/parse "2020-01-01")
+             (LocalDate/parse "2020-01-02")))
+  (t/is
+   (not
+    (time/t<= (LocalDate/parse "2020-01-02")
+              (LocalDate/parse "2020-01-01")))))
+
+(def r
+  (mr/composite-registry
+   m/default-registry
+   (mr/registry (time/-time-schemas))))
+
+(t/deftest basic-types
+  (t/testing "zone id"
+    (t/is (m/validate :time/zone-id (ZoneId/of "UTC") {:registry r}))
+    (t/is (not (m/validate :time/zone-id "UTC" {:registry r}))))
+  (t/testing "local date"
+    (t/is (m/validate :time/local-date (LocalDate/parse "2020-01-01") {:registry r}))
+    (t/is (not (m/validate :time/local-date "2020-01-01" {:registry r}))))
+  (t/testing "local time"
+    (t/is (m/validate :time/local-time (LocalTime/parse "12:00:00") {:registry r}))
+    (t/is (not (m/validate :time/local-time "12:00:00" {:registry r}))))
+  (t/testing "local date time"
+    (t/is (m/validate :time/local-date-time (LocalDateTime/parse "2020-01-01T12:00:00") {:registry r}))
+    (t/is (not (m/validate :time/local-date-time "2020-01-01T12:00:00" {:registry r}))))
+  (t/testing "instant"
+    (t/is (m/validate :time/instant (Instant/parse "2022-12-18T12:00:25.840823567-00:00") {:registry r}))
+    (t/is (not (m/validate :time/instant "2022-12-18T12:00:25.840823567-00:00" {:registry r}))))
+  (t/testing "zoned date time"
+    (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T12:00:25.840823567Z[UTC]") {:registry r}))
+    (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T06:00:25.840823567-06:00[America/Chicago]") {:registry r}))
+    (t/is (not (m/validate :time/zoned-date-time "2022-12-18T12:00:25.840823567Z[UTC]" {:registry r}))))
+  (t/testing "offset date time"
+    (t/is (m/validate :time/offset-date-time (OffsetDateTime/parse "2022-12-18T12:00:25.840823567Z") {:registry r}))
+    (t/is (m/validate :time/offset-date-time (OffsetDateTime/parse "2022-12-18T06:00:25.840823567-06:00") {:registry r}))
+    (t/is (not (m/validate :time/offset-date-time "2022-12-18T12:00:25.840823567Z" {:registry r})))))
+
+(t/deftest min-max
+  (t/testing "local date"
+    (t/is (m/validate [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}] (LocalDate/parse "2020-01-01") {:registry r}))
+    (t/is (not (m/validate [:time/local-date {:min "2020-01-01" :max (LocalDate/parse "2020-01-03")}] (LocalDate/parse "2020-01-04") {:registry r})))
+    )
+  #_
+  (t/testing "local time"
+    (t/is (m/validate :time/local-time (LocalTime/parse "12:00:00") {:registry r}))
+    (t/is (not (m/validate :time/local-time "12:00:00" {:registry r}))))
+  #_
+  (t/testing "local date time"
+    (t/is (m/validate :time/local-date-time (LocalDateTime/parse "2020-01-01T12:00:00") {:registry r}))
+    (t/is (not (m/validate :time/local-date-time "2020-01-01T12:00:00" {:registry r}))))
+  #_
+  (t/testing "instant"
+    (t/is (m/validate :time/instant (Instant/parse "2022-12-18T12:00:25.840823567-00:00") {:registry r}))
+    (t/is (not (m/validate :time/instant "2022-12-18T12:00:25.840823567-00:00" {:registry r}))))
+  #_
+  (t/testing "zoned date time"
+    (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T12:00:25.840823567Z[UTC]") {:registry r}))
+    (t/is (m/validate :time/zoned-date-time (ZonedDateTime/parse "2022-12-18T06:00:25.840823567-06:00[America/Chicago]") {:registry r}))
+    (t/is (not (m/validate :time/zoned-date-time "2022-12-18T12:00:25.840823567Z[UTC]" {:registry r}))))
+  #_
+  (t/testing "offset date time"
+    (t/is (m/validate :time/offset-date-time (OffsetDateTime/parse "2022-12-18T12:00:25.840823567Z") {:registry r}))
+    (t/is (m/validate :time/offset-date-time (OffsetDateTime/parse "2022-12-18T06:00:25.840823567-06:00") {:registry r}))
+    (t/is (not (m/validate :time/offset-date-time "2022-12-18T12:00:25.840823567Z" {:registry r})))))

--- a/test/malli/experimental/time_test.clj
+++ b/test/malli/experimental/time_test.clj
@@ -15,6 +15,9 @@
    (time/<= (LocalDate/parse "2020-01-01")
             (LocalDate/parse "2020-01-02")))
   (t/is
+   (time/<= (Duration/ofMillis 10)
+            (Duration/ofMillis 11)))
+  (t/is
    (not
     (time/<= (LocalDate/parse "2020-01-02")
              (LocalDate/parse "2020-01-01")))))
@@ -25,6 +28,9 @@
    (mr/registry (time/-time-schemas))))
 
 (t/deftest basic-types
+  (t/testing "Duration"
+    (t/is (m/validate :time/duration (Duration/ofMillis 10) {:registry r}))
+    (t/is (not (m/validate :time/duration 10 {:registry r}))))
   (t/testing "zone id"
     (t/is (m/validate :time/zone-id (ZoneId/of "UTC") {:registry r}))
     (t/is (not (m/validate :time/zone-id "UTC" {:registry r}))))
@@ -50,6 +56,12 @@
     (t/is (not (m/validate :time/offset-date-time "2022-12-18T12:00:25.840823567Z" {:registry r})))))
 
 (t/deftest min-max
+  (t/testing "Duration"
+    (t/is (-> [:time/duration {:min (Duration/ofMillis 9) :max (Duration/ofMillis 10)}]
+              (m/validate (Duration/ofMillis 10) {:registry r})))
+    (t/is (-> [:time/duration {:min (Duration/ofMillis 9) :max (Duration/ofMillis 10)}]
+              (m/validate (Duration/ofMillis 12) {:registry r})
+              not)))
   (t/testing "local date"
     (t/is (-> [:time/local-date {:min (LocalDate/parse "2020-01-01") :max (LocalDate/parse "2020-01-03")}]
               (m/validate (LocalDate/parse "2020-01-01") {:registry r})))


### PR DESCRIPTION
Please find below an initial implementation for time schemas

Status: mature draft, at testing phase
Scope: JVM, schemas, transformers, generators, JSON schema, swagger

Design:

At various points users can provide a DateTimeFormatter or pattern which will be compiled to one.

- time: contains validation code, bounds check and default formats, temporal queries and parsers
- transform: dynamically pick a user provided formatter or a default one, compile to decoder/encoder for each type.
- generator: normalize all types to long, generate and rebuild the temporal type
- json schema: provide accept methods for the formats defined by the RFC
- min/max specification is clunky but all parsing code resides in transform ns