### PR TITLE
Use clj-kondo `:seqable` for `:+`, `:*`, and `:?` not `{:op :rest}`

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -124,15 +124,15 @@
 (defmethod accept :qualified-symbol [_ _ _ _] :symbol)
 (defmethod accept :uuid [_ _ _ _] :any) ;;??
 
-(defn -seqable-or-rest [_ _ [child] {:keys [arity]}]
+(defn -seqable-or-rest [[child] {:keys [arity]}]
   (if (= arity :varargs)
     {:op :rest :spec child}
     :seqable))
 
-(defmethod accept :+ [_ _  children options] (-seqable-or-rest nil nil children options))
-(defmethod accept :* [_ _  children options] (-seqable-or-rest nil nil children options))
-(defmethod accept :? [_ _  children options] (-seqable-or-rest nil nil children options))
-(defmethod accept :repeat [_ _  children options] (-seqable-or-rest nil nil children options))
+(defmethod accept :+ [_ _  children options] (-seqable-or-rest children options))
+(defmethod accept :* [_ _  children options] (-seqable-or-rest children options))
+(defmethod accept :? [_ _  children options] (-seqable-or-rest children options))
+(defmethod accept :repeat [_ _  children options] (-seqable-or-rest children options))
 
 (defmethod accept :cat [_ _ children _] children)
 (defmethod accept :catn [_ _ children _] (mapv last children))

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -124,9 +124,9 @@
 (defmethod accept :qualified-symbol [_ _ _ _] :symbol)
 (defmethod accept :uuid [_ _ _ _] :any) ;;??
 
-(defmethod accept :+ [_ _ [child] _] {:op :rest, :spec child})
-(defmethod accept :* [_ _ [child] _] {:op :rest, :spec child})
-(defmethod accept :? [_ _ [child] _] {:op :rest, :spec child})
+(defmethod accept :+ [_ _ _ _] :seqable)
+(defmethod accept :* [_ _ _ _] :seqable)
+(defmethod accept :? [_ _ _ _] :seqable)
 (defmethod accept :repeat [_ _ [child] _] {:op :rest, :spec child})
 (defmethod accept :cat [_ _ children _] children)
 (defmethod accept :catn [_ _ children _] (mapv last children))

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -40,6 +40,18 @@
 
 (m/=> siren [:=> [:cat ifn? coll?] map?])
 
+(defn clj-kondo-issue-1922-1 [_x])
+(m/=> clj-kondo-issue-1922-1
+      [:=> [:cat [:map [:keys [:+ :keyword]]]] :nil])
+
+(defn clj-kondo-issue-1922-2 [_x])
+(m/=> clj-kondo-issue-1922-2
+      [:=> [:cat [:map [:keys [:* :int]]]] :nil])
+
+(defn clj-kondo-issue-1922-3 [_x])
+(m/=> clj-kondo-issue-1922-3
+      [:=> [:cat [:map [:keys [:? :string]]]] :nil])
+
 (deftest clj-kondo-integration-test
 
   (is (= {:op :keys,
@@ -63,11 +75,27 @@
          {'kikka
           {:arities {1 {:args [:int],
                         :ret :int},
-                     :varargs {:args [:int :int {:op :rest, :spec :int}],
+                     :varargs {:args [:int :int :seqable],
                                :ret :int,
                                :min-arity 2}}}
           'siren
-          {:arities {2 {:args [:ifn :coll], :ret :map}}}}}]
+          {:arities {2 {:args [:ifn :coll], :ret :map}}}
+
+          'clj-kondo-issue-1922-1
+          {:arities {1 {:args [{:op :keys
+                                :req {:keys :seqable}}]
+                        :ret :nil}}}
+
+          'clj-kondo-issue-1922-2
+          {:arities {1 {:args [{:op :keys
+                                :req {:keys :seqable}}]
+                        :ret :nil}}}
+
+          'clj-kondo-issue-1922-3
+          {:arities {1 {:args [{:op :keys
+                                :req {:keys :seqable}}]
+                        :ret :nil}}}}}]
+
     #?(:clj
        (is (= expected-out
               (-> 'malli.clj-kondo-test

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -52,6 +52,12 @@
 (m/=> clj-kondo-issue-1922-3
       [:=> [:cat [:map [:keys [:? :string]]]] :nil])
 
+(defn clj-kondo-issue-1922-4 [_x])
+(m/=> clj-kondo-issue-1922-4
+      [:function
+       [:=> [:cat :int :int] :nil]
+       [:=> [:cat :int :int [:repeat :int]] :nil]])
+
 (deftest clj-kondo-integration-test
 
   (is (= {:op :keys,
@@ -75,7 +81,7 @@
          {'kikka
           {:arities {1 {:args [:int],
                         :ret :int},
-                     :varargs {:args [:int :int :seqable],
+                     :varargs {:args [:int :int {:op :rest :spec :int}],
                                :ret :int,
                                :min-arity 2}}}
           'siren
@@ -94,7 +100,14 @@
           'clj-kondo-issue-1922-3
           {:arities {1 {:args [{:op :keys
                                 :req {:keys :seqable}}]
-                        :ret :nil}}}}}]
+                        :ret :nil}}}
+
+          'clj-kondo-issue-1922-4
+          {:arities {2 {:args [:int :int]
+                        :ret :nil}
+                     :varargs {:args [:int :int {:op :rest :spec :int}]
+                               :ret :nil
+                               :min-arity 2}}}}}]
 
     #?(:clj
        (is (= expected-out
@@ -110,11 +123,11 @@
                   (clj-kondo/linter-config)
                   (get-in [:linters :type-mismatch :namespaces]))))))
   (testing "sequential elements"
-    (is (= {:op :rest :spec :int}
+    (is (= :seqable
            (clj-kondo/transform [:repeat :int])))
-    (is (= {:op :rest :spec {:op :keys :req {:price :int}}}
+    (is (= :seqable
            (clj-kondo/transform [:repeat [:map [:price :int]]])))
-    (is (= {:op :rest :spec [:int]}
+    (is (= :seqable
            (clj-kondo/transform [:repeat [:tuple :int]]))))
 
   (testing "regular expressions"


### PR DESCRIPTION
Update clj-kondo type generation. `{:op :rest}` should be used only for varargs.

```
This can be used to match remaining arguments in vararg signatures.

https://github.com/clj-kondo/clj-kondo/blob/master/doc/types.md
```

Setup for validating the changes with clj-kondo: https://github.com/tvaisanen/clj-kondo-malli-error-2022-12-20

closes #820 