### PR TITLE
Add clj-kondo support for cljs function schemas

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
                         jmh-clojure/task {:mvn/version "0.1.1"}}
                  :main-opts ["-m" "jmh.main"]}
            :shadow {:extra-paths ["app"]
-                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.20.5"}
+                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.20.20"}
                                  binaryage/devtools {:mvn/version "1.0.6"}}}
            :slow {:extra-deps {io.dominic/slow-namespace-clj
                                {:git/url "https://git.sr.ht/~severeoverfl0w/slow-namespace-clj"

--- a/docs/clojurescript-function-instrumentation.md
+++ b/docs/clojurescript-function-instrumentation.md
@@ -80,6 +80,29 @@ the instrumented function is the one with the red rectangle around it in the ima
 
 If you click the filename (`instrument_app.cljs` in this example) the browser devtools will open a file viewer at the problematic call-site.
 
+# Clj-Kondo config
+
+Running `malli.dev` instrumentation also emits [clj-kondo](https://github.com/metosin/malli#clj-kondo) type configs for all `defn`s,
+enabling basic static type checking/linting for the instrumented functions.
+
+This is currently only supported when using shadow-cljs.
+
+The config is determined at runtime by the browser's JavaScript VM so cannot be performed statically. Your application must be
+executed in orer to deal with dynamic schemas that may show up in function metadata.
+
+To enable this feature, in your `shadow-cljs.edn` file add the following build [hook](https://shadow-cljs.github.io/docs/UsersGuide.html#build-hooks):
+
+```clojure
+:build-hooks [(malli.dev.shadow-cljs-hooks/kondo-hook :main)]
+```
+
+where `:main` is the module id of your application.
+
+The build id is used to handle cases where multiple shadow-cljs compilations are running simultaneously.
+Currently the setup only supports adding this hook to one running module at a time.
+
+After you setup dev-time instrumentation and hot-reload your app you should see your kondo config file present on the filesystem.
+
 # Releaes builds
 
 For optimized ClojureScript release builds which produce only the required JavaScript for your production release it is advised

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "isomorphic-ws": "^4.0.1",
-        "shadow-cljs": "^2.17.8",
+        "shadow-cljs": "^2.20.20",
         "ws": "^7.4.6"
       }
     },
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.17.8.tgz",
-      "integrity": "sha512-O39cLA7ukEh+OeH1yZlaWjGFinPOsDD87TetAWPe1QBD9TZQ0Ail+2ovaXeAyZpJ+6Z37joFfival+LNuCgsmQ==",
+      "version": "2.20.20",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
+      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
@@ -1648,9 +1648,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.17.8.tgz",
-      "integrity": "sha512-O39cLA7ukEh+OeH1yZlaWjGFinPOsDD87TetAWPe1QBD9TZQ0Ail+2ovaXeAyZpJ+6Z37joFfival+LNuCgsmQ==",
+      "version": "2.20.20",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
+      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "isomorphic-ws": "^4.0.1",
-    "shadow-cljs": "^2.17.8",
+    "shadow-cljs": "^2.20.20",
     "ws": "^7.4.6"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,12 +7,13 @@
                                                    :depends-on #{:cljs}}
                                            :app   {:entries    [malli.app]
                                                    :depends-on #{:malli}}}}
-            :instrument {:target        :browser
-                         :build-options {:cache-level :off}
-                         :output-dir    "public/js/instrument"
-                         :asset-path    "/js/instrument"
-                         :modules       {:app {:entries [malli.instrument-app]
-                                                :init-fn malli.instrument-app/init}}}
+            :instrument {:target          :browser
+                         :build-options   {:cache-level :off}
+                         :build-hooks     [(malli.dev.shadow-cljs-hooks/kondo-hook :instrument)]
+                         :output-dir      "public/js/instrument"
+                         :asset-path      "/js/instrument"
+                         :modules         {:app {:entries [malli.instrument-app]
+                                                 :init-fn malli.instrument-app/init}}}
             :app-sci    {:target          :browser
                          :closure-defines {malli.registry/type "default"}
                          :devtools        {:preloads [sci.core]}

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -200,9 +200,13 @@
      (for [[k vs] (m/function-schemas :cljs) :when (-collect k) [_ v] vs v (from v)] v))))
 
 #?(:cljs
+   (defn get-kondo-config []
+     (-> (collect-cljs) (linter-config))))
+
+#?(:cljs
    (defn- print!* [config]
      (js/console.log (with-out-str (fipp/pprint config {:width 120})))))
 
 #?(:cljs
    (defn print-cljs! []
-     (-> (collect-cljs) (linter-config) (print!*)) nil))
+     (-> (get-kondo-config) (print!*)) nil))

--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -1,9 +1,13 @@
 (ns malli.dev.cljs
   #?(:cljs (:require-macros [malli.dev.cljs]))
-  #?(:cljs (:require [malli.instrument :as mi]
+  #?(:cljs (:require [clojure.string :as str]
+                     [goog.object :as g]
+                     [malli.instrument :as mi]
                      [malli.core :as m]
+                     [malli.clj-kondo :as clj-kondo]
                      [malli.dev.pretty :as pretty]))
   #?(:clj (:require [cljs.analyzer.api :as ana-api]
