### PR TITLE
Do not require timezone data directly for cljs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3031,6 +3031,21 @@ To use these schemas in ClojureScript you will need to install the npm packages 
 npm install @js-joda/core @js-joda/timezone
 ```
 
+Because historical timezone data can add ~500kb to your ClojureScript build malli does not require the `@js-joda/timezone`
+package directly. You must require timezone data before requiring the `malli.experimental.time` namespace if you want
+to make use of zone related time objects.
+
+For example, to include only timezone data for +/- 5 years from the time the library was released, use:
+
+```clojure
+(ns com.my-co.my-app
+  (:require ["@js-joda/timezone/dist/js-joda-timezone-10-year-range"]))
+```
+
+For more info see:
+
+https://github.com/js-joda/js-joda/tree/main/packages/timezone
+
 #### min/max
 
 Time schemas respect min/max predicates for their respective types:

--- a/src/malli/experimental/time.cljc
+++ b/src/malli/experimental/time.cljc
@@ -1,9 +1,7 @@
 (ns malli.experimental.time
   (:refer-clojure :exclude [<=])
   (:require [malli.core :as m]
-            #?@(:cljs
-                [["@js-joda/core" :as js-joda]
-                 ["@js-joda/timezone"]]))
+            #?(:cljs ["@js-joda/core" :as js-joda]))
   #?(:clj (:import (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId OffsetTime ZoneOffset))))
 
 (defn <= [^Comparable x ^Comparable y] (not (pos? (.compareTo x y))))

--- a/src/malli/experimental/time/generator.cljc
+++ b/src/malli/experimental/time/generator.cljc
@@ -10,10 +10,10 @@
 
 #?(:clj (set! *warn-on-reflection* true))
 
-(def zone-id-gen
+(defn zone-id-gen []
   (mg/generator (m/into-schema (m/-enum-schema) nil (map #(. ZoneId of ^String %) (. ZoneId getAvailableZoneIds)))))
 
-(defmethod mg/-schema-generator :time/zone-id [_schema _options] zone-id-gen)
+(defmethod mg/-schema-generator :time/zone-id [_schema _options] (zone-id-gen))
 
 #?(:clj  (def ^:const ^:private seconds-in-day 86400)
    :cljs (def ^:private seconds-in-day 86400))
@@ -109,7 +109,7 @@
   (gen/bind
    (-instant-gen schema options)
    (fn [instant]
-     (gen/fmap #(. ZonedDateTime ofInstant instant %) zone-id-gen))))
+     (gen/fmap #(. ZonedDateTime ofInstant instant %) (zone-id-gen)))))
 
 (defmethod mg/-schema-generator :time/zoned-date-time [schema options]
   (-zoned-date-time-gen schema options))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -7,7 +7,8 @@
             [malli.generator :as mg]
             [malli.json-schema-test :as json-schema-test]
             [malli.util :as mu]
-            #?(:clj [malli.test-macros :refer [when-env]]))
+            #?(:clj [malli.test-macros :refer [when-env]]
+               :cljs ["@js-joda/timezone/dist/js-joda-timezone-10-year-range"]))
   #?(:cljs (:require-macros [malli.test-macros :refer [when-env]])))
 
 (deftest generator-test


### PR DESCRIPTION
When making a release cljs build I noticed js-joda was around 700kb and then realized the `malli.experimental.time` namespace was pulling in all historical timezone data.
See the note at the bottom of the package for more info: https://www.npmjs.com/package/@js-joda/timezone
using the +/- 5 year range adds ~30kb.


This change requires ClojureScript users of malli to include the timezone data of their choice explicitly.

I had to convert the  `zone-id-gen` to a function due to `ZoneId` now not being available until runtime.