### PR TITLE
fix path->in with :orn, :catn and :altn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* `mu/path->in` works with `:orn`, `:catn` and `:altn`.
+
 ## 0.13.0 (2023-09-24)
 
 * **BREAKING** Fallback to use result of first branch when decoding `:or` and `:orn`, [#946](https://github.com/metosin/malli/pull/946) 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -772,7 +772,20 @@
                   [:a [:maybe [:sequential [:maybe [:map [:b [:and [:or int?]]]]]]]]]]
                 [:fn '(constantly true)]]
                (m/schema)
-               (mu/in->paths [:a 0 :b]))))))
+               (mu/in->paths [:a 0 :b])))))
+  (testing "orn, catn and altn don't contribute to :in"
+    (are [type value]
+      (= [:a]
+         (let [schema (m/schema [type [:a-branch [:map [:a :int]]]])]
+           (->> (m/explain schema value)
+                :errors
+                first
+                :path
+                (mu/path->in schema))))
+
+      :orn {:a "2"}
+      :catn [{:a "2"}]
+      :altn [{:a "2"}])))
 
 (deftest declarative-schemas
   (let [->> #(m/schema % {:registry (merge (mu/schemas) (m/default-schemas))})]


### PR DESCRIPTION
this is wrong:

```clojure
(require '[malli.core :as m ]) 
  (def my-schema
    (m/schema [:orn
               [:a-branch [:map [:a :int]]]
               [:b-branch [:map [:b :int]]]]))   

  (let [{:keys [errors schema]} (m/explain my-schema {:a "2"})]
    (mu/path->in schema (:path (first errors))))
;;=>
[:a-branch :a]
```

PR fixes it.