### PR TITLE
Improve map gen creation performance

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -476,13 +476,16 @@
 (defn- -create-from-elements [props]
   (some-> (:gen/elements props) gen-elements))
 
+(extend-protocol Generator
+  Object
+  (-generator [schema options]
+    (-schema-generator schema (assoc options ::original-generator-schema schema))))
+
 (defn- -create-from-gen
   [props schema options]
   (or (:gen/gen props)
       (when-not (:gen/elements props)
-        (if (satisfies? Generator schema)
-          (-generator schema options)
-          (-schema-generator schema (assoc options ::original-generator-schema schema))))))
+        (-generator schema options))))
 
 (defn- -create-from-schema [props options]
   (some-> (:gen/schema props) (generator options)))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -501,8 +501,8 @@
                   (gen/return nil)))))
 
 (defn- -create [schema options]
-  (let [props (merge (m/type-properties schema)
-                     (m/properties schema))]
+  (let [props (-merge (m/type-properties schema)
+                      (m/properties schema))]
     (or (-create-from-fmap props schema options)
         (-create-from-return props)
         (-create-from-elements props)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -435,7 +435,7 @@
 
 (defmethod -schema-generator :maybe [schema options]
   (let [g (-> schema (m/children options) first (generator options) -not-unreachable)]
-    (gen-one-of (cond-> [(gen/return nil)]
+    (gen-one-of (cond-> [nil-gen]
                   g (conj g)))))
 
 (defmethod -schema-generator :tuple [schema options]
@@ -446,7 +446,7 @@
 #?(:clj (defmethod -schema-generator :re [schema options] (-re-gen schema options)))
 (defmethod -schema-generator :any [_ _] (ga/gen-for-pred any?))
 (defmethod -schema-generator :some [_ _] gen/any-printable)
-(defmethod -schema-generator :nil [_ _] (gen/return nil))
+(defmethod -schema-generator :nil [_ _] nil-gen)
 (defmethod -schema-generator :string [schema options] (-string-gen schema options))
 (defmethod -schema-generator :int [schema options] (gen/large-integer* (-min-max schema options)))
 (defmethod -schema-generator :double [schema options]
@@ -514,7 +514,7 @@
                   (-create-from-elements props)
                   (-create-from-schema props options)
                   (-create-from-gen props schema options)
-                  (gen/return nil)))))
+                  nil-gen))))
 
 (defn- -create [schema options]
   (let [props (-merge (m/type-properties schema)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -9,6 +9,7 @@
             [clojure.test.check.rose-tree :as rose]
             [malli.core :as m]
             [malli.registry :as mr]
+            [malli.impl.util :refer [-not-any? -last -merge]]
             #?(:clj [borkdude.dynaload :as dynaload])))
 
 (declare generator generate -create)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -494,7 +494,7 @@
   (some-> (:gen/elements props) gen-elements))
 
 (extend-protocol Generator
-  Object
+  #?(:clj Object, :cljs default)
   (-generator [schema options]
     (-schema-generator schema (assoc options ::original-generator-schema schema))))
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -48,6 +48,8 @@
 ;;   [:vector M] would generate like [:= []] if M were unreachable.
 ;;   [:vector {:min 1} M] would itself be unreachable if M were unreachable.
 
+(def nil-gen (gen/return nil))
+
 (defn -never-gen
   "Return a generator of no values that is compatible with -unreachable-gen?."
   [{::keys [original-generator-schema] :as _options}]

--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -68,3 +68,23 @@
 (def ^{:arglists '([[& preds]])} -some-pred
   #?(:clj  (-pred-composer or 16)
      :cljs (fn [preds] (fn [x] (boolean (some #(% x) preds))))))
+
+(defn -last [x]
+  (if (vector? x)
+    (peek x)
+    (last x)))
+
+(defn -some
+  [pred coll]
+  (reduce
+   (fn [ret x] (if (pred x) (reduced true) ret))
+   nil
+   coll))
+
+(defn -not-any? [pred coll] (not (-some pred coll)))
+
+(defn -merge
+  [m1 m2]
+  (if m1
+    (persistent! (reduce-kv assoc! (transient m1) m2))
+    m2))


### PR DESCRIPTION
This MR improves the performance for creating a map gen ~x5, mostly by removing a call to `satisfies?`, and further by choosing performant functions in the implementation.