### PR TITLE
Add missing dependency to malli.dev.cljs

### DIFF
--- a/src/malli/dev/cljs.cljc
+++ b/src/malli/dev/cljs.cljc
@@ -1,7 +1,8 @@
 (ns malli.dev.cljs
   #?(:cljs (:require-macros [malli.dev.cljs]))
   #?(:cljs (:require [malli.core :as m]
-                     [malli.dev.pretty :as pretty]))
+                     [malli.dev.pretty :as pretty]
+                     [malli.instrument]))
   #?(:clj (:require [cljs.analyzer.api :as ana-api]
                     [malli.clj-kondo :as clj-kondo]
                     [malli.core :as m]


### PR DESCRIPTION
`malli.dev.cljs/start!` references `malli.instrument` and therefore should require it from `:cljs` context.