### PR TITLE
don't pretend to support clojure 1.10

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -14,7 +14,7 @@ jobs:
         # Supported Java versions: LTS releases and latest
         # TODO: Replace 19=>20 when available
         jdk: [8, 11, 17, 19]
-        clojure: [10, 11]
+        clojure: [11]
 
     name: Clojure ${{ matrix.clojure }} (Java ${{ matrix.jdk }})
 

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # Should work if the env var is empty
-clojure -A:$CLOJURE -M:test -m kaocha.runner "$@"
+clojure -A:$CLOJURE_ALIAS -M:test -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -77,5 +77,4 @@
                   :jvm-opts ["-server"
                              "-Xmx4096m"
                              "-Dclojure.compiler.direct-linking=true"]}
-           :clojure-10 {:extra-deps {org.clojure/clojure {:mvn/version "1.10.3"}}}
            :clojure-11 {}}}


### PR DESCRIPTION
We weren't really running tests on clojure 1.10 due to a mistake in the CI script (see first commit). Unsurprisingly the tests don't pass on 1.10 due to code using new functions like `random-uuid`.

Drop the fake 1.10 testing.