### PR TITLE
Add clj-kondo support for cljs function schemas

### DIFF
--- a/app/malli/dev_preload.cljs
+++ b/app/malli/dev_preload.cljs
@@ -1,0 +1,7 @@
+(ns malli.dev-preload
+  {:dev/always true}
+  (:require
+    [malli.instrument-app]
+    [malli.dev.cljs :as dev]))
+
+(dev/start!)

--- a/app/malli/instrument_app.cljs
+++ b/app/malli/instrument_app.cljs
@@ -1,18 +1,18 @@
 (ns malli.instrument-app
   (:require
     [malli.instrument :as mi-new]
-    ;[malli.clj-kondo :as mari]
-    ;[malli.helpers2 :as h2]
     malli.helpers
     [malli.core :as m]
-    [malli.dev.cljs :as dev]
     [malli.dev.pretty :as pretty]
     [malli.generator :as mg]
-    ;[malli.dev.cljs :as md]
+    [malli.experimental :as mx]))
 
-    [malli.instrument.cljs :as mi.old]
-    [malli.experimental :as mx]
-    ))
+(mx/defn my-ex-fn :- [:int]
+  [a :- :string] (+ 5 a))
+
+(mx/defn my-ex-fn2 :- [:double]
+  ([a :- :string] (+ 5 a))
+  ([a :- :string, b :- :double] (+ 5 a b)))
 
 (defn init [] (js/console.log "INIT!"))
 (defn x+y
@@ -33,7 +33,6 @@
   (m/-instrument {:schema (m/schema [:=> [:cat :int :int] :int])
                   :report (pretty/reporter)}
     sum))
-
 
 (defn minus
   "a normal clojure function, no dependencies to malli"
@@ -74,6 +73,9 @@
   ([a b & others]
    (apply + a b others)))
 
+(defn a-fun {:malli/schema [:=> [:cat :int] :int]} [a] (+ 5 a))
+(defn a-fun2 {:malli/schema [:=> [:cat :string] :int]} [a] (+ 5 a))
+
 ;(m/=> plus-many
 ;  [:function
 ;   [:=> [:cat :int] :int]
@@ -85,7 +87,6 @@
               [:=> [:cat :int] [:int {:max 6}]]
               [:=> [:cat :int :int] [:int {:max 6}]]]
      :gen mg/generate}))
-
 
 (defn minus2
   "kukka"
@@ -192,9 +193,10 @@
   ;                     ;:skip-instrumented? true
   ;
   ;                 :report (pretty/thrower)})
-  (dev/start!)
+  ;(dev/start!)
   ;(mi.old/instrument!)
