### PR TITLE
add malli experimental describe functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Data-driven Schemas for Clojure/Script and [babashka](#babashka).
 - [Parsing](#parsing-values), [Unparsing](#unparsing-values) and [Sequence Schemas](#sequence-schemas)
 - [Persisting schemas](#persisting-schemas), even [function schemas](#serializable-functions)
 - Immutable, Mutable, Dynamic, Lazy and Local [Schema Registries](#schema-registry)
-- [Schema Transformations](#schema-Transformation) to [JSON Schema](#json-schema) and [Swagger2](#swagger2)
+- [Schema Transformations](#schema-Transformation) to [JSON Schema](#json-schema), [Swagger2](#swagger2), and [descriptions in english](#description)
 - [Multi-schemas](#multi-schemas), [Recursive Schemas](#recursive-schemas) and [Default values](#default-values)
 - [Function Schemas](docs/function-schemas.md) with dynamic and static schema checking
    - Integrates with both [clj-kondo](#clj-kondo) and [Typed Clojure](#static-type-checking-via-typed-clojure) 
@@ -2933,6 +2933,20 @@ Contains `:and`, `:or`, `:orn`, `:not`, `:map`, `:map-of`, `:vector`, `:sequenti
 ### `malli.util/schemas`
 
 `:merge`, `:union` and `:select-keys`.
+
+## Description
+
+You can call describe on a schema to get its description in english:
+
+```clojure
+(require '[malli.experimental.describe :as med])
+
+(med/describe [:map {:closed true}
+               [:x {:optional true} int?]
+               [:y :boolean]])
+
+;;=> "a map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
+```
 
 ## Links (and thanks)
 

--- a/src/malli/experimental/describe.cljc
+++ b/src/malli/experimental/describe.cljc
@@ -101,8 +101,8 @@
 (defmethod accept 'pos-int? [_ _ _ _] "integer greater than 0")
 (defmethod accept :pos-int [_ _ _ _] "integer greater than 0")
 
-(defmethod accept 'neg-int? [_ _ _ _] "integer less than -1")
-(defmethod accept :neg-int [_ _ _ _] "integer less than -1")
+(defmethod accept 'neg-int? [_ _ _ _] "integer less than 0")
+(defmethod accept :neg-int [_ _ _ _] "integer less than 0")
 
 (defmethod accept 'nat-int? [_ _ _ _] "natural integer")
 (defmethod accept :nat-int [_ _ _ _] "natural integer")

--- a/src/malli/experimental/describe.cljc
+++ b/src/malli/experimental/describe.cljc
@@ -1,0 +1,224 @@
+(ns malli.experimental.describe
+  (:require [clojure.string :as str]
+            [malli.core :as m]))
+
+(declare -transform describe)
+
+(defprotocol Descriptor (-accept [this children options] "transforms schema to a text descriptor"))
+
+(defn- diamond [s] (str "<" s ">"))
+(defn- titled [schema] (if-let [t (-> schema m/properties :title)] (str "(titled: ‘" t "’) ") ""))
+(defn- min-max-suffix [schema]
+  (let [{:keys [min max]} (-> schema m/properties)]
+    (cond
+      (and min max) (str " with length between " min " and " max)
+      min (str " with length longer than " min)
+      max (str " with length shorter than " max)
+      :else "")))
+
+(defmulti accept (fn [name _schema _children _options] name) :default ::default)
+
+(defmethod accept ::default [name schema children {:keys [missing-fn]}] (if missing-fn (missing-fn name schema children) ""))
+
+(defn- -schema [schema children options]
+  ;;(def -sin [schema children options])
+  (let [just-one (= 1 (count (:registry (m/properties schema))))]
+    (str (last children)
+         (when (:registry (m/properties schema))
+           (str " "
+                (when-not just-one "which is: ")
+                (diamond
+                  (str/join ", "
+                            (for [[name schema] (:registry (m/properties schema))]
+                              (str (when-not just-one (str name " is "))
+                                   (describe schema))))))))))
+
+(defmethod accept :schema [_ schema children options] (-schema schema children options))
+(defmethod accept ::m/schema [_ schema children options] (-schema schema children options))
+(defmethod accept :ref [_ schema children _] (pr-str (first children)))
+
+(defmethod accept 'ident? [_ _ _ _] "ident")
+(defmethod accept 'simple-ident? [_ _ _ _] "simple-ident")
+
+(defmethod accept 'uuid? [_ _ _ _] "uuid")
+(defmethod accept 'uri? [_ _ _ _] "uri")
+(defmethod accept 'decimal? [_ _ _ _] "decimal")
+(defmethod accept 'inst? [_ _ _ _] "inst (aka date time)")
+(defmethod accept 'seqable? [_ _ _ _] "seqable")
+(defmethod accept 'indexed? [_ _ _ _] "indexed")
+(defmethod accept 'vector? [_ _ _ _] "vector")
+(defmethod accept 'list? [_ _ _ _] "list")
+(defmethod accept 'seq? [_ _ _ _] "seq")
+(defmethod accept 'char? [_ _ _ _] "char")
+(defmethod accept 'set? [_ _ _ _] "set")
+
+(defmethod accept 'false? [_ _ _ _] "false")
+(defmethod accept 'true? [_ _ _ _] "true")
+(defmethod accept 'zero? [_ _ _ _] "zero")
+#?(:clj (defmethod accept 'rational? [_ _ _ _] "rational"))
+(defmethod accept 'coll? [_ _ _ _] "collection")
+(defmethod accept 'empty? [_ _ _ _] "empty")
+(defmethod accept 'associative? [_ _ _ _] "is associative")
+#?(:clj (defmethod accept 'ratio? [_ _ _ _] "ratio"))
+(defmethod accept 'bytes? [_ _ _ _] "bytes")
+(defmethod accept 'ifn? [_ _ _ _] "implmenets IFn")
+(defmethod accept 'fn? [_ _ _ _] "function")
+
+(defmethod accept :>  [_ _ [value] _] (str "> " value))
+(defmethod accept :>= [_ _ [value] _] (str ">= " value))
+(defmethod accept :<  [_ _ [value] _] (str "< " value))
+(defmethod accept :<= [_ _ [value] _] (str "<= " value))
+(defmethod accept :=  [_ _ [value] _] (str "must equal " value))
+(defmethod accept :not= [_ _ [value] _] (str "not equal " value))
+(defmethod accept :not [_ _ children _] {:not (last children)})
+
+(defmethod accept :multi [_ s children _]
+  (let [dispatcher (or (-> s m/properties :dispatch-description)
+                       (-> s m/properties :dispatch))]
+    (str "one of "
+         (diamond
+           (str/join " | " (map (fn [[title _ shape]] (str title " = " shape)) children)))
+         " dispatched by " dispatcher)))
+
+(defmethod accept :map-of [_ schema children _]
+  (str "a map " (titled schema) "from " (diamond (first children)) " to " (diamond (second children)) (min-max-suffix schema)))
+
+(defmethod accept 'vector? [_ schema children _] (str "vector" (titled schema) (min-max-suffix schema) " of " (first children)))
+(defmethod accept :vector [_ schema children _] (str "vector" (titled schema) (min-max-suffix schema) " of " (first children)))
+
+(defmethod accept 'sequential? [_ schema children _] (str "sequence" (titled schema) (min-max-suffix schema) " of " (first children)))
+(defmethod accept :sequential [_ schema children _] (str "sequence" (titled schema) (min-max-suffix schema) " of " (first children)))
+
+(defmethod accept 'set? [_ schema children _] (str "set" (titled schema) (min-max-suffix schema) " of " (first children)))
+(defmethod accept :set [_ schema children _] (str "set" (titled schema) (min-max-suffix schema) " of " (first children)))
+
+(defmethod accept 'string? [_ schema _ _] (str "string" (min-max-suffix schema)))
+(defmethod accept :string [_ schema _ _] (str "string" (min-max-suffix schema)))
+
+(defmethod accept 'number? [_ _ _ _] "number")
+(defmethod accept :number [_ _ _ _] "number")
+
+(defmethod accept 'pos-int? [_ _ _ _] "integer greater than 0")
+(defmethod accept :pos-int [_ _ _ _] "integer greater than 0")
+
+(defmethod accept 'neg-int? [_ _ _ _] "integer less than -1")
+(defmethod accept :neg-int [_ _ _ _] "integer less than -1")
+
+(defmethod accept 'nat-int? [_ _ _ _] "natural integer")
+(defmethod accept :nat-int [_ _ _ _] "natural integer")
+
+(defmethod accept 'float? [_ _ _ _] "float")
+(defmethod accept :float [_ _ _ _] "float")
+
+(defmethod accept 'pos? [_ _ _ _] "number greater than 0")
+(defmethod accept :pos [_ _ _ _] "number greater than 0")
+
+(defmethod accept 'neg? [_ _ _ _] "number less than 0")
+(defmethod accept :neg [_ _ _ _] "number less than 0")
+
+(defmethod accept 'integer? [_ schema _ _] (str "integer" (min-max-suffix schema)))
+(defmethod accept 'int? [_ schema _ _] (str "integer" (min-max-suffix schema)))
+(defmethod accept :int [_ schema _ _] (str "integer" (min-max-suffix schema)))
+
+(defmethod accept 'double? [_ schema _ _] (str "double" (min-max-suffix schema)))
+(defmethod accept :double [_ schema _ _] (str "double" (min-max-suffix schema)))
+
+(defmethod accept :merge [_ schema _ {::keys [describe] :as options}] (describe (m/deref schema) options))
+(defmethod accept :union [_ schema _ {::keys [describe] :as options}] (describe (m/deref schema) options))
+(defmethod accept :select-keys [_ schema _ {::keys [describe] :as options}] (describe (m/deref schema) options))
+
+(defmethod accept :and [_ s children _] (str (str/join ", and " children) (titled s)))
+(defmethod accept :enum [_ s children _options] (str "an enum" (titled s) " of " (str/join ", " children)))
+(defmethod accept :maybe [_ s children _] (str "a nullable " (titled s) (first children)))
+(defmethod accept :tuple [_ s children _] (str "a vector " (titled s) "with exactly " (count children) " items of type: " (str/join ", " children)))
+(defmethod accept :re [_ s _ options] (str "a regex pattern " (titled s) "matching " (pr-str (first (m/children s options)))))
+
+(defmethod accept 'any? [_ s _ _] (str "anything" (titled s)))
+(defmethod accept :any [_ s _ _] (str "anything" (titled s)))
+
+(defmethod accept 'some? [_ _ _ _] "anything but null")
+(defmethod accept :some [_ _ _ _] "anything but null")
+
+(defmethod accept 'nil? [_ _ _ _] "null")
+(defmethod accept :nil [_ _ _ _] "null")
+
+(defmethod accept 'qualified-ident? [_ _ _ _] "qualified-ident")
+(defmethod accept :qualified-ident [_ _ _ _] "qualified-ident")
+
+(defmethod accept 'simple-keyword? [_ _ _ _] "simple-keyword")
+(defmethod accept :simple-keyword [_ _ _ _] "simple-keyword")
+
+(defmethod accept 'simple-symbol? [_ _ _ _] "simple-symbol")
+(defmethod accept :simple-symbol [_ _ _ _] "simple-symbol")
+
+(defmethod accept 'qualified-keyword? [_ _ _ _] "qualified-keyword")
+(defmethod accept :qualified-keyword [_ _ _ _] "qualified keyword")
+
+(defmethod accept 'symbol? [_ _ _ _] "symbol")
+(defmethod accept :symbol [_ _ _ _] "symbol")
+
+(defmethod accept 'qualified-symbol? [_ _ _ _] "qualified-symbol")
+(defmethod accept :qualified-symbol [_ _ _ _] "qualified symbol")
+(defmethod accept :uuid [_ _ _ _] "uuid")
+
+(defmethod accept :=> [_ s _ _]
+  (let [{:keys [input output]} (m/-function-info s)]
+    (str "a function that takes input: [" (describe input) "] and returns " (describe output))))
+
+(defmethod accept :function [_ _ _children _] "a function")
+(defmethod accept :fn [_ _ _ _] "a function")
+
+(defmethod accept :or [_ _ children _] (str/join ", or " children))
+(defmethod accept :orn [_ _ children _] (str/join ", or " (map (fn [[tag _ c]] (str c " (tag: " tag ")" )) children)))
+
+(defmethod accept :cat [_ _ children _] (str/join ", " children))
+(defmethod accept :catn [_ _ children _] (str/join ", or " (map (fn [[tag _ c]] (str c " (tag: " tag ")" )) children)))
+
+(defmethod accept 'boolean? [_ _ _ _] "boolean")
+(defmethod accept :boolean [_ _ _ _] "boolean")
+
+(defmethod accept 'keyword? [_ _ _ _] "keyword")
+(defmethod accept :keyword [_ _ _ _] "keyword")
+
+(defmethod accept 'integer? [_ _ _ _] "integer")
+(defmethod accept 'int? [_ _ _ _] "integer")
+(defmethod accept :int [_ _ _ _] "integer")
+
+(defn- -map [_n schema children _o]
+  (let [optional (set (->> children (filter (m/-comp :optional second)) (mapv first)))
+        additional-properties (:closed (m/properties schema))
+        kv-description (str/join ", " (map (fn [[k _ s]] (str k (when (contains? optional  k) " (optional)") " -> " (diamond s))) children))]
+    (cond-> (str "a map where {" kv-description "}")
+      additional-properties (str " with no other keys"))))
+
+(defmethod accept ::m/val [_ _ children _] (first children))
+(defmethod accept 'map? [n schema children o] (-map n schema children o))
+(defmethod accept :map [n schema children o] (-map n schema children o))
+
+(defn- -descriptor-walker [schema _ children options]
+  (let [p (merge (m/type-properties schema) (m/properties schema))]
+    (or (get p :description)
+        (if (satisfies? Descriptor schema)
+          (-accept schema children options)
+          (accept (m/type schema) schema children options)))))
+
+(defn- -describe [?schema options]
+  (m/walk ?schema -descriptor-walker options))
+
+;;
+;; public api
+;;
+
+(defn describe
+  ([?schema]
+   (describe ?schema nil))
+  ([?schema options]
+   (let [definitions (atom {})
+         options (merge options
+                        {::m/walk-entry-vals true,
+                         ::definitions definitions,
+                         ::describe -describe})]
+     (cond-> (-describe ?schema options)
+       ;; consider using an index for refs?
+       #_(seq @definitions)
+       #_(str @definitions)))))

--- a/src/malli/experimental/describe.cljc
+++ b/src/malli/experimental/describe.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [malli.core :as m]))
 
-(declare -describe)
+(declare -describe describe)
 
 (defprotocol Descriptor (-accept [this children options] "transforms schema to a text descriptor"))
 

--- a/src/malli/experimental/describe.cljc
+++ b/src/malli/experimental/describe.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [malli.core :as m]))
 
-(declare -transform describe)
+(declare -describe)
 
 (defprotocol Descriptor (-accept [this children options] "transforms schema to a text descriptor"))
 

--- a/test/malli/experimental/describe_test.cljc
+++ b/test/malli/experimental/describe_test.cljc
@@ -1,0 +1,78 @@
+(ns malli.experimental.describe-test
+  (:require [clojure.test :refer [deftest is]]
+            [malli.experimental.describe :as med]))
+
+(deftest descriptor-test
+
+  (is (= "a map where {:x -> <integer>}"
+         (med/describe [:map [:x int?]])))
+
+  (is (= "a map where {:x (optional) -> <integer>, :y -> <boolean>}"
+         (med/describe [:map [:x {:optional true} int?] [:y :boolean]])))
+
+  (is (= "a map where {:x -> <integer>} with no other keys"
+         (med/describe [:map {:closed true} [:x int?]])))
+
+  (is (= "a map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
+         (med/describe [:map {:closed true} [:x {:optional true} int?] [:y :boolean]])))
+
+  (is (= "a function that takes input: [integer] and returns integer"
+         (med/describe [:=> [:cat int?] int?])))
+
+  (is (= "a map where {:j-code -> <keyword, and has length 4>}"
+         (med/describe [:map [:j-code [:and
+                                   :keyword
+                                   [:fn {:description "has length 4"} #(= 4 (count (name %)))]]]])))
+
+  (is (= (med/describe [:map-of {:title "dict"} :int :string])
+         "a map (titled: ‘dict’) from <integer> to <string>"))
+
+  (is (= (med/describe [:vector [:sequential [:set :int]]])
+         "vector of sequence of set of integer"))
+
+  (is (= "one of <:dog = a map where {:x -> <integer>} | :cat = anything> dispatched by the type of animal"
+         (med/describe [:multi {:dispatch :type
+                            :dispatch-description "the type of animal"}
+                    [:dog [:map [:x :int]]]
+                    [:cat :any]])))
+
+  (is (= "one of <:dog = a map where {:x -> <integer>} | :cat = anything> dispatched by :type"
+         (med/describe [:multi {:dispatch :type}
+                    [:dog [:map [:x :int]]]
+                    [:cat :any]])))
+
+  (is (= "Order which is: <Country is a map where {:name -> <an enum of :FI, :PO>, :neighbors (optional) -> <vector of \"Country\">} with no other keys, Burger is a map where {:name -> <string>, :description (optional) -> <string>, :origin -> <a nullable Country>, :price -> <integer greater than 0>}, OrderLine is a map where {:burger -> <Burger>, :amount -> <integer>} with no other keys, Order is a map where {:lines -> <vector of OrderLine>, :delivery -> <a map where {:delivered -> <boolean>, :address -> <a map where {:street -> <string>, :zip -> <integer>, :country -> <Country>}>} with no other keys>} with no other keys>"
+         (med/describe [:schema
+                    {:registry {"Country" [:map
+                                           {:closed true}
+                                           [:name [:enum :FI :PO]]
+                                           [:neighbors
+                                            {:optional true}
+                                            [:vector [:ref "Country"]]]],
+                                "Burger" [:map
+                                          [:name string?]
+                                          [:description {:optional true} string?]
+                                          [:origin [:maybe "Country"]]
+                                          [:price pos-int?]],
+                                "OrderLine" [:map
+                                             {:closed true}
+                                             [:burger "Burger"]
+                                             [:amount int?]],
+                                "Order" [:map
+                                         {:closed true}
+                                         [:lines [:vector "OrderLine"]]
+                                         [:delivery
+                                          [:map
+                                           {:closed true}
+                                           [:delivered boolean?]
+                                           [:address
+                                            [:map
+                                             [:street string?]
+                                             [:zip int?]
+                                             [:country "Country"]]]]]]}}
+                    "Order"])))
+
+  (is (= "ConsCell <a nullable a vector with exactly 2 items of type: integer, \"ConsCell\">"
+         (med/describe [:schema
+                    {:registry {"ConsCell" [:maybe [:tuple :int [:ref "ConsCell"]]]}}
+                    "ConsCell"]))))


### PR DESCRIPTION
This follows many conventions in the JSON Schema tranformation ns.

I believe it is complete, meaning it can translate all included malli schemas. 

It also exposes the ability to add a :description property which will be used instead of a computed (or un-computable) description string.