### PR TITLE
Strip-extra-keys should not break on non-map values

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -373,7 +373,12 @@
    (let [transform {:compile (fn [schema _]
                                (when (accept schema)
                                  (when-let [ks (some->> schema m/entries (map first) seq set)]
-                                   (fn [x] (reduce-kv (fn [acc k _] (if-not (ks k) (dissoc acc k) acc)) x x)))))}]
+                                   (fn [x]
+                                     ;; accept checks if the schema is compatible with strip-extra-keys,
+                                     ;; but the value might not be compatible with reduce-kv, i.e. a string.
+                                     (if (map? x)
+                                       (reduce-kv (fn [acc k _] (if-not (ks k) (dissoc acc k) acc)) x x)
+                                       x)))))}]
      (transformer
       {:decoders {:map transform}
        :encoders {:map transform}}))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -401,12 +401,23 @@
               [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
               {"key_x" "18" "key_y" "john" "key_a" "doe"}
               transformer))))
+
     (testing "encode"
       (is (= {"key_x" "18" "key_y" "john"}
              (m/encode
               [:map [:x int?] [:y string?] [[:opt :z] boolean?]]
               {:x 18 :y "john" :a "doe"}
-              transformer))))))
+              transformer)))))
+
+  (testing "extra-keys-transformer shouldn't break non map values"
+    (is (= {:foo "bar"}
+           (m/decode
+             [:map {:decode/string (fn [s] {:foo s})}
+              [:foo :string]]
+             "bar"
+             (mt/transformer
+               (mt/strip-extra-keys-transformer)
+               (mt/string-transformer)))))))
 
 (deftest strip-extra-keys-transformer-test
   (let [strip-default (mt/strip-extra-keys-transformer)


### PR DESCRIPTION
strip-extra-keys-transformer is used for transforming map schemas, but it doesn't check the value being transformed and reduce-kv will fail if given e.g. a string as a value.

Non-map values (like strings) are a valid case for :map schema transforming, as they can be decoded into maps. Reitit however has strip-extra-keys transformer before string-decoding, so strip-extra-keys always sees the string value. But I think transformers shouldn't fail like this in any case.