### PR TITLE
Fix support ref schemas as vector forms in a registry

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -267,7 +267,7 @@
 (defn- -lookup! [?schema f rec options]
   (or (and f (f ?schema) ?schema)
       (if-let [?schema (-lookup ?schema options)]
-        (cond-> ?schema rec (recur f rec options))
+        (if rec (recur (cond-> ?schema (vector? ?schema) first) f rec options) ?schema)
         (-fail! ::invalid-schema {:schema ?schema}))))
 
 (defn -properties-and-options [properties options f]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1949,6 +1949,12 @@
          #?(:clj Exception, :cljs js/Error) #":malli.core/invalid-ref"
          (m/schema [:map {:registry {:kikka :int}} :int])))))
 
+(deftest properties-on-qualified-ref-map-schema
+  (let [opts {:registry {:map (m/-map-schema), :int (m/-int-schema), ::test :map, ::test-2 [:map [:x :int]]}}]
+    (testing "A qualified ref schema of a composite schema with properties is resolved correctly."
+      (is (m/schema [::test {:a-prop 5}] opts))
+      (is (m/schema [::test-2 {:a-prop 5}] opts)))))
+
 (deftest simple-schemas
   (testing "simple schemas"
     (doseq [[type {:keys [schema validate explain decode encode map-syntax ast form]}]


### PR DESCRIPTION
Addresses https://github.com/metosin/malli/issues/847

Unwrap schemas in vector form for subsequent schema lookups.