### PR TITLE
Add :time/period schema to experimental.time

### DIFF
--- a/src/malli/experimental/time/transform.cljc
+++ b/src/malli/experimental/time/transform.cljc
@@ -2,10 +2,10 @@
   (:require [malli.transform :as mt :refer [-safe]]
             [malli.core :as m]
             #?(:cljs [malli.experimental.time :as time
-                      :refer [Duration LocalDate LocalDateTime LocalTime Instant OffsetTime ZonedDateTime OffsetDateTime ZoneId ZoneOffset
+                      :refer [Duration Period LocalDate LocalDateTime LocalTime Instant OffsetTime ZonedDateTime OffsetDateTime ZoneId ZoneOffset
                               TemporalAccessor TemporalQuery DateTimeFormatter createTemporalQuery]]))
   #?(:clj
-     (:import (java.time Duration LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId OffsetTime ZoneOffset)
+     (:import (java.time Duration Period LocalDate LocalDateTime LocalTime Instant ZonedDateTime OffsetDateTime ZoneId OffsetTime ZoneOffset)
               (java.time.temporal TemporalAccessor TemporalQuery)
               (java.time.format DateTimeFormatter))))
 
@@ -56,6 +56,7 @@
   (reduce-kv
    (fn [m k v] (assoc m k (-safe (->parser v (get queries k)))))
    {:time/duration (-safe #(. Duration parse %))
+    :time/period (-safe #(. Period parse %))
     :time/zone-offset (-safe #(. ZoneOffset of ^String %))
     :time/zone-id (-safe #(. ZoneId of %))}
    default-formats))
@@ -79,6 +80,7 @@
 (defn time-encoders [formats]
   (into
    {:time/duration str
+    :time/period str
     :time/zone-id str}
    (for [k (keys formats)]
      [k {:compile

--- a/test/malli/experimental/time/generator_test.cljc
+++ b/test/malli/experimental/time/generator_test.cljc
@@ -16,6 +16,7 @@
 (t/deftest generator-test
   (t/testing "simple schemas"
     (t/is (exercise :time/duration))
+    (t/is (exercise :time/period))
     (t/is (exercise :time/zone-id))
     (t/is (exercise :time/zone-offset))
     (t/is (exercise :time/instant))

--- a/test/malli/experimental/time/transform_test.cljc
+++ b/test/malli/experimental/time/transform_test.cljc
@@ -16,6 +16,10 @@
   (t/testing "Duration"
     (t/is (validate :time/duration "PT0.01S"))
     (t/is (not (validate :time/duration 10))))
+  (t/testing "Period"
+    (t/is (validate :time/period "P-1Y10D"))
+    (t/is (validate :time/period "P-1Y8M"))
+    (t/is (not (validate :time/period 10))))
   (t/testing "zone id"
     (t/is (validate :time/zone-id "UTC"))
     (t/is (not (validate :time/zone-id "UTC'"))))


### PR DESCRIPTION
Adds `:time/period` to the experimental time schemas.