### PR TITLE
Replace goog/mixin with Object.assign

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -44,7 +44,7 @@
                          org.clojure/tools.namespace {:mvn/version "RELEASE"}}}
 
            :shadow {:extra-paths ["app"]
-                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.22.2"}
+                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.22.10"}
                                  binaryage/devtools {:mvn/version "1.0.6"}}}
            :slow {:extra-deps {io.dominic/slow-namespace-clj
                                {:git/url "https://git.sr.ht/~severeoverfl0w/slow-namespace-clj"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
         "@js-joda/core": "5.5.2",
         "@js-joda/timezone": "2.17.2",
         "isomorphic-ws": "^4.0.1",
-        "shadow-cljs": "^2.20.20",
+        "shadow-cljs": "2.22.10",
         "ws": "^7.4.6"
       }
     },
@@ -787,14 +787,14 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.20.20",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
-      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
+      "version": "2.22.10",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.22.10.tgz",
+      "integrity": "sha512-a8d0d4HA+OPyAiy+OpeXiqvmfLcidODsJ/rnxF13D1jevGxAmFKfF3IedCtf4PRRzIRIrsvOhwZnrSFc0ykZ3w==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
         "readline-sync": "^1.4.7",
-        "shadow-cljs-jar": "1.3.2",
+        "shadow-cljs-jar": "1.3.4",
         "source-map-support": "^0.4.15",
         "which": "^1.3.1",
         "ws": "^7.4.6"
@@ -807,9 +807,9 @@
       }
     },
     "node_modules/shadow-cljs-jar": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
-      "integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
+      "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==",
       "dev": true
     },
     "node_modules/source-map": {
@@ -1678,23 +1678,23 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.20.20",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.20.20.tgz",
-      "integrity": "sha512-giP7W9twqZ/I8lSiaymNFiQXSqcFQiO9cI/pH2A2XaUJ1hNg8yk+ahXCxM7VZpboB61Gw7bBMzrYrpV+1QeC6Q==",
+      "version": "2.22.10",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.22.10.tgz",
+      "integrity": "sha512-a8d0d4HA+OPyAiy+OpeXiqvmfLcidODsJ/rnxF13D1jevGxAmFKfF3IedCtf4PRRzIRIrsvOhwZnrSFc0ykZ3w==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.2.1",
         "readline-sync": "^1.4.7",
-        "shadow-cljs-jar": "1.3.2",
+        "shadow-cljs-jar": "1.3.4",
         "source-map-support": "^0.4.15",
         "which": "^1.3.1",
         "ws": "^7.4.6"
       }
     },
     "shadow-cljs-jar": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.2.tgz",
-      "integrity": "sha512-XmeffAZHv8z7451kzeq9oKh8fh278Ak+UIOGGrapyqrFBB773xN8vMQ3O7J7TYLnb9BUwcqadKkmgaq7q6fhZg==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/shadow-cljs-jar/-/shadow-cljs-jar-1.3.4.tgz",
+      "integrity": "sha512-cZB2pzVXBnhpJ6PQdsjO+j/MksR28mv4QD/hP/2y1fsIa9Z9RutYgh3N34FZ8Ktl4puAXaIGlct+gMCJ5BmwmA==",
       "dev": true
     },
     "source-map": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@js-joda/core": "5.5.2",
     "@js-joda/timezone": "2.17.2",
     "isomorphic-ws": "^4.0.1",
-    "shadow-cljs": "^2.20.20",
+    "shadow-cljs": "2.22.10",
     "ws": "^7.4.6"
   }
 }

--- a/src/malli/instrument.cljs
+++ b/src/malli/instrument.cljs
@@ -18,7 +18,7 @@
   ;; Because the current MetaFn implementation can cause quirky errors in CLJS
   [f m]
   (let [new-f (goog/bind f #js{})]
-    (goog/mixin new-f f)
+    (js/Object.assign new-f f)
     (specify! new-f IMeta #_:clj-kondo/ignore (-meta [_] m))
     new-f))
 


### PR DESCRIPTION
The latest version of shadow-cljs uses a newer version of the closure compiler and library which removed `goog.mixin` here:
https://github.com/google/closure-library/commit/d9aace7423bcee7fc700e6f68db23e6ba9670f25

resulting in this error during cljs instrumentation:
![goog_mixin_err](https://user-images.githubusercontent.com/467827/230777436-5b65955e-7862-4337-a3b8-323aa6c1377e.png)

This PR replaces `goog/mixin` use with `js/Object.assign`.
