### PR TITLE
zone-id gen - do not use registry to lookup enum

### DIFF
--- a/src/malli/experimental/time/generator.cljc
+++ b/src/malli/experimental/time/generator.cljc
@@ -11,7 +11,7 @@
 #?(:clj (set! *warn-on-reflection* true))
 
 (def zone-id-gen
-  (mg/generator (into [:enum] (map #(. ZoneId of ^String %)) (. ZoneId getAvailableZoneIds))))
+  (mg/generator (m/into-schema (m/-enum-schema) nil (map #(. ZoneId of ^String %) (. ZoneId getAvailableZoneIds)))))
 
 (defmethod mg/-schema-generator :time/zone-id [_schema _options] zone-id-gen)
 


### PR DESCRIPTION
If you're using a custom default registry and require the `experimental.time.generator` namespace `:enum` will not be available yet when the `experimental.time.generator` namespace is compiled. 

This PR switches to getting the `:enum` schema directly from `malli.core`.

Here is an example error in cljs with a custom default registry:

![Screenshot_20230412_233325](https://user-images.githubusercontent.com/467827/231642290-2558c453-151e-4400-8d8f-59fc9b857d53.png)