-  (js/setTimeout try-it 100))
+  ;(js/setTimeout try-it 100)
+  )
 
 
 (comment

--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
                         jmh-clojure/task {:mvn/version "0.1.1"}}
                  :main-opts ["-m" "jmh.main"]}
            :shadow {:extra-paths ["app"]
-                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.20.5"}
+                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.20.20"}
                                  binaryage/devtools {:mvn/version "1.0.6"}}}
            :slow {:extra-deps {io.dominic/slow-namespace-clj
                                {:git/url "https://git.sr.ht/~severeoverfl0w/slow-namespace-clj"

--- a/docs/clojurescript-function-instrumentation.md
+++ b/docs/clojurescript-function-instrumentation.md
@@ -24,41 +24,48 @@ For an application that uses React.js such as Reagent you will typically declare
 ...}
 ```
 
-In your application's entry namespace you need to tell the compiler to always reload this namespace so that the macro will rerun when
-you change schemas and function definitions in other namespaces while developing.
+All development-time code should ideally live in a [preload](https://shadow-cljs.github.io/docs/UsersGuide.html#_preloads) namespace.
 
-We do this with the `{:dev/always true}` metadata on the namespace:
-
-(this was pointed out by Thomas Heller [here](https://clojureverse.org/t/problem-using-malli-clojurescript-instrumentation-and-shadow-cljs/8612/2).
-  If you're still running into stale code issues during development you can try requiring all namespaces in a preload like he suggests in that comment)
+Add a preload namespace to your codebase to enable the malli instrumentation:
 
 ```clojure
-(ns co.my-org.my-app.entry
+(ns com.myapp.dev-preload
   {:dev/always true}
-  (:require [malli.dev.cljs :as md]))
+  (:require
+    your-app.entry-ns ; <---- make sure you include your entry namespace
+    [malli.dev.cljs :as dev]))
+
+(dev/start!)
 ```
+By including your entry namespace in the `:require` form the compiler will ensure that the preload namespace is compiled
+after your application. This will ensure your schemas are up-to-date when `(malil.dev.cljs/start!)` is evaluated.
 
-and require the `malli.dev.cljs` namespace.
+We also add `{:dev/always true}` metadata to the namespace so that the compiler will never cache this file.
 
-In your init function before rendering your application invoke `malli.dev.cljs/start!`
+Add this preload to your shadow-cljs config:
 
 ```clojure
-(defn ^:export init [] 
-  (md/start!)
-  (my-app/mount!)
+{...
+ :modules {:app {:entries [your-app.entry-ns]
+                 :preloads [com.myapp.dev-preload]
+                 :init-fn your-app.entry-ns/init}}
+ ...}
 ```
 
-When you save source code files during development and new code is hot-reloaded the non-instrumented versions will now 
-overwrite any instrumented versions.
-
-To instrument the newly loaded code with shadow-cljs we can use the [lifecylce hook](https://shadow-cljs.github.io/docs/UsersGuide.html#_lifecycle_hooks)
-`:after-load` by adding metadata to a function and invoking `malli.dev.cljs/start!` again:
-
+If you want to get clj-kondo static checking from your function schemas add the `malli.dev.cljs-kondo-preload` namespace
+to the preloads vector:
 ```clojure
-(defn ^:dev/after-load reload []
-  (md/start!)
-  (my-app/mount!))
+{...
+ :modules {:app {:entries [your-app.entry-ns]
+                 :preloads [com.myapp.dev-preload
+                            malli.dev.cljs-kondo-preload ;; <----
+                            ]
+                 :init-fn your-app.entry-ns/init}}
+ ...}
 ```
+
+Now while you develop clj-kondo config will be written under the `.clj-kondo` directory to enable static type checking 
+on any functions that have schemas.
 
 ## Errors in the browser console
 
@@ -80,89 +87,36 @@ the instrumented function is the one with the red rectangle around it in the ima
 
 If you click the filename (`instrument_app.cljs` in this example) the browser devtools will open a file viewer at the problematic call-site.
 
-# Releaes builds
+# Release builds
 
-For optimized ClojureScript release builds which produce only the required JavaScript for your production release it is advised
-to use the included `malli.dev.cljs-noop` namespace which will result in adding 9 bytes to your production build instead 
-of pulling in all the instrumentation code.
+If you follow the strategy outlined above using a `preload` to include all development-time tooling then you don't
+have to make any changes to prevent that code from ending up in a release build.
 
-With shadow-cljs you can configure this like so using the `ns-aliases` build option:
+One other technique you may want to use to optimize even further is to have a separate malli registry for development
+and one for your release build. The dev build may include schemas that are only used for instrumenting functions or for
+attaching generators to schemas which can increase bundle size significantly.
+
+You can use a configuration like so using the `:ns-aliases` feature of shadow-cljs to switch malli registry namespaces
+without needing to update your codebase:
 
 ```clojure
-,,,
- {:main
-  {:target          :browser
-   :output-dir      "resources/public/js/main"
-   :asset-path      "js/main"
-   :modules         {:main {:init-fn com.my-org.client.entry/init}}
-   :closure-defines {malli.registry/type "custom"}
-   :release         {:build-options {:ns-aliases
-                                     {malli.dev.cljs                   malli.dev.cljs-noop
-                                      com.my-org.client.malli-registry com.my-org.client.malli-registry-release}}}
+{:target :browser
+ :output-dir "resources/public/js/main"
+ :asset-path "js/main"
+ :dev {:modules {:main {:init-fn com.my-org.client.dev-entry/init}}}
+ :release {:modules {:main {:init-fn com.my-org.client.release-entry/init}}
+           :build-options {:ns-aliases
+                           {com.my-org.client.malli-registry com.my-org.client.malli-registry-release}}}
+ :closure-defines {malli.registry/type "custom"}
 ,,,
 ```
-This example also shows how you can include a separate malli registry with only the schemas you need for your production
-release.
-
-This way you can include schemas that are only used for instrumenting functions during development, for example, but for a release include
-only the schemas needed to power functionality of your application.
+This example also demonstrates how if you really need to, you can also have a completely separate entry namespace for a release.
 
 It should be noted also that metadata declared on function vars in ClojureScript is excluded by default by the ClojureScript
 compiler. The function var metadata is only included in a build if you explicitly invoke a static call to it such as:
 ```clojure
 (meta (var com.my-org.some.ns/a-fn))
 ```
+
 Unless you explicitly ask for it, function var metadata will not be included in your compiled JS, so annotating functions
-with malli schemas in metadata has no costs to your builds.
-
----
-
-Another strategy to get optimal CLJS releases is by having a completely separate entry namespace for release builds.
-
-Then you have to either include a separate shadow-cljs config entry or use a Clojure build script like the following to compile
-your build which will let you have one config build entry in `shadow-cljs.edn` for your app:
-
-```clojure
-(ns fe-build
-  (:require
-    [shadow.cljs.devtools.config :as config]
-    [shadow.cljs.build-report :as report]
-    [shadow.cljs.devtools.api :as sh]))
-
-;; this code was figured out by inspecting the source of the shadow.cljs.devtools.api and related namespaces.
-
-;; replace the entry namespace
-(defn get-config [build-id]
-  (get-in
-    (assoc-in
-      (config/load-cljs-edn!)
-      [:builds build-id :modules :main :init-fn] 'com.my-org.client.release-entry/init)
-    ;; ^ note the :main module name may be different for your app
-    [:builds build-id]))
-
-(defn release-build [{:keys [id] :or {id :main}}]
-  (sh/with-runtime
-    (let [build-config (get-config id)]
-      (sh/release* build-config {})))
-  :done)
-
-(defn build-report [{:keys [id] :or {id :main}}]
-  (report/generate (get-config id)
-    {:print-table true
-     :report-file "fe-report.html"})
-  :done)
-```
-You would include this somewhere on your classpath (like under `src/build`) and then invoke it from the command line or via a REPL:
-
-```bash
-clojure -X:fe-build fe-build/release-build :id :main
-
-# and for the build report:
-
-clojure -X:fe-build fe-build/build-report :id :main
-```
-where `:fe-build` alias has:
-
-```clojure
-:fe-build {:extra-paths ["src/build"]}
-```
+with malli schemas in metadata adds no cost on your builds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "devDependencies": {
         "isomorphic-ws": "^4.0.1",
-        "shadow-cljs": "^2.17.8",
+        "shadow-cljs": "^2.20.20",
         "ws": "^7.4.6"
       }
     },
@@ -770,9 +770,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.17.8.tgz",
-      "integrity": "sha512-O39cLA7ukEh+OeH1yZlaWjGFinPOsDD87TetAWPe1QBD9TZQ0Ail+2ovaXeAyZpJ+6Z37joFfival+LNuCgsmQ==",
+      "version": "2.20.20",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
+      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
@@ -1648,9 +1648,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.17.8",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.17.8.tgz",
-      "integrity": "sha512-O39cLA7ukEh+OeH1yZlaWjGFinPOsDD87TetAWPe1QBD9TZQ0Ail+2ovaXeAyZpJ+6Z37joFfival+LNuCgsmQ==",
+      "version": "2.20.20",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
+      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "isomorphic-ws": "^4.0.1",
-    "shadow-cljs": "^2.17.8",
+    "shadow-cljs": "^2.20.20",
     "ws": "^7.4.6"
   }
 }

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -12,7 +12,8 @@
                          :output-dir    "public/js/instrument"
                          :asset-path    "/js/instrument"
                          :modules       {:app {:entries [malli.instrument-app]
-                                                :init-fn malli.instrument-app/init}}}
+                                               :preloads [malli.dev.cljs-kondo-preload malli.dev-preload]
+                                               :init-fn malli.instrument-app/init}}}
             :app-sci    {:target          :browser
                          :closure-defines {malli.registry/type "default"}
                          :devtools        {:preloads [sci.core]}

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -152,13 +152,16 @@
    (-transform ?schema options)))
 
 #?(:clj
-   (defn save! [config]
-     (let [cfg-file (io/file ".clj-kondo" "metosin" "malli-types" "config.edn")]
-       ;; delete the old file if exists (does not throw)
-       (.delete (io/file ".clj-kondo" "configs" "malli" "config.edn"))
-       (io/make-parents cfg-file)
-       (spit cfg-file (with-out-str (fipp/pprint config {:width 120})))
-       config)))
+   (defn save!
+     ([config]
+      (save! config :clj))
+     ([config key]
+      (let [cfg-file (io/file ".clj-kondo" "metosin" (str "malli-types-" (name key)) "config.edn")]
+        ;; delete the old file if exists (does not throw)
+        (.delete (io/file ".clj-kondo" "configs" "malli" "config.edn"))
+        (io/make-parents cfg-file)
+        (spit cfg-file (with-out-str (fipp/pprint config {:width 120})))
+        config))))
 
 (defn from [{:keys [schema ns name]}]
   (let [ns-name (-> ns str symbol)
@@ -200,9 +203,13 @@
      (for [[k vs] (m/function-schemas :cljs) :when (-collect k) [_ v] vs v (from v)] v))))
 
 #?(:cljs
+   (defn get-kondo-config []
+     (-> (collect-cljs) (linter-config))))
+
+#?(:cljs
    (defn- print!* [config]
      (js/console.log (with-out-str (fipp/pprint config {:width 120})))))
 
 #?(:cljs
    (defn print-cljs! []
-     (-> (collect-cljs) (linter-config) (print!*)) nil))
+     (-> (get-kondo-config) (print!*)) nil))

--- a/src/malli/dev/cljs_kondo_preload.cljc
+++ b/src/malli/dev/cljs_kondo_preload.cljc
@@ -1,0 +1,47 @@
+(ns malli.dev.cljs-kondo-preload
+  "Shadow-cljs preload for browser builds, used to persist clj-kondo config collected from function schemas to disk during development."
+  #?(:cljs (:require-macros [malli.dev.cljs-kondo-preload]))
+  (:require [malli.clj-kondo :as clj-kondo]
+            #?@(:cljs
+                [[shadow.cljs.devtools.client.shared :as client.shared]
+                 [shadow.cljs.devtools.client.env :as env]
+                 [shadow.remote.runtime.api :as api]
+                 [shadow.remote.runtime.shared :as runtime]])
+            #?@(:clj
+                [[shadow.cljs.devtools.server.worker.impl :as worker]])))
+
+#?(:cljs
+   (defn send-kondo-config-to-shadow!
+     "During development sends the clj-kondo config data for all collected functions with malli schemas to the shadow-cljs clojure runtime which writes it to disk."
+     {:dev/after-load true}
+     []
+     (runtime/relay-msg @client.shared/runtime-ref
+       {:op       ::clj-kondo/write-config
+        :to       env/worker-client-id
+        :build-id (keyword env/build-id)
+        :data     (clj-kondo/get-kondo-config)})))
+
+;; The following sends the config on first load of the app, the above function handles hot-reloads.
+
+#?(:cljs
+   (client.shared/add-plugin! ::client #{}
+     (fn [{:keys [runtime] :as env}]
+       (api/add-extension runtime ::client
+         {:on-welcome
+          (fn [] (send-kondo-config-to-shadow!))
+
+          :on-disconnect
+          (fn [e])
+
+          :on-reconnect
+          (fn [e] (send-kondo-config-to-shadow!))})
+       env)
+
+     (fn [{:keys [runtime]}]
+       (api/del-extension runtime ::client))))
+
+#?(:clj
+   (defmethod worker/do-relay-msg ::clj-kondo/write-config
+     [worker-state msg]
+     (clj-kondo/save! (:data msg) :cljs)
+     worker-state))


### PR DESCRIPTION
Fixes https://github.com/metosin/malli/issues/828

After lots of help from Thomas Heller [here](https://app.slack.com/client/T03RZGPFR/C6N245JGG/thread/C6N245JGG-1674780762.779839) I was able to put together a much simpler dev experience for cljs.

This PR adds kondo config and updates the docs with Thomas' recommended setup using a preload and namespace ordering by the compiler to ensure your function schemas are up to date when `malli.dev.cljs/start!` is evaluated at compile-time.

I updated the kondo `save!` function to emit to a different location for clj and cljs schemas so you can seamlessly use both during development. Let me know if you have any concerns or feedback about that . 

