### PR TITLE
doc: document dropping clojure 1.10 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Malli is in well matured [alpha](README.md#alpha).
 ## Unreleased
 
 * **BREAKING**: `decode` for `:double` and `double?` in cljs doesn't allow trailing garbage any more [#942](https://github.com/metosin/malli/pull/942)
+* Officially drop Clojure 1.10 support. Tests haven't passed for some time with Clojure 1.10, but this was not noticed due to a faulty CI setup.
 
 ## 0.12.0 (2023-08-31)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ So, we decided to spin out our own library, which would do all the things we fee
 
 [![Clojars Project](http://clojars.org/metosin/malli/latest-version.svg)](http://clojars.org/metosin/malli)
 
-Malli requires Clojure 1.10+ and is tested against 1.10 and 1.11.
+Malli requires Clojure 1.11.
 
 ## Syntax
 


### PR DESCRIPTION
follow-up to #644