### PR TITLE
fix: -string->double for cljs shouldn't allow trailing garbage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## Unreleased
+
+* **BREAKING**: `decode` for `:double` and `double?` in cljs doesn't allow trailing garbage any more [#942](https://github.com/metosin/malli/pull/942)
+
 ## 0.12.0 (2023-08-31)
 
 * FIX: retain order with `:catn` unparse, fixes [#925](https://github.com/metosin/malli/issues/925)

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -68,9 +68,7 @@
 
 (defn -string->double [x]
   (if (string? x)
-    (try #?(:clj  (Double/parseDouble x)
-            :cljs (let [x' (js/Number x)] (if (js/isNaN x') x x')))
-         (catch #?(:clj Exception, :cljs js/Error) _ x))
+    (or (parse-double x) x)
     x))
 
 (defn -number->double [x]

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -69,7 +69,7 @@
 (defn -string->double [x]
   (if (string? x)
     (try #?(:clj  (Double/parseDouble x)
-            :cljs (let [x' (js/parseFloat x)] (if (js/isNaN x') x x')))
+            :cljs (let [x' (js/Number x)] (if (js/isNaN x') x x')))
          (catch #?(:clj Exception, :cljs js/Error) _ x))
     x))
 

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -40,6 +40,7 @@
   (is (= 1.0 (mt/-string->double "1")))
   (is (= 1.0 (mt/-string->double 1.0)))
   (is (= 1 (mt/-string->double 1)))
+  (is (= "1.0abba" (mt/-string->double "1.0abba")))
   (is (= "abba" (mt/-string->double "abba"))))
 
 (deftest string->keyword
@@ -134,6 +135,7 @@
       (is (= "1" (m/decode int? "1" mt/json-transformer)))
       (is (= 1.0 (m/decode double? 1 mt/json-transformer)))
       (is (= 1 (m/decode double? 1 mt/string-transformer)))
+      (is (= "1.0x" (m/decode double? "1.0x" mt/string-transformer)))
       (is (= :user/kikka (m/decode keyword? "user/kikka" mt/string-transformer))))
     (testing "encode"
       (is (= "1" (m/encode int? 1 mt/string-transformer)))


### PR DESCRIPTION
(js/parseFloat "1.2abba") ==> 1.2

This was a difference between clj and cljs behaviour, but didn't have
a test.

Potentially a breaking change since somebody could've unknowingly
relied on this.