### PR TITLE
refactor(core): support passing custom ':type' in into-schema opt for :map and :map-of

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -956,7 +956,7 @@
      AST
      (-from-ast [parent ast options] (-from-entry-ast parent ast options))
      IntoSchema
-     (-type [_] :map)
+     (-type [_] (:type opts :map))
      (-type-properties [_] (:type-properties opts))
      (-properties-schema [_ _])
      (-children-schema [_ _])
@@ -1091,7 +1091,7 @@
      (-from-ast [parent ast options]
        (-into-schema parent (:properties ast) [(from-ast (:key ast) options) (from-ast (:value ast) options)] options))
      IntoSchema
-     (-type [_] :map-of)
+     (-type [_] (:type opts :map-of))
      (-type-properties [_] (:type-properties opts))
      (-properties-schema [_ _])
      (-children-schema [_ _])


### PR DESCRIPTION
since the into-schema/'higher kinded schema' `:map`'s uses `map?` as its predicate, and no instance of datomic.query.EntityMap is a `map?` but supports most of the interfaces&protocols, i need to define my own variant, namely `:entity-map`, i saw you support changing the predicate, so why not the `:type` tag as well? This PR does that.

<img width="837" alt="image" src="https://github.com/metosin/malli/assets/550839/9feeae4e-c647-46b9-b390-3ee3189b4a5c">
