### PR TITLE
Fix :any output for clj-kondo

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -98,7 +98,7 @@
 (defmethod accept :maybe [_ _ [child] _]
   (cond
     (= :keys (:op child)) (assoc child :nilable true)
-    (keyword? child) (keyword "nilable" (name child))
+    (and (keyword? child) (not= :any child)) (keyword "nilable" (name child))
     :else child))
 (defmethod accept :tuple [_ _ children _] children)
 (defmethod accept :multi [_ _ _ _] :any) ;;??

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -15,6 +15,9 @@
     [:tags {:optional true} [:set qualified-keyword?]]
     [::y {:optional true} boolean?]
     [:select-keys [:maybe [:select-keys [:map [:x int?] [:y int?]] [:x]]]]
+    [:xyz :any]
+    [:xyz2 [:maybe :any]]
+    [:xyz3 [:maybe :int]]
     [:nested [:merge
               [:map [:id ::id]]
               [:map [:price ::price]]]]
@@ -45,6 +48,9 @@
                 :name :string,
                 :description :nilable/string,
                 :select-keys {:op :keys, :req {:x :int} :nilable true},
+                :xyz :any
+                :xyz2 :any
+                :xyz3 :nilable/int
                 :nested {:op :keys, :req {:id :string, :price :double}},
                 :string-type-enum :nilable/string
                 :keyword-type-enum :keyword


### PR DESCRIPTION
Addresses https://github.com/metosin/malli/issues/821

Prevents adding `nilable` for `[:maybe :any]` schemas in clj-kondo config.