### PR TITLE
Fixing strip-extra-keys-transformer for recursive map encoding

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -381,16 +381,18 @@
                                                    (if (and (map? x) (not default-schema))
                                                      (reduce-kv (fn [acc k _] (if-not (ks k) (dissoc acc k) acc)) x x)
                                                      x))))))}
-         strip-map-of {:compile (fn [schema options]
-                                  (let [entry-schema (m/into-schema :tuple nil (m/children schema) options)
-                                        valid? (m/validator entry-schema options)]
-                                    {:leave (fn [x] (reduce (fn [acc entry]
+         strip-map-of (fn [stage]
+                        {:compile (fn [schema options]
+                                    (let [entry-schema (m/into-schema :tuple nil (m/children schema) options)
+                                          valid?       (m/validator entry-schema options)]
+                                      {stage (fn [x]
+                                              (reduce (fn [acc entry]
                                                               (if (valid? entry)
                                                                 (apply assoc acc entry)
-                                                                acc)) (empty x) x))}))}]
+                                                                acc)) (empty x) x))}))})]
      (transformer
-      {:decoders {:map strip-map, :map-of strip-map-of}
-       :encoders {:map strip-map, :map-of strip-map-of}}))))
+       {:decoders {:map strip-map, :map-of (strip-map-of :leave)}
+        :encoders {:map strip-map, :map-of (strip-map-of :enter)}}))))
 
 (defn key-transformer [{:keys [decode encode types] :or {types #{:map}}}]
   (let [transform (fn [f stage] (when f {stage (-transform-map-keys f)}))]


### PR DESCRIPTION
This PR fixes an issue when `strip-extra-keys-transformer` was used to encode the `:map-of` used in a recursive way. Transformer needs to run before the encoder otherwise it sees already encoded value which does not pass the validation. 

There is a pending issue when an invalid key in `:map-of` instead of being removed from the value invalidates the whole `:map-of`. This would probably require recursive validation, which may add some computational complexity.