### PR TITLE
Add :gen/return support in malli.generator

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -469,6 +469,10 @@
 ;; Creating a generator by different means, centralized under [[-create]]
 ;;
 
+(defn- -create-from-return [props]
+  (when (contains? props :gen/return)
+    (gen/return (:gen/return props))))
+
 (defn- -create-from-elements [props]
   (some-> (:gen/elements props) gen-elements))
 
@@ -486,7 +490,8 @@
 (defn- -create-from-fmap [props schema options]
   (when-some [fmap (:gen/fmap props)]
     (gen/fmap (m/eval fmap (or options (m/options schema)))
-              (or (-create-from-elements props)
+              (or (-create-from-return props)
+                  (-create-from-elements props)
                   (-create-from-schema props options)
                   (-create-from-gen props schema options)
                   (gen/return nil)))))
@@ -495,6 +500,7 @@
   (let [props (merge (m/type-properties schema)
                      (m/properties schema))]
     (or (-create-from-fmap props schema options)
+        (-create-from-return props)
         (-create-from-elements props)
         (-create-from-schema props options)
         (-create-from-gen props schema options)

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -123,10 +123,14 @@
   (testing "map entries"
     (is (= {:korppu "koira"
             :piilomaan "pikku aasi"
-            :muuli "mukkelis"}
+            :muuli "mukkelis"
+            :aasi "isaskarin"
+            :kissa "pikimustan kissan"}
            (mg/generate [:map {:gen/fmap '#(assoc % :korppu "koira")}
                          [:piilomaan {:gen/fmap '(partial str "pikku ")} [:string {:gen/elements ["aasi"]}]]
-                         [:muuli {:gen/elements ["mukkelis"]} [:string {:gen/elements ["???"]}]]]))))
+                         [:muuli {:gen/elements ["mukkelis"]} [:string {:gen/elements ["???"]}]]
+                         [:aasi {:gen/return "isaskarin"} [:string {:gen/return "???"}]]
+                         [:kissa {:gen/fmap '(partial str "pikimustan ")} [:string {:gen/return "kissan"}]]]))))
 
   (testing "ref"
     (testing "recursion"
@@ -172,6 +176,10 @@
                             #"abc"]))
         "Using :gen/gen")
     (is (= 42 (mg/generate [:re
+                            {:gen/return 42}
+                            #"abc"]))
+        "Using :gen/return")
+    (is (= 42 (mg/generate [:re
                             {:gen/fmap (fn [_] 42)
                              :gen/schema :int}
                             #"abc"]))
@@ -210,6 +218,11 @@
           (m/validate schema (mg/generate generator)))))
     (testing "with generator"
       (is (re-matches #"kikka_\d+" (mg/generate [:and {:gen/fmap '(partial str "kikka_")} pos-int?])))))
+
+  (testing "gen/return"
+    (is (every? nil? (mg/sample [:and {:gen/return nil} int?] {:size 1000})))
+    (is (every? #{1} (mg/sample [:and {:gen/return 1} int?] {:size 1000})))
+    (is (every? #{"1"} (mg/sample [:and {:gen/return 1, :gen/fmap 'str} int?] {:size 1000}))))
 
   (testing "gen/elements"
     (is (every? #{1 2} (mg/sample [:and {:gen/elements [1 2]} int?] {:size 1000})))


### PR DESCRIPTION
Resolves #932.

Adds idiom for `:gen/return x` in properties, just like `clojure.test.check.generators/return x`. It has similar effect to more indirect workarounds previously like `:gen/elements [x]` or `:gen/gen (gen/return x)` or `:gen/fmap (constantly x)`.

Combining `:gen/return` and `:gen/fmap` works similarly to combining `:gen/return` and `:gen/elements`. Returning `nil` from `:gen/return nil` is supported.