### PR TITLE
feat(assert): adds new assert-like functionality to check malli schema

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1,5 +1,5 @@
 (ns malli.core
-  (:refer-clojure :exclude [eval type -deref deref -lookup -key])
+  (:refer-clojure :exclude [eval type -deref deref -lookup -key assert])
   #?(:cljs (:require-macros malli.core))
   (:require #?(:clj [clojure.walk :as walk])
             [clojure.core :as c]
@@ -2229,6 +2229,18 @@
   ([?schema value transformer options] (coerce ?schema value transformer nil nil options))
   ([?schema value transformer respond raise] (coerce ?schema value transformer respond raise nil))
   ([?schema value transformer respond raise options] ((coercer ?schema transformer respond raise options) value)))
+
+(defmacro assert
+  "Assert that `value` validates against schema `?schema`, or throws ExceptionInfo.
+   The var clojure.core/*assert* determines whether assertion are checked."
+
+  ([?schema value]
+   `(assert ~?schema ~value nil))
+
+  ([?schema value options]
+   (if *assert*
+     `(coerce ~?schema ~value nil ~options)
+     value)))
 
 (defn entries
   "Returns `EntrySchema` children as a sequence of `clojure.lang/MapEntry`s

--- a/src/malli/dev/virhe.cljc
+++ b/src/malli/dev/virhe.cljc
@@ -25,7 +25,9 @@
   (let [colors (:colors printer -dark-colors)
         color (get colors color (:error colors))]
     #?(:cljs [:span body]
-       :clj  [:span [:pass (str "\033[38;5;" color "m")] body [:pass "\u001B[0m"]])))
+       :clj (if color
+              [:span [:pass (str "\033[38;5;" color "m")] body [:pass "\u001B[0m"]]
+              [:span body]))))
 
 ;;
 ;; EDN

--- a/test/malli/assert_test.cljc
+++ b/test/malli/assert_test.cljc
@@ -1,0 +1,29 @@
+(ns malli.assert-test
+  (:refer-clojure :exclude [assert])
+  (:require
+   [clojure.test :refer [deftest is]]
+   [malli.core :refer [assert]]))
+
+
+(set! *assert* true)
+
+(deftest assert-throws-test
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (assert :int "42" )))
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (assert int? "42" )))
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (assert string? 42)))
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (assert int? nil)))
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (assert [:map [:a int?]] {:a "42"})))
+  (is (thrown? #?(:clj Exception, :cljs js/Error)
+               (assert ::invalid-schema 42))))
+
+(deftest assert-checked-and-does-not-throw
+  (is (= 42 (assert :int 42 )))
+  (is (= 42 (assert int? 42 )))
+  (is (= "42" (assert string? "42")))
+  (is (= nil (assert any? nil)))
+  (is (= {:a 42} (assert [:map [:a int?]] {:a 42}))))


### PR DESCRIPTION
First *draft* of assert functionality, 

Couple explanations on approach here
(1) the on/off switch for assert checking is modeled off of clojure.core/assert, not clojure.spec.alpha, the latter uses volatile! for on/off switch... the former is more efficient because if assertions are disabled, it won't exist in byte-code. I'm open to changing it, but that's my preference. 

(2) I added 'no color' / 'nil color' to virhe, in order to play nicely with emacs which won't render ANSI color codes in stack traces by default. 

(3) This is in malli.assert namespace temporarily, just let me know where you want it. 

![image](https://github.com/metosin/malli/assets/550839/917f08ea-7d73-4791-b4c5-f813cf34ce69)
