### PR TITLE
0.12.0

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Java ${{ matrix.jdk }}
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v3.12.0
         with:
           distribution: zulu
           java-version: ${{ matrix.jdk }}
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Java 11
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v3.12.0
         with:
           distribution: zulu
           java-version: 11
@@ -52,7 +52,7 @@ jobs:
         with:
           cli: latest
       - name: Setup Node.js
-        uses: actions/setup-node@v3.6.0
+        uses: actions/setup-node@v3.8.1
         with:
           node-version: 16
       - name: Install dependencies
@@ -67,7 +67,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Setup Java 11
-        uses: actions/setup-java@v3.11.0
+        uses: actions/setup-java@v3.12.0
         with:
           distribution: zulu
           java-version: 11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * Add `:gen/return` support in malli.generator [#933](https://github.com/metosin/malli/pull/933)
 * Make uuid transformer to be case insensitive [#929](https://github.com/metosin/malli/pull/929)
 * Add `:default/fn` prop for default-value-transformer [#927](https://github.com/metosin/malli/pull/927)
+* Updated dependencies:
 
 ```clojure
 borkdude/edamame 1.3.20 -> 1.3.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,13 +14,21 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
-## UNRELEASED
+## 0.12.0 (2023-08-31)
 
 * FIX: retain order with `:catn` unparse, fixes [#925](https://github.com/metosin/malli/issues/925)
 * **BREAKING**: Do not require timezone data directly for cljs [#898](https://github.com/metosin/malli/pull/898) with `malli.experimental.time`
 * Remove non-root swagger definitions [#900](https://github.com/metosin/malli/pull/900)
 * FIX: `malli.core/-comp` keeps interceptor order with long chains [#905](https://github.com/metosin/malli/pull/905)
 * FIX: `malli.dev/start!` exception does not contain source [#896](https://github.com/metosin/malli/issues/896)
+* FIX: don't add extra :schema nil to swagger :parameters [#939](https://github.com/metosin/malli/pull/939)
+* Add `:gen/return` support in malli.generator [#933](https://github.com/metosin/malli/pull/933)
+* Make uuid transformer to be case insensitive [#929](https://github.com/metosin/malli/pull/929)
+* Add `:default/fn` prop for default-value-transformer [#927](https://github.com/metosin/malli/pull/927)
+
+```clojure
+borkdude/edamame 1.3.20 -> 1.3.23
+```
 
 ## 0.11.0 (2023-04-12)
 

--- a/README.md
+++ b/README.md
@@ -1638,6 +1638,11 @@ Schemas can be used to generate values:
   {:seed 42, :size 10})
 ; => "CaR@MavCk70OHiX.yZ"
 
+;; :gen/return (note, not validated)
+(mg/generate
+ [:and {:gen/return 42} :int])
+; => 42
+
 ;; :gen/elements (note, are not validated)
 (mg/generate
   [:and {:gen/elements ["kikka" "kukka" "kakka"]} string?]

--- a/deps.edn
+++ b/deps.edn
@@ -1,32 +1,33 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.11.1"}
         borkdude/dynaload {:mvn/version "0.3.5"}
-        borkdude/edamame {:mvn/version "1.3.20"}
+        borkdude/edamame {:mvn/version "1.3.23"}
         org.clojure/test.check {:mvn/version "1.1.1"}
         ;; pretty errors, optional deps
         fipp/fipp {:mvn/version "0.6.26"}
         mvxcvi/arrangement {:mvn/version "2.1.0"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {com.gfredericks/test.chuck {:mvn/version "0.2.14"}
-                               lambdaisland/kaocha {:mvn/version "1.82.1306"}
-                               lambdaisland/kaocha-cljs {:mvn/version "1.4.130"}
-                               org.babashka/sci {:mvn/version "0.7.39"}
+                               lambdaisland/kaocha {:mvn/version "1.86.1355"}
+                               lambdaisland/kaocha-cljs {:mvn/version "1.5.154"}
+                               org.babashka/sci {:mvn/version "0.8.40"}
                                lambdaisland/kaocha-junit-xml {:mvn/version "1.17.101"}
-                               metosin/spec-tools {:mvn/version "0.10.5"}
+                               metosin/spec-tools {:mvn/version "0.10.6"}
                                spec-provider/spec-provider {:mvn/version "0.4.14"}
-                               metosin/schema-tools {:mvn/version "0.13.0"}
+                               metosin/schema-tools {:mvn/version "0.13.1"}
                                metosin/jsonista {:mvn/version "0.3.7"}
                                prismatic/schema {:mvn/version "1.4.1"}
                                minimallist/minimallist {:mvn/version "0.0.10"}
                                net.cgrand/seqexp {:mvn/version "0.6.2"}
+                               djblue/portal {:mvn/version "0.46.0"}
                                meta-merge/meta-merge {:mvn/version "1.0.0"}
                                expound/expound {:mvn/version "0.9.0"}
                                lambdaisland/deep-diff {:mvn/version "0.0-47"}
                                com.bhauman/spell-spec {:mvn/version "0.1.2"}
                                org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
-                                                        :sha "46b183d19984cafb655647f212bfa286b4d0dc63"}}}
-           :sci {:extra-deps {org.babashka/sci {:mvn/version "0.7.39"}}}
-           :cherry {:extra-deps {io.github.squint-cljs/cherry {:git/sha "0e12c4a0289b094c800b54e7e97889c786109ad3"}}}
+                                                        :sha "4cbfa677c4cd66339f18e1c122222c05c69e0d8e"}}}
+           :sci {:extra-deps {org.babashka/sci {:mvn/version "0.8.40"}}}
+           :cherry {:extra-deps {io.github.squint-cljs/cherry {:git/sha "24635085f3a268e624dee5f6b7ec049323a01173"}}}
            :test-sci {:extra-paths ["test-sci"]
                       :main-opts ["-m" "cljs-test-runner.main" "-d" "test-sci" "-d" "test"]}
            :test-cherry {:extra-paths ["test-cherry"]
@@ -36,7 +37,7 @@
                                            com.widdindustries/cljs.java-time {:mvn/version "0.1.20"}}
                               :extra-paths ["test" "cljs-test-runner-out/gen"]
                               :main-opts ["-m" "cljs-test-runner.main" "-d" "test"]}
-           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}}
+           :build {:deps {io.github.clojure/tools.build {:git/tag "v0.9.5" :git/sha "24f2894"}}
                    :ns-default build}
            :jmh {:paths ["target/uber.jar" "classes"]
                  :deps {jmh-clojure/jmh-clojure {:mvn/version "0.4.1"}
@@ -48,7 +49,7 @@
                                 org.clojure/tools.namespace #_:clj-kondo/ignore {:mvn/version "RELEASE"}}}
 
            :shadow {:extra-paths ["app"]
-                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.22.10"}
+                    :extra-deps {thheller/shadow-cljs {:mvn/version "2.25.3"}
                                  binaryage/devtools {:mvn/version "1.0.7"}}}
            :slow {:extra-deps {io.dominic/slow-namespace-clj
                                {:git/url "https://git.sr.ht/~severeoverfl0w/slow-namespace-clj"
@@ -68,11 +69,11 @@
                                  "malli.jar"]}
            :graalvm {:extra-paths ["graal-test/src"]
                      :extra-deps {org.clojure/clojure {:mvn/version "1.11.1"}
-                                  org.babashka/sci {:mvn/version "0.7.39"}}}
+                                  org.babashka/sci {:mvn/version "0.8.40"}}}
            :perf {:extra-paths ["perf"]
                   :extra-deps {criterium/criterium {:mvn/version "0.4.6"}
                                org.clojure/clojure {:mvn/version "1.11.1"}
-                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.3"}}
+                               com.clojure-goes-fast/clj-async-profiler {:mvn/version "1.0.5"}}
                   :jvm-opts ["-server"
                              "-Xmx4096m"
                              "-Dclojure.compiler.direct-linking=true"]}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>metosin</groupId>
   <artifactId>malli</artifactId>
-  <version>0.11.0</version>
+  <version>0.12.0</version>
   <name>malli</name>
   <licenses>
     <license>
@@ -15,7 +15,7 @@
     <url>https://github.com/metosin/malli</url>
     <connection>scm:git:git://github.com/metosin/malli.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/metosin/malli.git</developerConnection>
-    <tag>0.11.0</tag>
+    <tag>0.12.0</tag>
   </scm>
   <dependencies>
     <dependency>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>borkdude</groupId>
       <artifactId>edamame</artifactId>
-      <version>1.3.20</version>
+      <version>1.3.23</version>
     </dependency>
     <dependency>
       <groupId>org.clojure</groupId>

--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -1,5 +1,5 @@
 (ns malli.impl.util
-  #?(:clj (:import #?(:bb (clojure.lang MapEntry)
+  #?(:clj (:import #?(:bb  (clojure.lang MapEntry)
                       :clj (clojure.lang MapEntry LazilyPersistentVector))
                    (java.util.concurrent TimeoutException TimeUnit FutureTask))))
 
@@ -23,7 +23,7 @@
                      (if-not (zero? c)
                        (let [oa (object-array c), iter (.iterator ^Iterable os)]
                          (loop [n 0] (when (.hasNext iter) (aset oa n (f (.next iter))) (recur (unchecked-inc n))))
-                         #?(:bb (vec oa)
+                         #?(:bb  (vec oa)
                             :clj (LazilyPersistentVector/createOwning oa))) []))
              :cljs (into [] (map f) os))))
 
@@ -32,8 +32,8 @@
      (let [task (FutureTask. f), t (Thread. task)]
        (try
          (.start t) (.get task ms TimeUnit/MILLISECONDS)
-         (catch TimeoutException _ (.cancel task true) (.stop t) ::timeout)
-         (catch Exception e (.cancel task true) (.stop t) (throw e))))))
+         (catch TimeoutException _ (.cancel task true) ::timeout)
+         (catch Exception e (.cancel task true) (throw e))))))
 
 #?(:clj
    (defmacro -combine-n
@@ -62,9 +62,9 @@
             ~else)))))
 
 (def ^{:arglists '([[& preds]])} -every-pred
-  #?(:clj (-pred-composer and 16)
+  #?(:clj  (-pred-composer and 16)
      :cljs (fn [preds] (fn [m] (boolean (reduce #(or (%2 m) (reduced false)) true preds))))))
 
 (def ^{:arglists '([[& preds]])} -some-pred
-  #?(:clj (-pred-composer or 16)
+  #?(:clj  (-pred-composer or 16)
      :cljs (fn [preds] (fn [x] (boolean (some #(% x) preds))))))


### PR DESCRIPTION
## 0.12.0 (2023-08-31)

* FIX: retain order with `:catn` unparse, fixes [#925](https://github.com/metosin/malli/issues/925)
* **BREAKING**: Do not require timezone data directly for cljs [#898](https://github.com/metosin/malli/pull/898) with `malli.experimental.time`
* Remove non-root swagger definitions [#900](https://github.com/metosin/malli/pull/900)
* FIX: `malli.core/-comp` keeps interceptor order with long chains [#905](https://github.com/metosin/malli/pull/905)
* FIX: `malli.dev/start!` exception does not contain source [#896](https://github.com/metosin/malli/issues/896)
* FIX: don't add extra :schema nil to swagger :parameters [#939](https://github.com/metosin/malli/pull/939)
* Add `:gen/return` support in malli.generator [#933](https://github.com/metosin/malli/pull/933)
* Make uuid transformer to be case insensitive [#929](https://github.com/metosin/malli/pull/929)
* Add `:default/fn` prop for default-value-transformer [#927](https://github.com/metosin/malli/pull/927)

```clojure
borkdude/edamame 1.3.20 -> 1.3.23
```