### PR TITLE
Fail when map schema is missing a type for a key

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -440,7 +440,9 @@
             n (alength ea)
             e0 (aget ea 0)]
         (if (== n 1)
-          (if (and (-reference? e0) naked-keys) (-parse-ref-vector1 e e0) i)
+          (if (and (-reference? e0) naked-keys)
+            (-parse-ref-vector1 e e0)
+            (-fail! ::invalid-children {:children -children}))
           (let [e1 (aget ea 1)]
             (if (== n 2)
               (if (and (-reference? e0) (map? e1))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -72,6 +72,26 @@
               [::y {:optional true} ::y]
               [:y {:optional true, :title "boolean"} 'boolean?]]
              (map #(update % 2 m/form) (m/-entry-children entry-parser))))))
+  (testing "invalid entries fail"
+    (is (thrown? #?(:clj Exception, :cljs js/Error)
+                 (m/-create-entry-parser
+                  [[:x]
+                   [:y boolean?]] {:naked-keys true} nil)))
+    (is (thrown? #?(:clj Exception, :cljs js/Error)
+                 (m/-create-entry-parser
+                  [[:x boolean?]
+                   [:y]] {:naked-keys true} nil)))
+    (is (thrown? #?(:clj Exception, :cljs js/Error)
+                 (m/-create-entry-parser
+                  [[:x boolean?]
+                   [:y]
+                   [:z boolean?]] {:naked-keys true} nil)))
+    (is (thrown? #?(:clj Exception, :cljs js/Error)
+                 (m/-create-entry-parser
+                  [[:x boolean?]
+                   [:y [:map
+                        [:x]
+                        [:y :int]]]] {:naked-keys true} nil))))
   (testing "duplicate keys"
     (is (thrown? #?(:clj Exception, :cljs js/Error)
                  (m/-create-entry-parser


### PR DESCRIPTION
Fixes issue #860

Invalid entries should not be accepted.

For example the following should fail.

```clojure
(malli.core/schema [:map [:foo]])
;; => :map
```

The issue was that `malli.core/-eager-entry-parser`'s loop iterator was not incremented properly when given entry such as `[:foo]`. This was caused by `malli.core/-parse-entry` returning the same iterator `i` value that it was given.

Fail instead of "skipping" the entry.