### PR TITLE
mr/set-default-registry! takes varargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * automatic type inferring with `:enum` and `:=` with `malli.transform` and `malli.json-schema` - detects homogenous `:string`, `:keyword`, `:symbol`, `:int` and `:double`), [#782](https://github.com/metosin/malli/pull/782) & [#784](https://github.com/metosin/malli/pull/784)
 * **BREAKING**: Prefer to real Schemas instead of predicates (e.g. `:int` over `'int?`)
 * New `:some` schema (like `some?`)
+* `mr/set-default-registry!` also supports varargs, creating a composite-registry when needed
 * New `malli.experimental.describe` to describe Schemas in english:
 
 ```clojure

--- a/README.md
+++ b/README.md
@@ -2577,6 +2577,19 @@ Registries can be composed, a full example:
 ; => true
 ```
 
+`mr/set-default-registry!` also takes varargs, so you can write the previous as:
+
+```clojure
+;; linear search
+(mr/set-default-registry!
+ ;; immutable registry
+ {:map (m/-map-schema)}
+ ;; mutable (spec-like) registry
+ (mr/mutable-registry registry)
+ ;; on the perils of dynamic scope
+ (mr/dynamic-registry))
+```
+
 ## Function schemas
 
 See [Working with functions](docs/function-schemas.md).

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -71,3 +71,15 @@
                   {:Type "AWS::ApiGateway::UsagePlan"})))
 
       (is (= 2 (count @loads))))))
+
+;; extend-protocol required (slow) call to satisfy?
+(deftype CustomRegistry [])
+(extend-protocol mr/Registry CustomRegistry)
+
+(deftype NotARegistry [])
+
+(deftest registry?-test
+  (is (= true (mr/registry? (mr/composite-registry {}))))
+  (is (= true (mr/registry? (->CustomRegistry))))
+  (is (= false (mr/registry? {})))
+  (is (= false (mr/registry? (->NotARegistry)))))


### PR DESCRIPTION
Not sure if this is a good idea, but this:

```clojure
(mr/set-default-registry!
  ;; linear search
  (mr/composite-registry
    ;; immutable registry
    {:map (m/-map-schema)}
    ;; mutable (spec-like) registry
    (mr/mutable-registry registry)
    ;; on the perils of dynamic scope
    (mr/dynamic-registry)))
```

... could be written as:

```clojure
;; linear search
(mr/set-default-registry!
 ;; immutable registry
 {:map (m/-map-schema)}
 ;; mutable (spec-like) registry
 (mr/mutable-registry registry)
 ;; on the perils of dynamic scope
 (mr/dynamic-registry))
```

comments welcome.