### PR TITLE
[DRAFT] Add clj-kondo support for cljs function schemas

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
                         jmh-clojure/task {:mvn/version "0.1.1"}}
                  :main-opts ["-m" "jmh.main"]}
            :shadow {:extra-paths ["app"]
-                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.20.5"}
+                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.20.20"}
                                  binaryage/devtools {:mvn/version "1.0.6"}}}
            :slow {:extra-deps {io.dominic/slow-namespace-clj
                                {:git/url "https://git.sr.ht/~severeoverfl0w/slow-namespace-clj"

--- a/docs/clojurescript-function-instrumentation.md
+++ b/docs/clojurescript-function-instrumentation.md
@@ -80,10 +80,92 @@ the instrumented function is the one with the red rectangle around it in the ima
 
 If you click the filename (`instrument_app.cljs` in this example) the browser devtools will open a file viewer at the problematic call-site.
 
-# Releaes builds
+# Clj-Kondo config
 
-For optimized ClojureScript release builds which produce only the required JavaScript for your production release it is advised
-to use the included `malli.dev.cljs-noop` namespace which will result in adding 9 bytes to your production build instead 
+Running `malli.dev` instrumentation also emits [clj-kondo](https://github.com/metosin/malli#clj-kondo) type configs for all `defn`s,
+enabling basic static type checking/linting for the instrumented functions.
+
+This is currently only supported when using shadow-cljs.
+
+The config is determined at runtime by the browser's JavaScript VM so cannot be performed statically. Your application must be
+executed in orer to deal with dynamic schemas that may show up in function metadata.
+
+To enable this feature, in your `shadow-cljs.edn` file add the following build [hook](https://shadow-cljs.github.io/docs/UsersGuide.html#build-hooks):
+
+```clojure
+:build-hooks [(malli.dev.shadow-cljs-hooks/kondo-hook :main)]
+```
+
+where `:main` is the module id of your application.
+
+The build id is used to handle cases where multiple shadow-cljs compilations are running simultaneously.
+Currently the setup only supports adding this hook to one running module at a time.
+
+After you setup dev-time instrumentation and hot-reload your app you should see your kondo config file present on the filesystem.
+
+# Release builds
+
+You have a few options to ensure that schemas and tooling only used during development don't end up in release builds
+
+1. Put all dev tooling in a preload
+2. Use the same app entry for dev and release builds but alias a noop ns for releases.
+2. Use a separate entry for dev and release builds and use a script to change them in the shadow-cljs config.
+
+## Use a preload file
+
+The technique was described by Thomas Heller [here](https://clojureverse.org/t/problem-using-malli-clojurescript-instrumentation-and-shadow-cljs/8612/2)
+and is adapted here:
+
+"The best way to go about this is via `:preloads` with a custom namespace created for it."
+
+Example:
+
+```clojure
+(ns com.my-org.client.preload
+  {:dev/always true}
+  (:require
+    [my.app] ;; must require all namespace here that potentially get instrumented
+    [my.app.util]
+    [malli.instrument :as mi]))
+
+(mi/instrument!)
+```
+
+Then in your build config include the preload for the build you want using `:devtools {:preloads [com.my-org.client.preload]}`.
+
+Like so:
+```clojure
+,,,
+{:main
+ {:target          :browser
+  :output-dir      "resources/public/js/main"
+  :asset-path      "js/main"
+  :modules         {:main {:init-fn com.my-org.client.entry/init}}
+  :devtools        {:preloads [com.my-org.client.preload]}    ;;      <------------
+  :closure-defines {malli.registry/type "custom"}
+  :release         {:build-options {:ns-aliases
+                                    {malli.dev.cljs                   malli.dev.cljs-noop
+                                     com.my-org.client.malli-registry com.my-org.client.malli-registry-release}}}
+,,,
+```
+
+From Thomas' post:
+
+The `{:dev/always true}` metadata on the namespace ensures that this namespace is always recompiled.
+Although note that this can make your build a lot slower.
+It isn’t strictly necessary if the macro doesn’t emit changing code but since there is no reliable way to know what the macro does (from the shadow-cljs side) it might be best to always run it.
+
+The `my.app` require ensures that the preload is actually compiled after all your app namespaces have been compiled.
+I know "preload" isn’t the best name here but you must do this to ensure that other namespaces aren’t still compiling when the macro runs.
+
+----
+
+Using this setup you will not have development-time tooling and schemas in your release build as `preloads` are not included
+in release builds.
+
+## Use a release no-op namespace
+
+To use the included `malli.dev.cljs-noop` namespace which will result in adding 9 bytes to your production build instead
 of pulling in all the instrumentation code.
 
 With shadow-cljs you can configure this like so using the `ns-aliases` build option:
@@ -101,6 +183,7 @@ With shadow-cljs you can configure this like so using the `ns-aliases` build opt
                                       com.my-org.client.malli-registry com.my-org.client.malli-registry-release}}}
 ,,,
 ```
+
 This example also shows how you can include a separate malli registry with only the schemas you need for your production
 release.
 
@@ -115,7 +198,7 @@ compiler. The function var metadata is only included in a build if you explicitl
 Unless you explicitly ask for it, function var metadata will not be included in your compiled JS, so annotating functions
 with malli schemas in metadata has no costs to your builds.
 
----
+## `ns-alias` release namespaces
 
 Another strategy to get optimal CLJS releases is by having a completely separate entry namespace for release builds.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "isomorphic-ws": "^4.0.1",
-        "shadow-cljs": "^2.17.8",
+        "shadow-cljs": "^2.20.20",
         "ws": "^7.4.6"
       }
     },
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.17.8.tgz",
-      "integrity": "sha512-O39cLA7ukEh+OeH1yZlaWjGFinPOsDD87TetAWPe1QBD9TZQ0Ail+2ovaXeAyZpJ+6Z37joFfival+LNuCgsmQ==",
+      "version": "2.20.20",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
+      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
@@ -1648,9 +1648,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.17.8.tgz",
-      "integrity": "sha512-O39cLA7ukEh+OeH1yZlaWjGFinPOsDD87TetAWPe1QBD9TZQ0Ail+2ovaXeAyZpJ+6Z37joFfival+LNuCgsmQ==",
+      "version": "2.20.20",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
+      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "isomorphic-ws": "^4.0.1",
-    "shadow-cljs": "^2.17.8",
+    "shadow-cljs": "^2.20.20",
     "ws": "^7.4.6"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -7,12 +7,13 @@
                                                    :depends-on #{:cljs}}
                                            :app   {:entries    [malli.app]
                                                    :depends-on #{:malli}}}}
-            :instrument {:target        :browser
-                         :build-options {:cache-level :off}
-                         :output-dir    "public/js/instrument"
-                         :asset-path    "/js/instrument"
-                         :modules       {:app {:entries [malli.instrument-app]
-                                                :init-fn malli.instrument-app/init}}}
+            :instrument {:target          :browser
+                         :build-options   {:cache-level :off}
+                         :build-hooks     [(malli.dev.shadow-cljs-hooks/kondo-hook :instrument)]
+                         :output-dir      "public/js/instrument"
+                         :asset-path      "/js/instrument"
+                         :modules         {:app {:entries [malli.instrument-app]
+                                                 :init-fn malli.instrument-app/init}}}
             :app-sci    {:target          :browser
                          :closure-defines {malli.registry/type "default"}
                          :devtools        {:preloads [sci.core]}

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -200,9 +200,13 @@
      (for [[k vs] (m/function-schemas :cljs) :when (-collect k) [_ v] vs v (from v)] v))))
 
 #?(:cljs
+   (defn get-kondo-config []
+     (-> (collect-cljs) (linter-config))))
+
+#?(:cljs
    (defn- print!* [config]
      (js/console.log (with-out-str (fipp/pprint config {:width 120})))))
 
 #?(:cljs
    (defn print-cljs! []
-     (-> (collect-cljs) (linter-config) (print!*)) nil))
+     (-> (get-kondo-config) (print!*)) nil))

--- a/src/malli/dev/shadow_cljs_hooks.clj
+++ b/src/malli/dev/shadow_cljs_hooks.clj
@@ -1,0 +1,55 @@
+(ns malli.dev.shadow-cljs-hooks
+  (:require [clojure.edn :as edn]
+            [malli.clj-kondo :as clj-kondo]
+            [shadow.cljs.devtools.api :as sh]))
+
+(def build-number_ (atom 0))
+(def running?_ (atom false))
+
+(defn fetch-build-number [build-id]
+  (when-let [num-str (-> (sh/cljs-eval build-id "(malli.dev.cljs/get-build-number)" {}) :results first)]
+    (parse-long num-str)))
+
+(defn fetch-clj-kondo-config [build-id]
+  (-> build-id
+    (sh/cljs-eval "(malli.clj-kondo/get-kondo-config)" {})
+    :results first edn/read-string))
+
+(defn fetch-and-save-kondo-config* [build-id]
+  (when-let [config (fetch-clj-kondo-config build-id)]
+    (clj-kondo/save! config)))
+
+(def max-retries 10)
+
+(defn fetch-and-save-kondo-config [build-id]
+  (if (zero? @build-number_)
+    (do (fetch-and-save-kondo-config* build-id)
+        (swap! build-number_ inc))
+    (loop [client-build-number (fetch-build-number build-id)
+           retries             0]
+      (when client-build-number
+        (cond (> client-build-number @build-number_)
+              (do
+                (fetch-and-save-kondo-config* build-id)
+                (reset! build-number_ client-build-number))
+
+              ;; If the client state is reset this will return to 0
+              (< client-build-number @build-number_)
+              (reset! build-number_ client-build-number)
+
+              ;; if the build numbers are equal, wait for the client to update
+              :else
+              (when (< retries max-retries)
+                (Thread/sleep 500)
+                (recur (fetch-build-number build-id) (inc retries))))))))
+
+(defn kondo-hook
+  "After each ClojureScript compilation will fetch the clj-kondo config from the client application and persist to disk."
+  {:shadow.build/stage :flush}
+  [build-state & [build-id]]
+  (when-not build-id (throw (Exception. "Missing build-id in clj-kondo hook")))
+  (when (and (= (:build-id build-state) build-id) (not @running?_) (compare-and-set! running?_ false true))
+    (future
+      (fetch-and-save-kondo-config build-id)
+      (reset! running?_ false)))
+  build-state)


### PR DESCRIPTION
https://github.com/metosin/malli/issues/828

UPDATE:
In chatting with Thomas Heller I think there is a simpler solution that doesn't need a hook. I will attempt that next.

Using a shadow-cljs hook we can send the clj-kondo config for cljs function schemas to the shadow-cljs clojure runtime to persist to disk.

A counter is used to track when the cljs is not only compiled but evaluated so that the clojure side (the hook) knows that the kondo config will reflect any code changes during hot reload.

There may be a way to determine when the latest code has been evaluated by a client from shadow-cljs's build state but I could not find a place where that information is available, thus the counter technique with a busy loop is used.

If you do not include the build hook there is no effect on the build. If you pass a `build-id` that doesn't actually exist in you `shadow-cljs.edn` config, the hook will effectively be a no-op as all `eval-cljs` calls wil return `nil`.

There is a potential problem if you have instrumentation running for clojure and clojurescript code at the same time in that they will overwrite each others' kondo config file.

I think it would make sense to have a separate output file for each side, one for cljs, one for clj. What do you think?