### PR TITLE
Fix inconsistencies on UUID transform helper

### DIFF
--- a/bin/repl
+++ b/bin/repl
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -ex
+clojure -M:shadow:rebel:test -m rebel-readline.main

--- a/deps.edn
+++ b/deps.edn
@@ -37,6 +37,12 @@
                  :deps {jmh-clojure/jmh-clojure {:mvn/version "0.4.1"}
                         jmh-clojure/task {:mvn/version "0.1.1"}}
                  :main-opts ["-m" "jmh.main"]}
+
+           :rebel
+           {:extra-paths ["dev"]
+            :extra-deps {com.bhauman/rebel-readline {:mvn/version "RELEASE"}
+                         org.clojure/tools.namespace {:mvn/version "RELEASE"}}}
+
            :shadow {:extra-paths ["app"]
                     :extra-deps {thheller/shadow-cljs {:mvn/version "2.21.0"}
                                  binaryage/devtools {:mvn/version "1.0.6"}}}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,37 @@
+(ns user
+  (:require
+   [clojure.pprint :refer [pprint]]
+   [clojure.test :as test]
+   [clojure.tools.namespace.repl :as r]
+   [clojure.walk :refer [macroexpand-all]]))
+
+(r/set-refresh-dirs "src/malli" "dev" "test/malli")
+
+(defn- run-test
+  ([] (run-test #"^malli.*test$"))
+  ([o]
+   (r/refresh)
+   (cond
+     (instance? java.util.regex.Pattern o)
+     (test/run-all-tests o)
+
+     (symbol? o)
+     (if-let [sns (namespace o)]
+       (do (require (symbol sns))
+           (test/test-vars [(resolve o)]))
+       (test/test-ns o)))))
+
+(comment
+  ;; Refresh changed namespaces
+  (r/refresh)
+
+  ;; Run all tests
+  (run-test)
+
+  ;; Run all transform tests
+  (run-test 'malli.transform-test)
+
+  ;; Run a specific test case of transform tests
+  (run-test 'malli.transform-test/string->uuid)
+
+  )

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -89,15 +89,15 @@
       :else x)
     x))
 
+(def ^:private uuid-re
+  #"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
 (defn -string->uuid [x]
   (if (string? x)
-    (try
-      #?(:clj  (UUID/fromString x)
-         ;; http://stackoverflow.com/questions/7905929/how-to-test-valid-uuid-guid
-         :cljs (if (re-find #"^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" x)
-                 (uuid x)
-                 x))
-      (catch #?(:clj Exception, :cljs js/Error) _ x))
+    (if-let [x (re-matches uuid-re x)]
+      #?(:clj (UUID/fromString x)
+         :cljs (uuid x))
+      x)
     x))
 
 #?(:clj

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -52,9 +52,15 @@
   (is (= "abba" (mt/-string->boolean "abba"))))
 
 (deftest string->uuid
-  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/-string->uuid "5f60751d-9bf7-4344-97ee-48643c9949ce")))
-  (is (= #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/-string->uuid #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce")))
-  (is (= "abba" (mt/-string->uuid "abba"))))
+  (is (= #uuid "5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/-string->uuid "5f60751d-9bf7-4344-97ee-48643c9949ce")))
+  (is (= #uuid "5f60751d-9bf7-4344-97ee-48643c9949ce" (mt/-string->uuid #uuid"5f60751d-9bf7-4344-97ee-48643c9949ce")))
+  (is (= "abba" (mt/-string->uuid "abba")))
+
+  ;; Regression tests: we should ensure that invalid or incomplete
+  ;; uuids are handled unformly in CLJ and CLJS
+  (is (= "5f60751d-9bf7-4344-97ee-48643c"             (mt/-string->uuid "5f60751d-9bf7-4344-97ee-48643c")))
+  (is (= "1-1-1-1-1"                                  (mt/-string->uuid "1-1-1-1-1"))))
+
 
 (deftest string->date
   (is (= #inst "2018-04-27T18:25:37Z" (mt/-string->date "2018-04-27T18:25:37Z")))


### PR DESCRIPTION
This commit fixes the https://github.com/metosin/malli/issues/867 issue. It normalizes all to an uuid regex check and then a simple platform dependent UUID object creation.

Additional:

I used to use a rebel repl + tools.namespaces + user ns for experimenting and running tests and tried to add this workflow locally (don't pretend this merged on malli. But I found that I'm unable to start repl because I constantly get exceptions on refreshing the namespaces.

Example:

```bash
~/tmp/malli niwinz-uuid-schema ⇡1 !1 ?1 ❯ ./bin/repl                                                                                                                                                                                              3s 11:09:37
+ clojure -M:shadow:rebel:test -m rebel-readline.main
[Rebel readline] Type :repl/help for online help info
user=> (r/refresh)
:reloading (malli.sci malli.registry malli.impl.util malli.impl.regex malli.core malli.generator malli.instrument malli.destructure malli.experimental malli.clj-kondo malli.util malli.error malli.dev.virhe malli.dev.pretty malli.dev malli.demo malli.provider malli.experimental.time malli.experimental.time.generator malli.experimental.time-test malli.experimental.time.generator-test malli.dot malli.plantuml malli.plantuml-test malli.dev.cljs-kondo-preload malli.transform malli.provider-test malli.json-schema malli.dot-test malli.edn malli.core-test malli.swagger malli.swagger-test malli.clj-kondo-test malli.dev-test malli.registry-test malli.app2 malli.experimental.always-test malli.dev.cljs malli.experimental.time.json-schema clojure.alpha.spec.protocols clojure.alpha.spec.gen clojure.alpha.spec clojure.alpha.spec.impl malli.experimental.describe malli.experimental-test malli.experimental.time.json-schema-test malli.error-test malli.json-schema-test malli.generator-test malli.experimental.describe-test malli.experimental.time.transform malli.instrument-test malli.util-test malli.destructure-test malli.transform-test bb-test-runner malli.experimental.lite malli.experimental.lite-test malli.dev.pretty-test malli.app malli.generator-ast malli.generator-ast-test malli.dev.virhe-test malli.experimental.time.transform-test clojure.alpha.spec.test malli.instrument.cljs user malli.generator-debug demo malli.dev.cljs-noop)
:error-while-loading malli.experimental.always-test
#error {
 :cause ":malli.core/invalid-schema"
 :data {:type :malli.core/invalid-schema, :message :malli.core/invalid-schema, :data {:schema :=>}}
 :via
 [{:type clojure.lang.Compiler$CompilerException
   :message "Syntax error macroexpanding at (malli/experimental/always_test.cljc:7:1)."
   :data #:clojure.error{:phase :execution, :line 7, :column 1, :source "malli/experimental/always_test.cljc"}
   :at [clojure.lang.Compiler load "Compiler.java" 7665]}
  {:type clojure.lang.ExceptionInfo
   :message ":malli.core/invalid-schema"
   :data {:type :malli.core/invalid-schema, :message :malli.core/invalid-schema, :data {:schema :=>}}
   :at [malli.core$_exception invokeStatic "core.cljc" 138]}]
 :trace
 [[malli.core$_exception invokeStatic "core.cljc" 138]
  [malli.core$_exception invoke "core.cljc" 136]
  [malli.core$_fail_BANG_ invokeStatic "core.cljc" 142]
  [malli.core$_fail_BANG_ invoke "core.cljc" 140]
  [malli.core$_lookup_BANG_ invokeStatic "core.cljc" 271]
  [malli.core$_lookup_BANG_ invoke "core.cljc" 267]
  [malli.core$schema invokeStatic "core.cljc" 2019]
  [malli.core$schema invoke "core.cljc" 2005]
  [malli.core$_instrument invokeStatic "core.cljc" 2522]
  [malli.core$_instrument invoke "core.cljc" 2506]
  [malli.core$_instrument invokeStatic "core.cljc" 2520]
  [malli.core$_instrument invoke "core.cljc" 2506]
  [malli.experimental.always_test$eval38365 invokeStatic "always_test.cljc" 7]
  [malli.experimental.always_test$eval38365 invoke "always_test.cljc" 7]
  [clojure.lang.Compiler eval "Compiler.java" 7194]
  [clojure.lang.Compiler load "Compiler.java" 7653]
  [clojure.lang.RT loadResourceScript "RT.java" 381]
  [clojure.lang.RT loadResourceScript "RT.java" 372]
  [clojure.lang.RT load "RT.java" 459]
  [clojure.lang.RT load "RT.java" 424]
  [clojure.core$load$fn__6908 invoke "core.clj" 6161]
[...]
```

I'm pretty sure that I missed something but I don't understand exactly the cause of the exception. I added all the necessary code to an additional commit that I will delete before merge, but can you please help me understand what is happening?

I don't add nothing special, just tools.namespace and call (clojure.tools.namespace.repl/refresh), the same happens if I start plain clojure repl with `clj -M:shadow:rebel:test -r`
