### PR TITLE
Malli tuple should generate clj-kondo seqable

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -100,7 +100,7 @@
     (= :keys (:op child)) (assoc child :nilable true)
     (and (keyword? child) (not= :any child)) (keyword "nilable" (name child))
     :else child))
-(defmethod accept :tuple [_ _ children _] children)
+(defmethod accept :tuple [_ _ _ _] :seqable)
 (defmethod accept :multi [_ _ _ _] :any) ;;??
 (defmethod accept :re [_ _ _ _] :string)
 (defmethod accept :fn [_ _ _ _] :fn)

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -18,6 +18,7 @@
     [:xyz :any]
     [:xyz2 [:maybe :any]]
     [:xyz3 [:maybe :int]]
+    [:tuple-of-ints [:maybe [:tuple :int :int]]]
     [:nested [:merge
               [:map [:id ::id]]
               [:map [:price ::price]]]]
@@ -73,7 +74,8 @@
                 :string-type-enum :nilable/string
                 :keyword-type-enum :keyword
                 :any-type-enum :any
-                :z :vector}}
+                :z :vector
+                :tuple-of-ints :nilable/seqable}}
          (clj-kondo/transform Schema)))
 
   (let [expected-out


### PR DESCRIPTION
The existing malli code generated invalid clj-kondo config. 

Before:
`[:tuple :int :int] => [:int :int]`

After
`[:tuple :int :int] => :seqable`

Context: https://clojurians.slack.com/archives/CHY97NXE2/p1676474936435069