### PR TITLE
Add support for default/fallback branch for :map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Malli is in well matured [alpha](README.md#alpha).
 
 ## UNRELEASED
 
+* Allow additional entries in `:map` schemas via `::m/default` key [#871](https://github.com/metosin/malli/pull/871), [docs](README.md#map-with-default-schemas)
+* new `m/default-schmea` and `m/explicit-keys` helpers
+* `mt/strip-extra-keys-transformer` works with `:map-of` schemas
 * Simplify content-dependent schema creation with `m/-simple-schema` and `m/-collection-schema` via new 3-arity `:compile` function of type `children properties options -> props`. Old 2-arity top-level callback function is `m/deprecated!` and support for it will be removed in future versions. [#866](https://github.com/metosin/malli/pull/866)
 
 ## 0.10.2 (2023-03-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ Malli is in well matured [alpha](README.md#alpha).
 ## UNRELEASED
 
 * Allow additional entries in `:map` schemas via `::m/default` key [#871](https://github.com/metosin/malli/pull/871), [docs](README.md#map-with-default-schemas)
-* new `m/default-schmea` and `m/explicit-keys` helpers
+* `m/default-schema` to pull the `::m/default` schema from entry schemas
+* `m/explicit-keys` to get a vector of explicit keys from entry schemas (no `::m/default`
 * `mt/strip-extra-keys-transformer` works with `:map-of` schemas
 * Simplify content-dependent schema creation with `m/-simple-schema` and `m/-collection-schema` via new 3-arity `:compile` function of type `children properties options -> props`. Old 2-arity top-level callback function is `m/deprecated!` and support for it will be removed in future versions. [#866](https://github.com/metosin/malli/pull/866)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ Malli is in well matured [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* Allow additional entries in `:map` schemas via `::m/default` key [#871](https://github.com/metosin/malli/pull/871), [docs](README.md#map-with-default-schemas)
+* Add support for default/fallback branch for `:map`
+  [#871](https://github.com/metosin/malli/pull/871), [docs](README.md#map-with-default-schemas)
 * `m/default-schema` to pull the `::m/default` schema from entry schemas
 * `m/explicit-keys` to get a vector of explicit keys from entry schemas (no `::m/default`
 * `mt/strip-extra-keys-transformer` works with `:map-of` schemas

--- a/README.md
+++ b/README.md
@@ -212,14 +212,8 @@ Validating values against a schema:
 (m/validate [:= 1] 1)
 ; => true
 
-(m/validate [:= 1] 2)
-; => false
-
 (m/validate [:enum 1 2] 1)
 ; => true
-
-(m/validate [:enum 1 2] 0)
-; => false
 
 (m/validate [:and :int [:> 6]] 7)
 ; => true
@@ -325,6 +319,31 @@ pairs have the same type. For this use case, we can use the `:map-of` schema.
   {"oslo" {:lat 60 :long 11}
    "helsinki" {:lat 60 :long 24}})
 ;; => true
+```
+## Map with default schemas
+
+Map schemas can define a special `:malli.core/default` key to handle extra keys:
+
+```clojure
+(m/validate
+ [:map
+  [:x :int]
+  [:y :int]
+  [::m/default [:map-of :int :int]]]
+ {:x 1, :y 2, 1 1, 2 2})
+; => true
+```
+default branching can be arbitraty nested:
+
+```clojure
+(m/validate
+ [:map
+  [:x :int]
+  [::m/default [:map
+                [:y :int]
+                [::m/default [:map-of :int :int]]]]]
+ {:x 1, :y 2, 1 1, 2 2})
+; => true
 ```
 
 ## Sequence schemas

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2275,6 +2275,7 @@
      (when (-entry-schema? schema) (-entries schema)))))
 
 (defn explicit-keys
+  "Returns a vector of explicit (not ::m/default) keys from EntrySchema"
   ([?schema] (explicit-keys ?schema nil))
   ([?schema options]
    (let [schema (schema ?schema options)]
@@ -2284,6 +2285,7 @@
         [] (-entries schema))))))
 
 (defn default-schema
+  "Returns the default (::m/default) schema from EntrySchema"
   ([?schema] (default-schema ?schema nil))
   ([?schema options]
    (let [schema (schema ?schema options)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2274,6 +2274,15 @@
    (when-let [schema (schema ?schema options)]
      (when (-entry-schema? schema) (-entries schema)))))
 
+(defn explicit-keys
+  ([?schema] (explicit-keys ?schema nil))
+  ([?schema options]
+   (let [schema (schema ?schema options)]
+     (when (-entry-schema? schema)
+       (reduce
+        (fn [acc [k :as e]] (cond-> acc (not (-default-entry e)) (conj k)))
+        [] (-entries schema))))))
+
 (defn deref
   "Derefs top-level `RefSchema`s or returns original Schema."
   ([?schema]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2283,6 +2283,13 @@
         (fn [acc [k :as e]] (cond-> acc (not (-default-entry e)) (conj k)))
         [] (-entries schema))))))
 
+(defn default-schema
+  ([?schema] (default-schema ?schema nil))
+  ([?schema options]
+   (let [schema (schema ?schema options)]
+     (when (-entry-schema? schema)
+       (-default-entry-schema (-children schema))))))
+
 (defn deref
   "Derefs top-level `RefSchema`s or returns original Schema."
   ([?schema]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -996,14 +996,10 @@
                                         default-parser
                                         (cons (fn [m]
                                                 (let [m' (default-parser
-                                                          (if (= f -parser)
-                                                            (reduce (fn [acc k] (dissoc acc k)) m (keys keyset))
-                                                            (::default m)))]
+                                                          (reduce (fn [acc k] (dissoc acc k)) m (keys keyset)))]
                                                   (if (miu/-invalid? m')
                                                     (reduced m')
-                                                    (if (= f -parser)
-                                                      (assoc (select-keys m (keys keyset)) ::default m')
-                                                      (dissoc (merge (select-keys m (keys keyset)) m') ::default))))))
+                                                    (merge (select-keys m (keys keyset)) m')))))
                                         closed
                                         (cons (fn [m]
                                                 (reduce

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1037,7 +1037,7 @@
                                         (default-explainer
                                          (reduce (fn [acc k] (dissoc acc k)) x (keys keyset))
                                          in acc)))
-                                (and closed not default-explainer)
+                                (and closed (not default-explainer))
                                 (conj (fn [x in acc]
                                         (reduce-kv
                                          (fn [acc k v]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -996,10 +996,14 @@
                                         default-parser
                                         (cons (fn [m]
                                                 (let [m' (default-parser
-                                                          (reduce (fn [acc k] (dissoc acc k)) m (keys keyset)))]
+                                                          (if (= f -parser)
+                                                            (reduce (fn [acc k] (dissoc acc k)) m (keys keyset))
+                                                            (::default m)))]
                                                   (if (miu/-invalid? m')
                                                     (reduced m')
-                                                    (merge (select-keys m (keys keyset)) m')))))
+                                                    (if (= f -parser)
+                                                      (assoc (select-keys m (keys keyset)) ::default m')
+                                                      (dissoc (merge (select-keys m (keys keyset)) m') ::default))))))
                                         closed
                                         (cons (fn [m]
                                                 (reduce

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -154,8 +154,10 @@
     (gen-one-of gs)
     (-never-gen options)))
 
+;; TODO: handle ::m/default
 (defn -map-gen [schema options]
-  (let [entries (m/entries schema)
+  (let [eks (set (m/explicit-keys schema))
+        entries (filter (m/-comp eks key) (m/entries schema))
         value-gen (fn [k s] (let [g (generator s options)]
                               (cond->> g
                                 (-not-unreachable g)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -154,7 +154,6 @@
     (gen-one-of gs)
     (-never-gen options)))
 
-;; TODO: handle ::m/default
 (defn -map-gen [schema options]
   (let [entries (m/entries schema)
         value-gen (fn [k s] (let [g (generator s options)]
@@ -170,7 +169,7 @@
                                         (gen-one-of (cond-> [(gen/return nil)] g (conj g)))))))
         undefault (fn [kvs] (reduce (fn [acc [k v]]
                                       (cond (and (= k ::m/default) (map? v)) (into acc (map identity v))
-                                            (and (nil? k) (nil? v)) acc
+                                            (nil? k) acc
                                             :else (conj acc [k v]))) [] kvs))]
     (if (not-any? -unreachable-gen? gens-req)
       (gen/fmap (fn [[req opt]] (into {} (undefault (concat req opt))))

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -89,12 +89,12 @@
         {additionalProperties' :additionalProperties properties' :properties required' :required} default
         children (filter (m/-comp ks first) children)
         required (->> children (filter (m/-comp not :optional second)) (mapv first))
-        cloased (:closed (m/properties schema))
+        closed (:closed (m/properties schema))
         object {:type "object"
                 :properties (apply array-map (mapcat (fn [[k _ s]] [k s]) children))}]
     (cond-> (merge default object)
       (seq required) (assoc :required required)
-      cloased (assoc :additionalProperties false)
+      closed (assoc :additionalProperties false)
       default (cond->
                 additionalProperties' (assoc :additionalProperties additionalProperties')
                 properties' (update :properties merge properties')

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -86,17 +86,19 @@
 (defmethod accept :map [_ schema children _]
   (let [ks (set (m/explicit-keys schema))
         default (some->> children (remove (m/-comp ks first)) first last)
+        {additionalProperties' :additionalProperties properties' :properties required' :required} default
         children (filter (m/-comp ks first) children)
         required (->> children (filter (m/-comp not :optional second)) (mapv first))
         cloased (:closed (m/properties schema))
         object {:type "object"
                 :properties (apply array-map (mapcat (fn [[k _ s]] [k s]) children))}]
-    ;; should do a deep-merge instead? e.g. [:map [:x :int] [::m/default [:map [:y :int]]]]
     (cond-> (merge default object)
       (seq required) (assoc :required required)
       cloased (assoc :additionalProperties false)
-      default (-> (merge (select-keys default [:additionalProperties]))
-                  (->> (merge default))))))
+      default (cond->
+                additionalProperties' (assoc :additionalProperties additionalProperties')
+                properties' (update :properties merge properties')
+                required' (update :required (comp vec distinct into) required')))))
 
 (defmethod accept :multi [_ _ children _] {:oneOf (mapv last children)})
 

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -82,14 +82,21 @@
 (defmethod accept :orn [_ _ children _] {:anyOf (map last children)})
 
 (defmethod accept ::m/val [_ _ children _] (first children))
+
 (defmethod accept :map [_ schema children _]
-  (let [required (->> children (filter (m/-comp not :optional second)) (mapv first))
-        additional-properties (:closed (m/properties schema))
+  (let [ks (set (m/explicit-keys schema))
+        default (some->> children (remove (m/-comp ks first)) first last)
+        children (filter (m/-comp ks first) children)
+        required (->> children (filter (m/-comp not :optional second)) (mapv first))
+        cloased (:closed (m/properties schema))
         object {:type "object"
                 :properties (apply array-map (mapcat (fn [[k _ s]] [k s]) children))}]
-    (cond-> object
+    ;; should do a deep-merge instead? e.g. [:map [:x :int] [::m/default [:map [:y :int]]]]
+    (cond-> (merge default object)
       (seq required) (assoc :required required)
-      additional-properties (assoc :additionalProperties false))))
+      cloased (assoc :additionalProperties false)
+      default (-> (merge (select-keys default [:additionalProperties]))
+                  (->> (merge default))))))
 
 (defmethod accept :multi [_ _ children _] {:oneOf (mapv last children)})
 

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -92,7 +92,7 @@
 (defn -string->uuid [x]
   (if (string? x)
     (if-let [x (re-matches uuid-re x)]
-      #?(:clj (UUID/fromString x)
+      #?(:clj  (UUID/fromString x)
          :cljs (uuid x))
       x)
     x))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -349,7 +349,7 @@
                    (assoc :map-of {:compile (fn [schema _]
                                               (let [key-schema (some-> schema (m/children) (first))]
                                                 (or (some-> key-schema (m/type) map-of-key-decoders
-                                                            (-interceptor schema {}) m/-intercepting
+                                                            (-interceptor schema {}) (m/-intercepting)
                                                             (m/-comp m/-keyword->string)
                                                             (-transform-if-valid key-schema)
                                                             (-transform-map-keys))

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -364,21 +364,27 @@
     :encoders (-string-encoders)}))
 
 (defn strip-extra-keys-transformer
-  ([]
-   (strip-extra-keys-transformer nil))
+  ([] (strip-extra-keys-transformer nil))
   ([{:keys [accept] :or {accept (m/-comp #(or (nil? %) (true? %)) :closed m/properties)}}]
-   (let [transform {:compile (fn [schema _]
-                               (when (accept schema)
-                                 (when-let [ks (some->> schema m/entries (map first) seq set)]
-                                   (fn [x]
-                                     ;; accept checks if the schema is compatible with strip-extra-keys,
-                                     ;; but the value might not be compatible with reduce-kv, i.e. a string.
-                                     (if (map? x)
-                                       (reduce-kv (fn [acc k _] (if-not (ks k) (dissoc acc k) acc)) x x)
-                                       x)))))}]
+   (let [strip-map {:compile (fn [schema _]
+                               (let [default-schema (m/default-schema schema)
+                                     ks (some->> schema (m/explicit-keys) (set))]
+                                 (cond-> nil
+                                   (accept schema)
+                                   (assoc :enter (fn [x]
+                                                   (if (and (map? x) (not default-schema))
+                                                     (reduce-kv (fn [acc k _] (if-not (ks k) (dissoc acc k) acc)) x x)
+                                                     x))))))}
+         strip-map-of {:compile (fn [schema options]
+                                  (let [entry-schema (m/into-schema :tuple nil (m/children schema) options)
+                                        valid? (m/validator entry-schema options)]
+                                    {:leave (fn [x] (reduce (fn [acc entry]
+                                                              (if (valid? entry)
+                                                                (apply assoc acc entry)
+                                                                acc)) (empty x) x))}))}]
      (transformer
-      {:decoders {:map transform}
-       :encoders {:map transform}}))))
+      {:decoders {:map strip-map, :map-of strip-map-of}
+       :encoders {:map strip-map, :map-of strip-map-of}}))))
 
 (defn key-transformer [{:keys [decode encode types] :or {types #{:map}}}]
   (let [transform (fn [f stage] (when f {stage (-transform-map-keys f)}))]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -911,6 +911,7 @@
 
       (is (true? (every? map-entry? (m/entries schema))))
       (is (= [:x :y :z] (map key (m/entries schema))))
+      (is (= [:x :y :z] (m/explicit-keys schema)))
 
       (is (schema= [[:x [::m/val 'boolean?]]
                     [:y [::m/val {:optional true} 'int?]]
@@ -2945,6 +2946,7 @@
     (testing "entries"
       (is (true? (every? map-entry? (m/entries schema))))
       (is (= [:x :y ::m/default] (map key (m/entries schema))))
+      (is (= [:x :y] (m/explicit-keys schema)))
       (is (schema= [[:x [::m/val :boolean]]
                     [:y [::m/val {:optional true} :int]]
                     [::m/default [::m/val [:map-of :int :int]]]]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -888,8 +888,8 @@
                           [:y {:optional true} int?]
                           [:z {:optional false} string?]])
           valid {:x true, :y 1, :z "kikka"}
-          valid-with-extras {:x true, :y 1, :z "kikka", :extra "key"}
           valid2 {:x false, :y 1, :z "kikka"}
+          valid-with-extras {:x true, :y 1, :z "kikka", :extra "key"}
           invalid {:x true, :y "invalid", :z "kikka", :extra "ok"}]
 
       (is (true? (m/validate schema valid)))
@@ -2905,3 +2905,110 @@
                                     :value {:x "kikka"}}
                           :schema schema
                           :value {:x "kikka"}}} (as-data (<result)))))))))
+
+(deftest extra-entries-in-map-test
+  (let [schema (m/schema
+                [:map
+                 [:x :boolean]
+                 [:y {:optional true} :int]
+                 [::m/default [:map-of :int :int]]])
+        valid {:x true, :y 1}
+        valid2 {:x true, :y 1, 123 123, 456 456}
+        invalid {:x true, :y 1, 123 "123", "456" 456}]
+
+    (is (true? (m/validate schema valid)))
+    (is (true? (m/validate schema valid2)))
+    (is (false? (m/validate schema invalid)))
+    (is (false? (m/validate schema "not-a-map")))
+
+    (is (nil? (m/explain schema valid)))
+    (is (nil? (m/explain schema valid2)))
+
+    (is (schema= [[:x nil :boolean]
+                  [:y {:optional true} :int]
+                  [::m/default nil [:map-of :int :int]]]
+                 (m/children schema)))
+
+    (is (true? (every? map-entry? (m/entries schema))))
+    (is (= [:x :y ::m/default] (map key (m/entries schema))))
+
+    (is (schema= [[:x [::m/val :boolean]]
+                  [:y [::m/val {:optional true} :int]]
+                  [::m/default [::m/val [:map-of :int :int]]]]
+                 (m/entries schema)))
+
+    (is (results= {:schema schema,
+                   :value {:y "invalid", "123" "123"},
+                   :errors [{:path [:x],
+                             :in [:x],
+                             :schema schema,
+                             :value nil,
+                             :type :malli.core/missing-key}
+                            {:path [:y], :in [:y], :schema :int, :value "invalid"}
+                            {:path [::m/default 0], :in ["123"], :schema :int, :value "123"}
+                            {:path [::m/default 1], :in ["123"], :schema :int, :value "123"}]}
+                  (m/explain schema {:y "invalid", "123" "123"})))
+
+    #_(is (= valid (m/parse schema valid)))
+    #_(is (= valid2 (m/parse schema valid2)))
+    #_(is (= ::m/invalid (m/parse schema invalid)))
+    #_(is (= ::m/invalid (m/parse schema "not-a-map")))
+    #_(is (= valid (m/unparse schema valid)))
+    #_(is (= valid2 (m/unparse schema valid2)))
+    #_(is (= ::m/invalid (m/unparse schema invalid)))
+    #_(is (= ::m/invalid (m/unparse schema "not-a-map")))
+
+    #_(is (= {:x true, :y 1} (m/decode schema {:x true, :y 1, :a 1} mt/strip-extra-keys-transformer)))
+    #_(is (= {:x_key true, :y_key 2} (m/decode schema {:x true, :y 2}
+                                               (mt/key-transformer
+                                                {:decode #(-> % name (str "_key") keyword)}))))
+
+    (testing "::m/default transforming doesn't effect defined keys"
+      (is (= {:id 12
+              :name :kikka
+              "age" 13
+              "ABBA" "jabba"
+              "KIKKA" "kukka"}
+             (m/decode
+              [:map
+               [:id :int]
+               [:name :keyword]
+               ["age" :int]
+               [::m/default [:map-of [:string {:decode/test str/upper-case}] :string]]]
+              {:id 12, :name :kikka, "age" "13", "abba" "jabba", "kikka" "kukka"}
+              (mt/transformer
+               (mt/string-transformer)
+               (mt/transformer {:name :test}))))))
+
+    (testing "nil-punning tranformers"
+      (is (= identity
+             (m/decoder
+              [:map
+               [:id :int]
+               [:name :keyword]
+               ["age" :int]
+               [::m/default [:map-of :keyword :keyword]]]
+              (mt/transformer)))))
+
+    (is (true? (m/validate (over-the-wire schema) valid)))
+
+    (testing "ast"
+      (is (= {:type :map,
+              :keys {:x {:order 0
+                         :value {:type :boolean}},
+                     :y {:order 1
+                         :value {:type :int}
+                         :properties {:optional true}},
+                     :malli.core/default {:order 2
+                                          :value {:type :map-of
+                                                  :key {:type :int}
+                                                  :value {:type :int}}}}}
+
+             (m/ast schema)))
+      (is (true? (m/validate (m/from-ast (m/ast schema)) valid))))
+
+    (is (= [:map
+            [:x :boolean]
+            [:y {:optional true} :int]
+            [::m/default [:map-of :int :int]]]
+           (m/form schema)))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1240,6 +1240,9 @@
                                 {:path [::m/default 1], :in [1], :schema :string, :value :invalid}]}
                       (m/explain schema [:so :invalid]))))
 
+      (testing "default schema"
+        (is (schema= [:tuple :string :string] (m/default-schema schema))))
+
       (testing "parser"
         (is (= (miu/-tagged :human [:human]) (m/parse schema [:human])))
         (is (= (miu/-tagged :bear [:bear [1 2 3]]) (m/parse schema [:bear 1 2 3])))
@@ -2951,6 +2954,9 @@
                     [:y [::m/val {:optional true} :int]]
                     [::m/default [::m/val [:map-of :int :int]]]]
                    (m/entries schema))))
+
+    (testing "default-schema"
+      (is (schema= [:map-of :int :int] (m/default-schema schema))))
 
     (testing "parsing and unparsing"
       (let [schema [:map {:registry {'int [:orn ['int :int]]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2907,11 +2907,10 @@
                           :value {:x "kikka"}}} (as-data (<result)))))))))
 
 (deftest extra-entries-in-map-test
-  (let [schema (m/schema
-                [:map
-                 [:x :boolean]
-                 [:y {:optional true} :int]
-                 [::m/default [:map-of :int :int]]])
+  (let [schema [:map
+                [:x :boolean]
+                [:y {:optional true} :int]
+                [::m/default [:map-of :int :int]]]
         valid {:x true, :y 1}
         valid2 {:x true, :y 1, 123 123, 456 456}
         invalid {:x true, :y 1, 123 "123", "456" 456}]
@@ -2959,9 +2958,9 @@
                     [::m/default [:map-of 'str 'str]]]
             valid {:id 1, "name" "tommi", "kikka" "kukka", "abba" "jabba"}]
         (is (= {:id ['int 1],
-                "name" ['str "tommi"],
-                ['str "kikka"] ['str "kukka"]
-                ['str "abba"] ['str "jabba"]}
+                "name" ['str "tommi"]
+                ::m/default {['str "kikka"] ['str "kukka"]
+                             ['str "abba"] ['str "jabba"]}}
                (m/parse schema valid)))
         (is (= valid (->> valid (m/parse schema) (m/unparse schema))))
         (is (= ::m/invalid (m/parse schema {"kukka" 42})))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2916,38 +2916,40 @@
         valid2 {:x true, :y 1, 123 123, 456 456}
         invalid {:x true, :y 1, 123 "123", "456" 456}]
 
-    (is (true? (m/validate schema valid)))
-    (is (true? (m/validate schema valid2)))
-    (is (false? (m/validate schema invalid)))
-    (is (false? (m/validate schema "not-a-map")))
+    (testing "validation"
+      (is (true? (m/validate schema valid)))
+      (is (true? (m/validate schema valid2)))
+      (is (false? (m/validate schema invalid)))
+      (is (false? (m/validate schema "not-a-map"))))
 
-    (is (nil? (m/explain schema valid)))
-    (is (nil? (m/explain schema valid2)))
+    (testing "explain"
+      (is (nil? (m/explain schema valid)))
+      (is (nil? (m/explain schema valid2)))
+      (is (results= {:schema schema,
+                     :value {:y "invalid", "123" "123"},
+                     :errors [{:path [:x],
+                               :in [:x],
+                               :schema schema,
+                               :value nil,
+                               :type :malli.core/missing-key}
+                              {:path [:y], :in [:y], :schema :int, :value "invalid"}
+                              {:path [::m/default 0], :in ["123"], :schema :int, :value "123"}
+                              {:path [::m/default 1], :in ["123"], :schema :int, :value "123"}]}
+                    (m/explain schema {:y "invalid", "123" "123"}))))
 
-    (is (schema= [[:x nil :boolean]
-                  [:y {:optional true} :int]
-                  [::m/default nil [:map-of :int :int]]]
-                 (m/children schema)))
+    (testing "children"
+      (is (schema= [[:x nil :boolean]
+                    [:y {:optional true} :int]
+                    [::m/default nil [:map-of :int :int]]]
+                   (m/children schema))))
 
-    (is (true? (every? map-entry? (m/entries schema))))
-    (is (= [:x :y ::m/default] (map key (m/entries schema))))
-
-    (is (schema= [[:x [::m/val :boolean]]
-                  [:y [::m/val {:optional true} :int]]
-                  [::m/default [::m/val [:map-of :int :int]]]]
-                 (m/entries schema)))
-
-    (is (results= {:schema schema,
-                   :value {:y "invalid", "123" "123"},
-                   :errors [{:path [:x],
-                             :in [:x],
-                             :schema schema,
-                             :value nil,
-                             :type :malli.core/missing-key}
-                            {:path [:y], :in [:y], :schema :int, :value "invalid"}
-                            {:path [::m/default 0], :in ["123"], :schema :int, :value "123"}
-                            {:path [::m/default 1], :in ["123"], :schema :int, :value "123"}]}
-                  (m/explain schema {:y "invalid", "123" "123"})))
+    (testing "entries"
+      (is (true? (every? map-entry? (m/entries schema))))
+      (is (= [:x :y ::m/default] (map key (m/entries schema))))
+      (is (schema= [[:x [::m/val :boolean]]
+                    [:y [::m/val {:optional true} :int]]
+                    [::m/default [::m/val [:map-of :int :int]]]]
+                   (m/entries schema))))
 
     (testing "parsing and unparsing"
       (let [schema [:map {:registry {'int [:orn ['int :int]]
@@ -2996,7 +2998,8 @@
                [::m/default [:map-of :keyword :keyword]]]
               (mt/transformer)))))
 
-    (is (true? (m/validate (over-the-wire schema) valid)))
+    (testing "over the wire"
+      (is (true? (m/validate (over-the-wire schema) valid))))
 
     (testing "ast"
       (is (= {:type :map,
@@ -3013,8 +3016,9 @@
              (m/ast schema)))
       (is (true? (m/validate (m/from-ast (m/ast schema)) valid))))
 
-    (is (= [:map
-            [:x :boolean]
-            [:y {:optional true} :int]
-            [::m/default [:map-of :int :int]]]
-           (m/form schema)))))
+    (testing "form"
+      (is (= [:map
+              [:x :boolean]
+              [:y {:optional true} :int]
+              [::m/default [:map-of :int :int]]]
+             (m/form schema))))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2949,14 +2949,20 @@
                             {:path [::m/default 1], :in ["123"], :schema :int, :value "123"}]}
                   (m/explain schema {:y "invalid", "123" "123"})))
 
-    #_(is (= valid (m/parse schema valid)))
-    #_(is (= valid2 (m/parse schema valid2)))
-    #_(is (= ::m/invalid (m/parse schema invalid)))
-    #_(is (= ::m/invalid (m/parse schema "not-a-map")))
-    #_(is (= valid (m/unparse schema valid)))
-    #_(is (= valid2 (m/unparse schema valid2)))
-    #_(is (= ::m/invalid (m/unparse schema invalid)))
-    #_(is (= ::m/invalid (m/unparse schema "not-a-map")))
+    (testing "parsing and unparsing"
+      (let [schema [:map {:registry {'int [:orn ['int :int]]
+                                     'str [:orn ['str :string]]}}
+                    [:id 'int]
+                    ["name" 'str]
+                    [::m/default [:map-of 'str 'str]]]
+            valid {:id 1, "name" "tommi", "kikka" "kukka", "abba" "jabba"}]
+        (is (= {:id ['int 1],
+                "name" ['str "tommi"],
+                ['str "kikka"] ['str "kukka"]
+                ['str "abba"] ['str "jabba"]}
+               (m/parse schema valid)))
+        (is (= valid (->> valid (m/parse schema) (m/unparse schema))))
+        (is (= ::m/invalid (m/parse schema {"kukka" 42})))))
 
     #_(is (= {:x true, :y 1} (m/decode schema {:x true, :y 1, :a 1} mt/strip-extra-keys-transformer)))
     #_(is (= {:x_key true, :y_key 2} (m/decode schema {:x true, :y 2}

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -45,11 +45,19 @@
      :properties {:x {:type "integer"}}
      :required [:x]
      :default {:x 1}}]
-   [[:map [:x :int] [::m/default [:map [:y :int]]]]
-      {:type "object"
-       :properties {:x {:type "integer"}
-                    :y {:type "integer"}}
-       :required [:x :y]}]
+   [[:map
+     [:x :int]
+     [::m/default [:map
+                   [:y :int]
+                   [::m/default [:map
+                                 [:z :int]
+                                 [::m/default [:map-of :int :int]]]]]]]
+    {:type "object",
+     :additionalProperties {:type "integer"},
+     :properties {:x {:type "integer"}
+                  :y {:type "integer"}
+                  :z {:type "integer"}},
+     :required [:x :y :z]}]
    [[:multi {:dispatch :type
              :decode/string '(fn [x] (update x :type keyword))}
      [:sized [:map {:gen/fmap '#(assoc % :type :sized)} [:type keyword?] [:size int?]]]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -1,5 +1,6 @@
 (ns malli.json-schema-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.test.check.generators :as gen]
+            [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [malli.core-test]
             [malli.json-schema :as json-schema]
@@ -40,7 +41,7 @@
      :additionalProperties {:type "integer"}}]
    [[:map
      [:x :int]
-     [::m/default [:fn {:json-schema/default {:x 1}} map?]]]
+     [::m/default [:fn {:json-schema/default {:x 1}, :gen/gen (gen/return {})} map?]]]
     {:type "object"
      :properties {:x {:type "integer"}}
      :required [:x]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -45,9 +45,11 @@
      :properties {:x {:type "integer"}}
      :required [:x]
      :default {:x 1}}]
-   ;; TODO: :map does not deep-merge ::m/default contents
-   #_[[:map [:x :int] [::m/default [:map [:y :int]]]]
-      {:type "object", :properties {:x {:type "integer"}, :y {:type "integer"}}, :required [:x :y]}]
+   [[:map [:x :int] [::m/default [:map [:y :int]]]]
+      {:type "object"
+       :properties {:x {:type "integer"}
+                    :y {:type "integer"}}
+       :required [:x :y]}]
    [[:multi {:dispatch :type
              :decode/string '(fn [x] (update x :type keyword))}
      [:sized [:map {:gen/fmap '#(assoc % :type :sized)} [:type keyword?] [:size int?]]]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -25,11 +25,29 @@
    [[:map
      [:a string?]
      [:b {:optional true} string?]
-     [:c {:optional false} string?]] {:type "object"
-                                      :properties {:a {:type "string"}
-                                                   :b {:type "string"}
-                                                   :c {:type "string"}}
-                                      :required [:a :c]}]
+     [:c {:optional false} string?]]
+    {:type "object"
+     :properties {:a {:type "string"}
+                  :b {:type "string"}
+                  :c {:type "string"}}
+     :required [:a :c]}]
+   [[:map
+     [:x :int]
+     [::m/default [:map-of :int :int]]]
+    {:type "object"
+     :properties {:x {:type "integer"}}
+     :required [:x]
+     :additionalProperties {:type "integer"}}]
+   [[:map
+     [:x :int]
+     [::m/default [:fn {:json-schema/default {:x 1}} map?]]]
+    {:type "object"
+     :properties {:x {:type "integer"}}
+     :required [:x]
+     :default {:x 1}}]
+   ;; TODO: :map does not deep-merge ::m/default contents
+   #_[[:map [:x :int] [::m/default [:map [:y :int]]]]
+      {:type "object", :properties {:x {:type "integer"}, :y {:type "integer"}}, :required [:x :y]}]
    [[:multi {:dispatch :type
              :decode/string '(fn [x] (update x :type keyword))}
      [:sized [:map {:gen/fmap '#(assoc % :type :sized)} [:type keyword?] [:size int?]]]
@@ -83,8 +101,8 @@
    [ifn? {}]
 
    [integer? {:type "integer"}]
-   #?@(:clj [[ratio? {:type "number"}]
-             [rational? {:type "number"}]]
+   #?@(:clj  [[ratio? {:type "number"}]
+              [rational? {:type "number"}]]
        :cljs [])
    ;; protocols
    [(reify
@@ -120,10 +138,10 @@
                          :x5 {:type "x-string"}}}
            (json-schema/transform
             [:map
-             [:x1 {:json-schema/title "x"          :optional true} :string]
-             [:x2 {:json-schema {:title "x"}       :optional true} [:string {:json-schema/default "x"}]]
-             [:x3 {:json-schema/title "x"          :optional true} [:string {:json-schema/default "x"}]]
-             [:x4 {:json-schema/title "x-string"   :optional true} [:string {:json-schema {:default "x2"}}]]
+             [:x1 {:json-schema/title "x" :optional true} :string]
+             [:x2 {:json-schema {:title "x"} :optional true} [:string {:json-schema/default "x"}]]
+             [:x3 {:json-schema/title "x" :optional true} [:string {:json-schema/default "x"}]]
+             [:x4 {:json-schema/title "x-string" :optional true} [:string {:json-schema {:default "x2"}}]]
              [:x5 {:json-schema {:type "x-string"} :optional true} [:string {:json-schema {:default "x"}}]]]))))
 
   (testing "map-entry overrides"

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -469,7 +469,7 @@
     (let [value {:x 1, :y 2, :z 3, 1 1, "2" 2, 3 "3", "4" "4"}
           expected {1 1, :x 1, :y 2}]
 
-      (testing "explicit and default values are both stripped"
+      (testing "stripping applies for both explicit and default values"
         (is (= expected
                (m/decode
                 [:map


### PR DESCRIPTION
Resolution for #43

Bonuses:

* `m/default-schema` to pull the `::m/default` schema from entry schemas
* `m/explicit-keys` to get a vector of explicit keys from entry schemas (no `::m/default`
* `mt/strip-extra-keys-transformer` works with `:map-of` schemas

TODO:
* [x] more tests
* [x] parsing & unparsing
* [x] strip-extra-keys-transformer
* [x] map-keys-transformer
* [x] json schema mapping
* [x] generators
* [x] docs
* [x] ~try perf~

```clojure
(def schema
  [:map
   [:id :int]
   ["age" :int]
   [::m/default [:map-of [:string {:decode/test str/upper-case}] :string]]])

(m/explicit-keys schema)
; => [:id "age"]

(m/default-schema schema)
; => [:map-of [:string {:decode/test str/upper-case}] :string]

(m/validate schema {:id 1, "age" 13, "kikka" "kukka"})
; => true

(m/decode
 schema
 {:id 1, "age" 13, "kikka" "kukka"}
 (mt/transformer
  (mt/string-transformer)
  (mt/transformer {:name :test})))
; => {:id 1, "age" 13, "KIKKA" "kukka"}

(m/explain schema {:id "1", "age" 13, "kikka" :kukka})
;{:schema ...,
; :value {:id "1", "age" 13, "kikka" :kukka},
; :errors ({:path [:id], :in [:id], :schema :int, :value "1"}
;          {:path [:malli.core/default 1], :in ["kikka"], :schema :string, :value :kukka})}

(m/parse schema {:id 1, "age" 13, "kikka" "kukka"})
;{:id 1, "age" 13, "kikka" "kukka"}

(mg/generate schema)
;{:id 12,
; "age" 4151222,
; "b9DR4P1s92" "1HV6XXcDqvqfF4NEMYL034as4",
; "5J4028PJp5n3z1BDX2h9zHwhT9" "CVeeNK72zQZ",
; "sRRhCH1" "2n2SGnKYY"}
```

```clojure
(m/decode
 [:map
  [:x :int]
  [:y :int]
  [::m/default [:map-of :int :int]]]
 {:x 1, :y 2, :z 3, 1 1, "2" 2, 3 "3", "4" "4"}
 (mt/strip-extra-keys-transformer))
; => {:x 1, :y 2, 1 1}

(json-schema/transform
 [:map
  [:x :int]
  [::m/default [:map-of :int :int]]])
;{:type "object"
; :required [:x]
; :properties {:x {:type "integer"}}
; :additionalProperties {:type "integer"}}

(json-schema/transform
 [:map
  [:x :int]
  [::m/default [:map [:y :int]]]])
;{:type "object"
; :properties {:x {:type "integer"}
;              :y {:type "integer"}}
; :required [:x :y]}
```