+                    [clojure.string :as str]
                     [malli.clj-kondo :as clj-kondo]
                     [malli.core :as m]
                     [malli.instrument])))
@@ -17,6 +21,33 @@
 
 #?(:clj (defmacro collect-all! [] (malli.instrument/collect! {:ns (ana-api/all-ns)})))
 
+#?(:cljs
+   (defn send-kondo-config-to-shadow!
+     "During development sends the clj-kondo config data for all collected functions with malli schemas to the
+     shadow-cljs build hook which writes it to disk.
+     If shadow-cljs is not present on the client this is a no-op."
+     []
+     (when (exists? js/shadow)
+       (let [ns-js-path         (fn [ns] (into-array (map munge (str/split (str ns) #"\."))))
+             shadow-runtime     (g/getValueByKeys goog/global (ns-js-path 'shadow.remote.runtime.shared))
+             shadow-call        (if shadow-runtime (g/get shadow-runtime "call") identity)
+
+             shadow-client      (g/getValueByKeys goog/global (ns-js-path 'shadow.cljs.devtools.client.shared))
+             shadow-runtime-ref (when shadow-client (g/get shadow-client "runtime_ref"))
+
+             shadow-client-env  (g/getValueByKeys goog/global (ns-js-path 'shadow.cljs.devtools.client.env))
+             runtime-state      (some-> (deref shadow-runtime-ref) :state-ref deref)]
+         ;; This is to wait until the shadow runtime is initialized, config will not be written until the second
+         ;; save during hot-reload.
+         (when (< 0 (:call-id-seq runtime-state))
+           (shadow-call
+             (deref shadow-runtime-ref)
+             {:op       ::clj-kondo/write-config
+              :to       (some-> shadow-client-env (g/get "worker_client_id"))
+              :build-id (some-> shadow-client-env (g/get "build_id") keyword)
+              :data     (clj-kondo/get-kondo-config)}
+             {}))))))
+
 #?(:clj
    (defmacro start!
      "Collects defn schemas from all loaded namespaces and starts instrumentation for
@@ -26,7 +57,7 @@
       - Does not unstrument functions - this is handled by hot reloading.
       - Does not emit clj-kondo type annotations. See `malli.clj-kondo/print-cljs!` to print clj-kondo config.
       - Does not re-instrument functions if the function schemas change - use hot reloading to get a similar effect."
-     ([] `(start! {:report (malli.dev.pretty/thrower) :skip-instrumented? true}))
+     ([] `(start! {:report (malli.dev.pretty/thrower) :skip-instrumented? false}))
      ([options]
       ;; register all function schemas and instrument them based on the options
       ;; first clear out all metadata schemas to support dev-time removal of metadata schemas on functions - they should not be instrumented
@@ -37,7 +68,8 @@
                                             (vec (ana-api/all-ns)))})
          (js/console.groupCollapsed "Instrumentation done")
          (malli.instrument/instrument! (assoc ~options :data (m/function-schemas :cljs)))
-         (js/console.groupEnd)))))
+         (js/console.groupEnd)
+         (send-kondo-config-to-shadow!)))))
 
 ;; only used by deprecated malli.instrument.cljs implementation
 #?(:clj (defmacro deregister-function-schemas! []

--- a/src/malli/dev/shadow_cljs_hooks.clj
+++ b/src/malli/dev/shadow_cljs_hooks.clj
@@ -1,0 +1,23 @@
+(ns malli.dev.shadow-cljs-hooks
+  (:require [malli.clj-kondo :as clj-kondo]
+            [shadow.cljs.devtools.api :as sh]
+            [shadow.cljs.devtools.config :as config]
+            [shadow.cljs.devtools.server :as server]
+            [shadow.cljs.devtools.server.worker.impl :as worker]))
+
+(def build-id_ (atom nil))
+
+(defmethod worker/do-relay-msg ::clj-kondo/write-config
+  [worker-state msg]
+  (when (= @build-id_ (:build-id msg))
+    (future
+      (malli.clj-kondo/save! (:data msg))))
+  worker-state)
+
+(defn kondo-hook
+  "This hook is a no-op used to setup a method handler for kondo config messages from the CLJS frontend app."
+  {:shadow.build/stage :flush}
+  [build-state & [build-id]]
+  (when-not build-id (throw (Exception. "Missing build-id in clj-kondo hook")))
+  (reset! build-id_ build-id)
+  build-state)


### PR DESCRIPTION
Figured out a way to piggy-back on the shadow-cljs implementation in order to get the cljs schemas in a browser access to the filesystem so kondo config can be saved!

One question this brings up is when you're running `malli.dev/start!` from both clj and cljs the last one to write 
the file will win. I'm not sure a good solution other than attempting to perform a merge with the existing schemas instead of overwriting them.

https://github.com/metosin/malli/issues/828