### PR TITLE
add :default/fn prop for default-value-transformer

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -397,9 +397,10 @@
   ([] (default-value-transformer nil))
   ([{:keys [key default-fn defaults ::add-optional-keys] :or {key :default, default-fn (fn [_ x] x)}}]
    (let [get-default (fn [schema]
-                       (if-some [e (some-> schema m/properties (find key))]
-                         (constantly (val e))
-                         (some->> schema m/type (get defaults) (#(constantly (% schema))))))
+                       (or (some-> schema m/properties :default/fn m/eval)
+                           (if-some [e (some-> schema m/properties (find key))]
+                             (constantly (val e))
+                             (some->> schema m/type (get defaults) (#(constantly (% schema)))))))
          set-default {:compile (fn [schema _]
                                  (when-some [f (get-default schema)]
                                    (fn [x] (if (nil? x) (default-fn schema (f)) x))))}

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -971,7 +971,11 @@
             seen (atom [])
             transformer (mt/default-value-transformer {:key :name, :default-fn (fn [_ x] (swap! seen conj x) x)})]
         (is (= {:first 'one, :second 'two} (m/encode schema {} transformer)))
-        (is (= ['one 'two] @seen))))))
+        (is (= ['one 'two] @seen)))))
+
+  (testing ":default/fn property on schema"
+    (let [schema [:string {:default/fn (fn [] "called")}]]
+      (is (= "called" (m/decode schema nil mt/default-value-transformer))))))
 
 (deftest type-properties-based-transformations
   (is (= 12 (m/decode malli.core-test/Over6 "12" mt/string-transformer))))


### PR DESCRIPTION
use case:
we want the default value to be current time.

previously you would have to do something like this:

```clojure
(m/decode
 [:time/instant {:default :now}]
 nil
 (mt/default-value-transformer {:default-fn
                                (fn [_ x ] (case x
                                             :now (java.time.Instant/now)
                                             x))}))
```

this patch lets you declare this without the indirection:

```clojure
(m/decode [:time/instant {:default/fn #(java.time.Instant/now)}]
          nil
          mt/default-value-transformer)
```