### PR TITLE
Fixes a bug in `malli.core/-comp`

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -189,8 +189,10 @@
              ([f1 f2 f3 f4 f5 f6] (fn [x] (-> x f6 f5 f4 f3 f2 f1)))
              ([f1 f2 f3 f4 f5 f6 f7] (fn [x] (-> x f7 f6 f5 f4 f3 f2 f1)))
              ([f1 f2 f3 f4 f5 f6 f7 f8] (fn [x] (-> x f8 f7 f6 f5 f4 f3 f2 f1)))
-             ([f1 f2 f3 f4 f5 f6 f7 f8 & fs] (-comp (fn [x] (-> x f8 f7 f6 f5 f4 f3 f2 f1)) (apply -comp fs)))]
-      :cljs [([f1 f2 f3 & fs] (-comp (fn [x] (-> x f3 f2 f1)) (apply -comp fs)))]))
+             ([f1 f2 f3 f4 f5 f6 f7 f8 & fs] (let [f9 (apply -comp fs)]
+                                               (fn [x] (-> x f9 f8 f7 f6 f5 f4 f3 f2 f1))))]
+      :cljs [([f1 f2 f3 & fs] (let [f4 (apply -comp fs)]
+                                (fn [x] (-> x f4 f3 f2 f1))))]))
 
 (defn -update [x k f] (assoc x k (f (get x k))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -189,8 +189,8 @@
              ([f1 f2 f3 f4 f5 f6] (fn [x] (-> x f6 f5 f4 f3 f2 f1)))
              ([f1 f2 f3 f4 f5 f6 f7] (fn [x] (-> x f7 f6 f5 f4 f3 f2 f1)))
              ([f1 f2 f3 f4 f5 f6 f7 f8] (fn [x] (-> x f8 f7 f6 f5 f4 f3 f2 f1)))
-             ([f1 f2 f3 f4 f5 f6 f7 f8 & fs] (-comp (apply -comp fs) (fn [x] (-> x f8 f7 f6 f5 f4 f3 f2 f1))))]
-      :cljs [([f1 f2 f3 & fs] (-comp (apply -comp fs) (fn [x] (-> x f3 f2 f1))))]))
+             ([f1 f2 f3 f4 f5 f6 f7 f8 & fs] (-comp (fn [x] (-> x f8 f7 f6 f5 f4 f3 f2 f1)) (apply -comp fs)))]
+      :cljs [([f1 f2 f3 & fs] (-comp (fn [x] (-> x f3 f2 f1)) (apply -comp fs)))]))
 
 (defn -update [x k f] (assoc x k (f (get x k))))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2940,3 +2940,22 @@
               [:y {:optional true} :int]
               [::m/default [:map-of :int :int]]]
              (m/form schema))))))
+
+(deftest -comp-test
+  (let [prefixer (fn [prefix]
+                   (fn [s] (str prefix s)))]
+    (testing "the order of function applications"
+      (is (= "abcxxx"
+             ((m/-comp (prefixer "a")
+                       (prefixer "b")
+                       (prefixer "c")) "xxx")))
+      (is (= "abcdefghixxx"
+             ((m/-comp (prefixer "a")
+                       (prefixer "b")
+                       (prefixer "c")
+                       (prefixer "d")
+                       (prefixer "e")
+                       (prefixer "f")
+                       (prefixer "g")
+                       (prefixer "h")
+                       (prefixer "i")) "xxx"))))))


### PR DESCRIPTION
The composition order of `-comp` is wrong.