### PR TITLE
Allow instrumenting external functions

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2469,22 +2469,24 @@
    (swap! -function-schemas* assoc-in [key ns name] (merge data {:schema (f ?schema), :ns ns, :name name}))))
 
 #?(:clj
-   (defmacro => [name value]
+   (defmacro => [given-sym value]
      (let [cljs-resolve (when (:ns &env) (ns-resolve 'cljs.analyzer.api 'resolve))
            cljs-resolve-symbols (fn [env d]
                                   (walk/postwalk (fn [x] (cond->> x (symbol? x) (or (:name (cljs-resolve env x)))))
                                                  d))
-           name' `'~(symbol (str name))
-           ns' `'~(symbol (str *ns*))
-           sym `'~(symbol (str *ns*) (str name))
+           name-str (name given-sym)
+           ns-str (str (or (not-empty (namespace given-sym)) *ns*))
+           name' `'~(symbol name-str)
+           ns' `'~(symbol ns-str)
+           sym `'~(symbol ns-str name-str)
            value' (cond->> value (:ns &env) (cljs-resolve-symbols &env))]
        ;; in cljs we need to register the schema in clojure (the cljs compiler)
        ;; so it is visible in the (function-schemas :cljs) map at macroexpansion time.
        (if (:ns &env)
          (do
-           (-register-function-schema! (symbol (str *ns*)) name value' (meta name) :cljs identity)
-           `(do (-register-function-schema! ~ns' ~name' ~value' ~(meta name) :cljs identity) ~sym))
-         `(do (-register-function-schema! ~ns' ~name' ~value' ~(meta name)) ~sym)))))
+           (-register-function-schema! (symbol ns-str) (symbol name-str) value' (meta given-sym) :cljs identity)
+           `(do (-register-function-schema! ~ns' ~name' ~value' ~(meta given-sym) :cljs identity) ~sym))
+         `(do (-register-function-schema! ~ns' ~name' ~value' ~(meta given-sym)) ~sym)))))
 
 (defn -instrument
   "Takes an instrumentation properties map and a function and returns a wrapped function,

--- a/test/malli/instrument_test.cljs
+++ b/test/malli/instrument_test.cljs
@@ -197,7 +197,7 @@
   (let [results (mi/check)]
     (is (map? results))))
 
-(deftest instrument-external-test
+(deftest ^:simple instrument-external-test
 
   (testing "Without instrumentation"
     (is (thrown?
@@ -206,12 +206,12 @@
           (select-keys {:a 1} :a))))
 
   (testing "With instrumentation"
-    (m/=> clojure.core/select-keys [:=> [:cat map? sequential?] map?])
-    (with-out-str (mi/instrument! {:filters [(mi/-filter-ns 'clojure.core)]}))
+    (m/=> cljs.core/select-keys [:=> [:cat map? sequential?] map?])
+    (with-out-str (mi/instrument! {:filters [(mi/-filter-ns 'cljs.core)]}))
     (is (thrown-with-msg?
           js/Error
           #":malli.core/invalid-input"
           #_:clj-kondo/ignore
           (select-keys {:a 1} :a)))
     (is (= {:a 1} (select-keys {:a 1} [:a])))
-    (with-out-str (mi/unstrument! {:filters [(mi/-filter-ns 'clojure.core)]}))))
+    (with-out-str (mi/unstrument! {:filters [(mi/-filter-ns 'cljs.core)]}))))

--- a/test/malli/instrument_test.cljs
+++ b/test/malli/instrument_test.cljs
@@ -196,3 +196,22 @@
 (deftest ^:simple check-test
   (let [results (mi/check)]
     (is (map? results))))
+
+(deftest instrument-external-test
+
+  (testing "Without instrumentation"
+    (is (thrown?
+          js/Error
+          #_:clj-kondo/ignore
+          (select-keys {:a 1} :a))))
+
+  (testing "With instrumentation"
+    (m/=> clojure.core/select-keys [:=> [:cat map? sequential?] map?])
+    (with-out-str (mi/instrument! {:filters [(mi/-filter-ns 'clojure.core)]}))
+    (is (thrown-with-msg?
+          js/Error
+          #":malli.core/invalid-input"
+          #_:clj-kondo/ignore
+          (select-keys {:a 1} :a)))
+    (is (= {:a 1} (select-keys {:a 1} [:a])))
+    (with-out-str (mi/unstrument! {:filters [(mi/-filter-ns 'clojure.core)]}))))


### PR DESCRIPTION
~Here's a currently broken attempt at fixing #840. I don't know enough about cljs to know how to solve it, but for clj it works well enough.~

I should note that in clj, it doesn't work for any function that is "inlined". So, if you say `(m/=> clojure.core/inc [:=> [:cat :int] :int])`, calling `(inc "1")` won't be instrumented as it's compiled to a raw `Numbers.inc("1")` call. However, writing `(#'inc "1")` will be instrumented as it will be compiled into `const__0.invoke("i")`.

I think that if this is noted in the docs it's an acceptable trade-off.

Closes #840