### PR TITLE
Tweaks to malli experimental describe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2944,8 +2944,7 @@ You can call describe on a schema to get its description in english:
 (med/describe [:map {:closed true}
                [:x {:optional true} int?]
                [:y :boolean]])
-
-;;=> "a map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
+;; => "map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
 ```
 
 ## Links (and thanks)

--- a/src/malli/experimental/describe.cljc
+++ b/src/malli/experimental/describe.cljc
@@ -112,36 +112,36 @@
 (defmethod accept 'set? [_ schema children _] (str "set" (titled schema) (length-suffix schema) (of-clause children)))
 (defmethod accept :set [_ schema children _] (str "set" (titled schema) (length-suffix schema) (of-clause children)))
 
-(defmethod accept 'string? [_ schema _ _] (str "string" (length-suffix schema)))
-(defmethod accept :string [_ schema _ _] (str "string" (length-suffix schema)))
+(defmethod accept 'string? [_ schema _ _] (str "string" (titled schema) (length-suffix schema)))
+(defmethod accept :string [_ schema _ _] (str "string" (titled schema) (length-suffix schema)))
 
-(defmethod accept 'number? [_ schema _ _] (str "number" (min-max-suffix schema)))
-(defmethod accept :number [_ schema _ _] (str "number" (min-max-suffix schema)))
+(defmethod accept 'number? [_ schema _ _] (str "number" (titled schema) (min-max-suffix schema)))
+(defmethod accept :number [_ schema _ _] (str "number" (titled schema) (min-max-suffix schema)))
 
-(defmethod accept 'pos-int? [_ schema _ _] (str "integer greater than 0" (min-max-suffix schema)))
-(defmethod accept :pos-int [_ schema _ _] (str "integer greater than 0" (min-max-suffix schema)))
+(defmethod accept 'pos-int? [_ schema _ _] (str "integer greater than 0" (titled schema) (min-max-suffix schema)))
+(defmethod accept :pos-int [_ schema _ _] (str "integer greater than 0" (titled schema) (min-max-suffix schema)))
 
-(defmethod accept 'neg-int? [_ schema _ _] (str "integer less than 0" (min-max-suffix schema)))
-(defmethod accept :neg-int [_ schema _ _] (str "integer less than 0" (min-max-suffix schema)))
+(defmethod accept 'neg-int? [_ schema _ _] (str "integer less than 0" (titled schema) (min-max-suffix schema)))
+(defmethod accept :neg-int [_ schema _ _] (str "integer less than 0" (titled schema) (min-max-suffix schema)))
 
-(defmethod accept 'nat-int? [_ schema _ _] (str "natural integer" (min-max-suffix schema)))
-(defmethod accept :nat-int [_ schema _ _] (str "natural integer" (min-max-suffix schema)))
+(defmethod accept 'nat-int? [_ schema _ _] (str "natural integer" (titled schema) (min-max-suffix schema)))
+(defmethod accept :nat-int [_ schema _ _] (str "natural integer" (titled schema) (min-max-suffix schema)))
 
-(defmethod accept 'float? [_ schema _ _] (str "float" (min-max-suffix schema)))
-(defmethod accept :float [_ schema _ _] (str "float" (min-max-suffix schema)))
+(defmethod accept 'float? [_ schema _ _] (str "float" (titled schema) (min-max-suffix schema)))
+(defmethod accept :float [_ schema _ _] (str "float" (titled schema) (min-max-suffix schema)))
 
-(defmethod accept 'pos? [_ schema _ _] (str "number greater than 0" (min-max-suffix schema)))
-(defmethod accept :pos [_ schema _ _] (str "number greater than 0" (min-max-suffix schema)))
+(defmethod accept 'pos? [_ schema _ _] (str "number greater than 0" (titled schema) (min-max-suffix schema)))
+(defmethod accept :pos [_ schema _ _] (str "number greater than 0" (titled schema) (min-max-suffix schema)))
 
-(defmethod accept 'neg? [_ schema _ _] (str "number less than 0" (min-max-suffix schema)))
-(defmethod accept :neg [_ schema _ _] (str "number less than 0" (min-max-suffix schema)))
+(defmethod accept 'neg? [_ schema _ _] (str "number less than 0" (titled schema) (min-max-suffix schema)))
+(defmethod accept :neg [_ schema _ _] (str "number less than 0" (titled schema) (min-max-suffix schema)))
 
-(defmethod accept 'integer? [_ schema _ _] (str "integer" (min-max-suffix-number schema)))
-(defmethod accept 'int? [_ schema _ _] (str "integer" (min-max-suffix-number schema)))
-(defmethod accept :int [_ schema _ _] (str "integer" (min-max-suffix-number schema)))
+(defmethod accept 'integer? [_ schema _ _] (str "integer" (titled schema)  (min-max-suffix-number schema)))
+(defmethod accept 'int? [_ schema _ _] (str "integer" (titled schema) (min-max-suffix-number schema)))
+(defmethod accept :int [_ schema _ _] (str "integer" (titled schema) (min-max-suffix-number schema)))
 
-(defmethod accept 'double? [_ schema _ _] (str "double" (min-max-suffix-number schema)))
-(defmethod accept :double [_ schema _ _] (str "double" (min-max-suffix-number schema)))
+(defmethod accept 'double? [_ schema _ _] (str "double" (titled schema) (min-max-suffix-number schema)))
+(defmethod accept :double [_ schema _ _] (str "double" (titled schema) (min-max-suffix-number schema)))
 
 (defmethod accept :merge [_ schema _ options] ((::describe options) (m/deref schema) options))
 (defmethod accept :union [_ schema _ options] ((::describe options) (m/deref schema) options))

--- a/src/malli/experimental/describe.cljc
+++ b/src/malli/experimental/describe.cljc
@@ -8,20 +8,38 @@
 
 (defn- diamond [s] (str "<" s ">"))
 (defn- titled [schema] (if-let [t (-> schema m/properties :title)] (str "(titled: ‘" t "’) ") ""))
+
 (defn- min-max-suffix [schema]
   (let [{:keys [min max]} (-> schema m/properties)]
     (cond
-      (and min max) (str " with length between " min " and " max)
-      min (str " with length longer than " min)
-      max (str " with length shorter than " max)
+      (and min max) (str " between " min " and " max " inclusive")
+      min (str " greater than " min)
+      max (str " less than " max)
       :else "")))
 
-(defmulti accept (fn [name _schema _children _options] name) :default ::default)
+(defn- length-suffix [schema]
+  (let [{:keys [min max]} (-> schema m/properties)]
+    (cond
+      (and min max) (str " with length between " min " and " max " inclusive")
+      min (str " with length <= " min)
+      max (str " with length >= " max)
+      :else "")))
+
+(defn- min-max-suffix-number [schema]
+  (let [{:keys [min max]} (-> schema m/properties)]
+    (cond
+      (and min max) (str " between " min " and " max " inclusive")
+      min (str " greater than or equal to " min)
+      max (str " less than or equal to " max)
+      :else "")))
+
+(defmulti accept
+  "Can this be accepted?"
+  (fn [name _schema _children _options] name) :default ::default)
 
 (defmethod accept ::default [name schema children {:keys [missing-fn]}] (if missing-fn (missing-fn name schema children) ""))
 
-(defn- -schema [schema children options]
-  ;;(def -sin [schema children options])
+(defn- -schema [schema children _options]
   (let [just-one (= 1 (count (:registry (m/properties schema))))]
     (str (last children)
          (when (:registry (m/properties schema))
@@ -35,7 +53,7 @@
 
 (defmethod accept :schema [_ schema children options] (-schema schema children options))
 (defmethod accept ::m/schema [_ schema children options] (-schema schema children options))
-(defmethod accept :ref [_ schema children _] (pr-str (first children)))
+(defmethod accept :ref [_ _schema children _] (pr-str (first children)))
 
 (defmethod accept 'ident? [_ _ _ _] "ident")
 (defmethod accept 'simple-ident? [_ _ _ _] "simple-ident")
@@ -81,57 +99,59 @@
          " dispatched by " dispatcher)))
 
 (defmethod accept :map-of [_ schema children _]
-  (str "a map " (titled schema) "from " (diamond (first children)) " to " (diamond (second children)) (min-max-suffix schema)))
+  (str "map " (titled schema) "from " (diamond (first children)) " to " (diamond (second children)) (length-suffix schema)))
 
-(defmethod accept 'vector? [_ schema children _] (str "vector" (titled schema) (min-max-suffix schema) " of " (first children)))
-(defmethod accept :vector [_ schema children _] (str "vector" (titled schema) (min-max-suffix schema) " of " (first children)))
+(defn- of-clause [children] (when children (str " of " (first children))))
 
-(defmethod accept 'sequential? [_ schema children _] (str "sequence" (titled schema) (min-max-suffix schema) " of " (first children)))
-(defmethod accept :sequential [_ schema children _] (str "sequence" (titled schema) (min-max-suffix schema) " of " (first children)))
+(defmethod accept 'vector? [_ schema children _] (str "vector" (titled schema) (length-suffix schema) (of-clause children)))
+(defmethod accept :vector [_ schema children _] (str "vector" (titled schema) (length-suffix schema) (of-clause children)))
 
-(defmethod accept 'set? [_ schema children _] (str "set" (titled schema) (min-max-suffix schema) " of " (first children)))
-(defmethod accept :set [_ schema children _] (str "set" (titled schema) (min-max-suffix schema) " of " (first children)))
+(defmethod accept 'sequential? [_ schema children _] (str "sequence" (titled schema) (length-suffix schema) (of-clause children)))
+(defmethod accept :sequential [_ schema children _] (str "sequence" (titled schema) (length-suffix schema) (of-clause children)))
 
-(defmethod accept 'string? [_ schema _ _] (str "string" (min-max-suffix schema)))
-(defmethod accept :string [_ schema _ _] (str "string" (min-max-suffix schema)))
+(defmethod accept 'set? [_ schema children _] (str "set" (titled schema) (length-suffix schema) (of-clause children)))
+(defmethod accept :set [_ schema children _] (str "set" (titled schema) (length-suffix schema) (of-clause children)))
 
-(defmethod accept 'number? [_ _ _ _] "number")
-(defmethod accept :number [_ _ _ _] "number")
+(defmethod accept 'string? [_ schema _ _] (str "string" (length-suffix schema)))
+(defmethod accept :string [_ schema _ _] (str "string" (length-suffix schema)))
 
-(defmethod accept 'pos-int? [_ _ _ _] "integer greater than 0")
-(defmethod accept :pos-int [_ _ _ _] "integer greater than 0")
+(defmethod accept 'number? [_ schema _ _] (str "number" (min-max-suffix schema)))
+(defmethod accept :number [_ schema _ _] (str "number" (min-max-suffix schema)))
 
-(defmethod accept 'neg-int? [_ _ _ _] "integer less than 0")
-(defmethod accept :neg-int [_ _ _ _] "integer less than 0")
+(defmethod accept 'pos-int? [_ schema _ _] (str "integer greater than 0" (min-max-suffix schema)))
+(defmethod accept :pos-int [_ schema _ _] (str "integer greater than 0" (min-max-suffix schema)))
 
-(defmethod accept 'nat-int? [_ _ _ _] "natural integer")
-(defmethod accept :nat-int [_ _ _ _] "natural integer")
+(defmethod accept 'neg-int? [_ schema _ _] (str "integer less than 0" (min-max-suffix schema)))
+(defmethod accept :neg-int [_ schema _ _] (str "integer less than 0" (min-max-suffix schema)))
 
-(defmethod accept 'float? [_ _ _ _] "float")
-(defmethod accept :float [_ _ _ _] "float")
+(defmethod accept 'nat-int? [_ schema _ _] (str "natural integer" (min-max-suffix schema)))
+(defmethod accept :nat-int [_ schema _ _] (str "natural integer" (min-max-suffix schema)))
 
-(defmethod accept 'pos? [_ _ _ _] "number greater than 0")
-(defmethod accept :pos [_ _ _ _] "number greater than 0")
+(defmethod accept 'float? [_ schema _ _] (str "float" (min-max-suffix schema)))
+(defmethod accept :float [_ schema _ _] (str "float" (min-max-suffix schema)))
 
-(defmethod accept 'neg? [_ _ _ _] "number less than 0")
-(defmethod accept :neg [_ _ _ _] "number less than 0")
+(defmethod accept 'pos? [_ schema _ _] (str "number greater than 0" (min-max-suffix schema)))
+(defmethod accept :pos [_ schema _ _] (str "number greater than 0" (min-max-suffix schema)))
 
-(defmethod accept 'integer? [_ schema _ _] (str "integer" (min-max-suffix schema)))
-(defmethod accept 'int? [_ schema _ _] (str "integer" (min-max-suffix schema)))
-(defmethod accept :int [_ schema _ _] (str "integer" (min-max-suffix schema)))
+(defmethod accept 'neg? [_ schema _ _] (str "number less than 0" (min-max-suffix schema)))
+(defmethod accept :neg [_ schema _ _] (str "number less than 0" (min-max-suffix schema)))
 
-(defmethod accept 'double? [_ schema _ _] (str "double" (min-max-suffix schema)))
-(defmethod accept :double [_ schema _ _] (str "double" (min-max-suffix schema)))
+(defmethod accept 'integer? [_ schema _ _] (str "integer" (min-max-suffix-number schema)))
+(defmethod accept 'int? [_ schema _ _] (str "integer" (min-max-suffix-number schema)))
+(defmethod accept :int [_ schema _ _] (str "integer" (min-max-suffix-number schema)))
 
-(defmethod accept :merge [_ schema _ {::keys [describe] :as options}] (describe (m/deref schema) options))
-(defmethod accept :union [_ schema _ {::keys [describe] :as options}] (describe (m/deref schema) options))
-(defmethod accept :select-keys [_ schema _ {::keys [describe] :as options}] (describe (m/deref schema) options))
+(defmethod accept 'double? [_ schema _ _] (str "double" (min-max-suffix-number schema)))
+(defmethod accept :double [_ schema _ _] (str "double" (min-max-suffix-number schema)))
+
+(defmethod accept :merge [_ schema _ options] ((::describe options) (m/deref schema) options))
+(defmethod accept :union [_ schema _ options] ((::describe options) (m/deref schema) options))
+(defmethod accept :select-keys [_ schema _ options] ((::describe options) (m/deref schema) options))
 
 (defmethod accept :and [_ s children _] (str (str/join ", and " children) (titled s)))
-(defmethod accept :enum [_ s children _options] (str "an enum" (titled s) " of " (str/join ", " children)))
-(defmethod accept :maybe [_ s children _] (str "a nullable " (titled s) (first children)))
-(defmethod accept :tuple [_ s children _] (str "a vector " (titled s) "with exactly " (count children) " items of type: " (str/join ", " children)))
-(defmethod accept :re [_ s _ options] (str "a regex pattern " (titled s) "matching " (pr-str (first (m/children s options)))))
+(defmethod accept :enum [_ s children _options] (str "enum" (titled s) " of " (str/join ", " children)))
+(defmethod accept :maybe [_ s children _] (str "nullable " (titled s) (first children)))
+(defmethod accept :tuple [_ s children _] (str "vector " (titled s) "with exactly " (count children) " items of type: " (str/join ", " children)))
+(defmethod accept :re [_ s _ options] (str "regex pattern " (titled s) "matching " (pr-str (first (m/children s options)))))
 
 (defmethod accept 'any? [_ s _ _] (str "anything" (titled s)))
 (defmethod accept :any [_ s _ _] (str "anything" (titled s)))
@@ -163,16 +183,28 @@
 
 (defmethod accept :=> [_ s _ _]
   (let [{:keys [input output]} (m/-function-info s)]
-    (str "a function that takes input: [" (describe input) "] and returns " (describe output))))
+    (str "function that takes input: [" (describe input) "] and returns " (describe output))))
 
-(defmethod accept :function [_ _ _children _] "a function")
-(defmethod accept :fn [_ _ _ _] "a function")
+(defmethod accept :function [_ _ _children _] "function")
+(defmethod accept :fn [_ _ _ _] "function")
+
+(defn- tagged [children]
+  (map (fn [[tag _ c]] (str c " (tag: " tag ")" )) children))
 
 (defmethod accept :or [_ _ children _] (str/join ", or " children))
-(defmethod accept :orn [_ _ children _] (str/join ", or " (map (fn [[tag _ c]] (str c " (tag: " tag ")" )) children)))
+(defmethod accept :orn [_ _ children _] (str/join ", or " (tagged children)))
 
 (defmethod accept :cat [_ _ children _] (str/join ", " children))
-(defmethod accept :catn [_ _ children _] (str/join ", or " (map (fn [[tag _ c]] (str c " (tag: " tag ")" )) children)))
+(defmethod accept :catn [_ _ children _] (str/join ", and " (tagged children)))
+
+(defmethod accept :alt [_ _ children _] (str/join ", or " children))
+(defmethod accept :altn [_ _ children _] (str/join ", or " (tagged children)))
+
+(defmethod accept :+ [_ _ children _] (str "one or more " (str/join ", " children)))
+(defmethod accept :* [_ _ children _] (str "zero or more " (str/join ", " children)))
+(defmethod accept :? [_ _ children _] (str "zero or one " (str/join ", " children)))
+
+(defmethod accept :repeat [_ schema children _] (str "more" (min-max-suffix schema) " of " (str/join ", " children)))
 
 (defmethod accept 'boolean? [_ _ _ _] "boolean")
 (defmethod accept :boolean [_ _ _ _] "boolean")
@@ -180,16 +212,14 @@
 (defmethod accept 'keyword? [_ _ _ _] "keyword")
 (defmethod accept :keyword [_ _ _ _] "keyword")
 
-(defmethod accept 'integer? [_ _ _ _] "integer")
-(defmethod accept 'int? [_ _ _ _] "integer")
-(defmethod accept :int [_ _ _ _] "integer")
-
 (defn- -map [_n schema children _o]
   (let [optional (set (->> children (filter (m/-comp :optional second)) (mapv first)))
         additional-properties (:closed (m/properties schema))
         kv-description (str/join ", " (map (fn [[k _ s]] (str k (when (contains? optional  k) " (optional)") " -> " (diamond s))) children))]
-    (cond-> (str "a map where {" kv-description "}")
-      additional-properties (str " with no other keys"))))
+    (str/trim
+     (cond-> (str "map ")
+       (seq kv-description) (str "where {" kv-description "} ")
+       additional-properties (str "with no other keys ")))))
 
 (defmethod accept ::m/val [_ _ children _] (first children))
 (defmethod accept 'map? [n schema children o] (-map n schema children o))
@@ -210,6 +240,7 @@
 ;;
 
 (defn describe
+  "Given a schema, returns a string explaiaing the required shape in English"
   ([?schema]
    (describe ?schema nil))
   ([?schema options]
@@ -218,7 +249,4 @@
                         {::m/walk-entry-vals true,
                          ::definitions definitions,
                          ::describe -describe})]
-     (cond-> (-describe ?schema options)
-       ;; consider using an index for refs?
-       #_(seq @definitions)
-       #_(str @definitions)))))
+     (str/trim (-describe ?schema options)))))

--- a/src/malli/experimental/describe.cljc
+++ b/src/malli/experimental/describe.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.string :as str]
             [malli.core :as m]))
 
-(declare -describe)
+(declare -describe describe)
 
 (defprotocol Descriptor (-accept [this children options] "transforms schema to a text descriptor"))
 

--- a/test/malli/experimental/describe_test.cljc
+++ b/test/malli/experimental/describe_test.cljc
@@ -1,103 +1,103 @@
 (ns malli.experimental.describe-test
-  (:require [clojure.test :refer [deftest is]]
+  (:require [clojure.test :refer [deftest is testing]]
             [malli.experimental.describe :as med]))
 
 (deftest descriptor-test
+  (testing "vector"
+    (is (= "vector" (med/describe vector?)))
+    (is (= "vector of integer" (med/describe [:vector :int]))))
 
-  ;; vector
-  (is (= "vector" (med/describe vector?)))
+  (testing "string"
+    (is (= "string with length <= 5" (med/describe [:string {:min 5}])))
+    (is (= "string with length >= 5" (med/describe [:string {:max 5}])))
+    (is (= "string with length between 3 and 5 inclusive" (med/describe [:string {:min 3 :max 5}]))))
 
-  (is (= "vector of integer" (med/describe [:vector :int])))
+  (testing "function"
+    (is (= "function that takes input: [integer] and returns integer"
+           (med/describe [:=> [:cat int?] int?]))))
 
-  ;; string
-  (is (= "string with length <= 5" (med/describe [:string {:min 5}])))
+  (testing "map"
+    (is (= "map" (med/describe map?)))
+    (is (= "map where {:x -> <integer>}"
+           (med/describe [:map [:x int?]])))
+    (is (= "map where {:x (optional) -> <integer>, :y -> <boolean>}"
+           (med/describe [:map [:x {:optional true} int?] [:y :boolean]])))
+    (is (= "map where {:x -> <integer>} with no other keys"
+           (med/describe [:map {:closed true} [:x int?]])))
+    (is (= "map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
+           (med/describe [:map {:closed true} [:x {:optional true} int?] [:y :boolean]])))
+    (is (= "map where {:j-code -> <keyword, and has length 4>}"
+           (med/describe [:map [:j-code [:and
+                                         :keyword
+                                         [:fn {:description "has length 4"} #(= 4 (count (name %)))]]]])))
+    (is (= "map (titled: ‘dict’) from <integer> to <string>"
+           (med/describe [:map-of {:title "dict"} :int :string]))))
 
-  (is (= "string with length >= 5" (med/describe [:string {:max 5}])))
+  (testing "compound schemas"
+    (is (= "vector of sequence of set of integer"
+           (med/describe [:vector [:sequential [:set :int]]]))))
 
-  (is (= "string with length between 3 and 5 inclusive" (med/describe [:string {:min 3 :max 5}])))
+  (testing "multi"
+    (is (= "one of <:dog = map where {:x -> <integer>} | :cat = anything> dispatched by the type of animal"
+           (med/describe [:multi {:dispatch :type
+                                  :dispatch-description "the type of animal"}
+                          [:dog [:map [:x :int]]]
+                          [:cat :any]])))
+    (is (= "one of <:dog = map where {:x -> <integer>} | :cat = anything> dispatched by :type"
+           (med/describe [:multi {:dispatch :type}
+                          [:dog [:map [:x :int]]]
+                          [:cat :any]]))))
 
-  ;; function
-  (is (= "function that takes input: [integer, one or more of boolean] and returns integer"
-         (med/describe [:=> [:cat int? [:+ boolean?]] int?])))
+  (testing "schema registry"
+    (is (= "Order which is: <Country is map where {:name -> <enum of :FI, :PO>, :neighbors (optional) -> <vector of \"Country\">} with no other keys, Burger is map where {:name -> <string>, :description (optional) -> <string>, :origin -> <nullable Country>, :price -> <integer greater than 0>}, OrderLine is map where {:burger -> <Burger>, :amount -> <integer>} with no other keys, Order is map where {:lines -> <vector of OrderLine>, :delivery -> <map where {:delivered -> <boolean>, :address -> <map where {:street -> <string>, :zip -> <integer>, :country -> <Country>}>} with no other keys>} with no other keys>"
+           (med/describe [:schema
+                          {:registry
+                           {"Country"
+                            [:map
+                             {:closed true}
+                             [:name [:enum :FI :PO]]
+                             [:neighbors
+                              {:optional true}
+                              [:vector [:ref "Country"]]]],
+                            "Burger" [:map
+                                      [:name string?]
+                                      [:description {:optional true} string?]
+                                      [:origin [:maybe "Country"]]
+                                      [:price pos-int?]],
+                            "OrderLine" [:map
+                                         {:closed true}
+                                         [:burger "Burger"]
+                                         [:amount int?]],
+                            "Order" [:map
+                                     {:closed true}
+                                     [:lines [:vector "OrderLine"]]
+                                     [:delivery
+                                      [:map
+                                       {:closed true}
+                                       [:delivered boolean?]
+                                       [:address
+                                        [:map
+                                         [:street string?]
+                                         [:zip int?]
+                                         [:country "Country"]]]]]]}}
+                          "Order"])))
+    (is (= "ConsCell <nullable vector with exactly 2 items of type: integer, \"ConsCell\">"
+           (med/describe [:schema
+                          {:registry {"ConsCell" [:maybe [:tuple :int [:ref "ConsCell"]]]}}
+                          "ConsCell"]))))
 
-  ;; map
-  (is (= "map" (med/describe map?)))
+  (testing "int"
+    (is (= "integer greater than or equal to 0"
+           (med/describe [:int {:min 0}])))
+    (is (= "integer less than or equal to 1"
+           (med/describe [:int {:max 1}])))
+    (is (= "integer between 0 and 1 inclusive"
+           (med/describe [:int {:min 0 :max 1}]))))
 
-  (is (= "map where {:x -> <integer>}"
-         (med/describe [:map [:x int?]])))
-
-  (is (= "map where {:x (optional) -> <integer>, :y -> <boolean>}"
-         (med/describe [:map [:x {:optional true} int?] [:y :boolean]])))
-
-  (is (= "map where {:x -> <integer>} with no other keys"
-         (med/describe [:map {:closed true} [:x int?]])))
-
-  (is (= "map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
-         (med/describe [:map {:closed true} [:x {:optional true} int?] [:y :boolean]])))
-
-  (is (= "function that takes input: [integer] and returns integer"
-         (med/describe [:=> [:cat int?] int?])))
-
-  (is (= "map where {:j-code -> <keyword, and has length 4>}"
-         (med/describe [:map [:j-code
-                              [:and
-                               :keyword
-                               [:fn {:description "has length 4"} #(= 4 (count (name %)))]]]])))
-
-  (is (= "a map where {:j-code -> <keyword, and has length 4>}"
-         (med/describe [:map [:j-code [:and
-                                       :keyword
-                                       [:fn {:description "has length 4"} #(= 4 (count (name %)))]]]])))
-
-  (is (= (med/describe [:map-of {:title "dict"} :int :string])
-         "map (titled: ‘dict’) from <integer> to <string>"))
-
-  (is (= (med/describe [:vector [:sequential [:set :int]]])
-         "vector of sequence of set of integer"))
-
-  (is (= "one of <:dog = map where {:x -> <integer>} | :cat = anything> dispatched by the type of animal"
-         (med/describe [:multi {:dispatch :type
-                                :dispatch-description "the type of animal"}
-                        [:dog [:map [:x :int]]]
-                        [:cat :any]])))
-
-  (is (= "one of <:dog = map where {:x -> <integer>} | :cat = anything> dispatched by :type"
-         (med/describe [:multi {:dispatch :type}
-                        [:dog [:map [:x :int]]]
-                        [:cat :any]])))
-
-  (is (= "Order which is: <Country is map where {:name -> <enum of :FI, :PO>, :neighbors (optional) -> <vector of \"Country\">} with no other keys, Burger is map where {:name -> <string>, :description (optional) -> <string>, :origin -> <nullable Country>, :price -> <integer greater than 0>}, OrderLine is map where {:burger -> <Burger>, :amount -> <integer>} with no other keys, Order is map where {:lines -> <vector of OrderLine>, :delivery -> <map where {:delivered -> <boolean>, :address -> <map where {:street -> <string>, :zip -> <integer>, :country -> <Country>}>} with no other keys>} with no other keys>"
-         (med/describe [:schema
-                        {:registry {"Country" [:map
-                                               {:closed true}
-                                               [:name [:enum :FI :PO]]
-                                               [:neighbors
-                                                {:optional true}
-                                                [:vector [:ref "Country"]]]],
-                                    "Burger" [:map
-                                              [:name string?]
-                                              [:description {:optional true} string?]
-                                              [:origin [:maybe "Country"]]
-                                              [:price pos-int?]],
-                                    "OrderLine" [:map
-                                                 {:closed true}
-                                                 [:burger "Burger"]
-                                                 [:amount int?]],
-                                    "Order" [:map
-                                             {:closed true}
-                                             [:lines [:vector "OrderLine"]]
-                                             [:delivery
-                                              [:map
-                                               {:closed true}
-                                               [:delivered boolean?]
-                                               [:address
-                                                [:map
-                                                 [:street string?]
-                                                 [:zip int?]
-                                                 [:country "Country"]]]]]]}}
-                        "Order"])))
-
-  (is (= "ConsCell <nullable vector with exactly 2 items of type: integer, \"ConsCell\">"
-         (med/describe [:schema
-                        {:registry {"ConsCell" [:maybe [:tuple :int [:ref "ConsCell"]]]}}
-                        "ConsCell"]))))
+  (testing "repeat"
+    (is (= "repeat <integer> at least 1 time"
+           (med/describe [:repeat {:min 1} int?])))
+    (is (= "repeat <integer> at most 7 times"
+           (med/describe [:repeat {:max 7} int?])))
+    (is (= "repeat <integer> at least 1 time, up to 7 times"
+           (med/describe [:repeat {:min 1 :max 7} int?])))))

--- a/test/malli/experimental/describe_test.cljc
+++ b/test/malli/experimental/describe_test.cljc
@@ -4,44 +4,60 @@
 
 (deftest descriptor-test
 
-  (is (= "a map where {:x -> <integer>}"
+  ;; vector
+  (is (= "vector" (med/describe vector?)))
+
+  (is (= "vector of integer" (med/describe [:vector :int])))
+
+  ;; string
+  (is (= "string with length <= 5" (med/describe [:string {:min 5}])))
+
+  (is (= "string with length >= 5" (med/describe [:string {:max 5}])))
+
+  (is (= "string with length between 3 and 5 inclusive" (med/describe [:string {:min 3 :max 5}])))
+
+  ;; map
+  (is (= "map" (med/describe map?)))
+
+  (is (= "map where {:x -> <integer>}"
          (med/describe [:map [:x int?]])))
 
-  (is (= "a map where {:x (optional) -> <integer>, :y -> <boolean>}"
+  (is (= "map where {:x (optional) -> <integer>, :y -> <boolean>}"
          (med/describe [:map [:x {:optional true} int?] [:y :boolean]])))
 
-  (is (= "a map where {:x -> <integer>} with no other keys"
+  (is (= "map where {:x -> <integer>} with no other keys"
          (med/describe [:map {:closed true} [:x int?]])))
 
-  (is (= "a map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
+  (is (= "map where {:x (optional) -> <integer>, :y -> <boolean>} with no other keys"
          (med/describe [:map {:closed true} [:x {:optional true} int?] [:y :boolean]])))
 
-  (is (= "a function that takes input: [integer] and returns integer"
+  (is (= "function that takes input: [integer] and returns integer"
          (med/describe [:=> [:cat int?] int?])))
 
-  (is (= "a map where {:j-code -> <keyword, and has length 4>}"
-         (med/describe [:map [:j-code [:and
-                                   :keyword
-                                   [:fn {:description "has length 4"} #(= 4 (count (name %)))]]]])))
+  (is (= "map where {:j-code -> <keyword, and has length 4>}"
+         (med/describe [:map [:j-code
+                              [:and
+                               :keyword
+                               [:fn {:description "has length 4"} #(= 4 (count (name %)))]]]])))
 
   (is (= (med/describe [:map-of {:title "dict"} :int :string])
-         "a map (titled: ‘dict’) from <integer> to <string>"))
+         "map (titled: ‘dict’) from <integer> to <string>"))
 
   (is (= (med/describe [:vector [:sequential [:set :int]]])
          "vector of sequence of set of integer"))
 
-  (is (= "one of <:dog = a map where {:x -> <integer>} | :cat = anything> dispatched by the type of animal"
+  (is (= "one of <:dog = map where {:x -> <integer>} | :cat = anything> dispatched by the type of animal"
          (med/describe [:multi {:dispatch :type
                             :dispatch-description "the type of animal"}
                     [:dog [:map [:x :int]]]
                     [:cat :any]])))
 
-  (is (= "one of <:dog = a map where {:x -> <integer>} | :cat = anything> dispatched by :type"
+  (is (= "one of <:dog = map where {:x -> <integer>} | :cat = anything> dispatched by :type"
          (med/describe [:multi {:dispatch :type}
                     [:dog [:map [:x :int]]]
                     [:cat :any]])))
 
-  (is (= "Order which is: <Country is a map where {:name -> <an enum of :FI, :PO>, :neighbors (optional) -> <vector of \"Country\">} with no other keys, Burger is a map where {:name -> <string>, :description (optional) -> <string>, :origin -> <a nullable Country>, :price -> <integer greater than 0>}, OrderLine is a map where {:burger -> <Burger>, :amount -> <integer>} with no other keys, Order is a map where {:lines -> <vector of OrderLine>, :delivery -> <a map where {:delivered -> <boolean>, :address -> <a map where {:street -> <string>, :zip -> <integer>, :country -> <Country>}>} with no other keys>} with no other keys>"
+  (is (= "Order which is: <Country is map where {:name -> <enum of :FI, :PO>, :neighbors (optional) -> <vector of \"Country\">} with no other keys, Burger is map where {:name -> <string>, :description (optional) -> <string>, :origin -> <nullable Country>, :price -> <integer greater than 0>}, OrderLine is map where {:burger -> <Burger>, :amount -> <integer>} with no other keys, Order is map where {:lines -> <vector of OrderLine>, :delivery -> <map where {:delivered -> <boolean>, :address -> <map where {:street -> <string>, :zip -> <integer>, :country -> <Country>}>} with no other keys>} with no other keys>"
          (med/describe [:schema
                     {:registry {"Country" [:map
                                            {:closed true}
@@ -72,7 +88,7 @@
                                              [:country "Country"]]]]]]}}
                     "Order"])))
 
-  (is (= "ConsCell <a nullable a vector with exactly 2 items of type: integer, \"ConsCell\">"
+  (is (= "ConsCell <nullable vector with exactly 2 items of type: integer, \"ConsCell\">"
          (med/describe [:schema
                     {:registry {"ConsCell" [:maybe [:tuple :int [:ref "ConsCell"]]]}}
                     "ConsCell"]))))


### PR DESCRIPTION
1. Using "a" prefix does not compose, so it's been removed. 
    - (e.g. `[:vector map?]` => "a map of a vector", is now fixed)
2. Differentiate between min/max length of collection vs. min/max numeral constraints
3. a couple linting fixes
1. adds repeat verbiage that makes sense
1. removed [duplicate int defmultis](https://github.com/metosin/malli/pull/814/files#diff-91e4afd493bcf0c63e0117f025a9f42e7e44123a813ef2f9f18ac0fa2202a222L191-L194)