### PR TITLE
[Proposal] map-of index should be part of `:in` during a walk

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1177,7 +1177,7 @@
            Cached
            (-cache [_] cache)
            LensSchema
-           (-keep [_])
+           (-keep [_] true)
            (-get [_ key default] (get children key default))
            (-set [this key value] (-set-assoc-children this key value))))))))
 

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -194,7 +194,7 @@
 
 (defn data-explainer
   "Like `m/explainer` but output is pure clojure data. Schema objects have been replaced with their m/form.
-   Useful when you need to serialise errrors."
+   Useful when you need to serialise errors."
   ([?schema]
    (data-explainer ?schema nil))
   ([?schema options]


### PR DESCRIPTION
```clojure
(defprotocol LensSchema
  (-keep [this] "returns truthy if schema contributes to value path")
```

I think that the index in `:map-of` should be part of `:in` during a walk as it contributes to the value path, otherwise we don't differentiate between the key and the value.