### PR TITLE
mu/deref-recursive

### DIFF
--- a/docs/tips.md
+++ b/docs/tips.md
@@ -539,33 +539,3 @@ Example utility to convert schemas recursively:
 ;                [:int {:gen/elements [1 2 3]}]
 ;                :string]]]]]
 ```
-
-## De-reference schemas from a registry
-
-When transforming schemas, if they are provided by a registry, it's useful to dereference them first.
-
-```clojure
-(defn deref-recursive
-  "deref all schemas at all levels so the resulting schema has no registry references"
-  [schema]
-  (m/walk schema
-          (m/schema-walker m/deref-all)
-          {::m/walk-schema-refs true
-           ::m/walk-refs        true}))
-
-(def smart-phone
-  (m/schema "smart-phone"
-            {:registry (merge (m/default-schemas)
-                              {"smart-phone" [:map
-                                              [:type [:enum :android :iphone]]
-                                              [:connector "connector"]]
-                               "connector"   [:enum :usb-c :micro-usb :lightning]})}))
-
-(deref-recursive smart-phone)
-=> [:map 
-    [:type [:enum :android :iphone]] 
-    [:connector [:enum :usb-c :micro-usb :lightning]]]
-```
-
-The fully de-referenced schema is plain data which is much easier to transform. 
-

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -217,6 +217,20 @@
   ([?schema value options]
    ((data-explainer ?schema options) value [] [])))
 
+(defn deref-recursive
+  "derefs all schemas at all levels. Does not walk over `:ref`s."
+  ([?schema]
+   (deref-recursive ?schema nil))
+  ([?schema options]
+   (let [schema (m/schema ?schema options)]
+     (-> (m/walk schema (fn [schema _ children _]
+                          (cond
+                            (= :ref (m/type schema)) schema
+                            (m/-ref-schema? schema) (first children)
+                            :else (m/-set-children schema children)))
+                 {::m/walk-schema-refs true})
+         (m/deref-all)))))
+
 ;;
 ;; EntrySchemas
 ;;

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -1005,6 +1005,6 @@
         expected [:map
                   [:id :uuid]
                   [:name :string]
-                  [:friends {:optional true} [:set [:ref :user/user]]]
+                  [:friends {:optional true} [:set [:ref ::user]]]
                   [:address [:map [:street :string] [:lonlat {:optional true} [:tuple :double :double]]]]]]
     (is (= expected (m/form (mu/deref-recursive schema))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -1007,4 +1007,4 @@
                   [:name :string]
                   [:friends {:optional true} [:set [:ref :user/user]]]
                   [:address [:map [:street :string] [:lonlat {:optional true} [:tuple :double :double]]]]]]
-    (= expected (m/form (mu/deref-recursive schema)))))
+    (is (= expected (m/form (mu/deref-recursive schema))))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -990,3 +990,21 @@
                  (mu/assoc-in [:foo :bar] :int)
                  (mu/assoc-in [:foo :baz] :int)
                  (mu/closed-schema)))))
+
+(deftest deref-recursive-test
+  (let [schema [:schema {:registry {::user-id :uuid
+                                    ::address [:map
+                                               [:street :string]
+                                               [:lonlat {:optional true} [:tuple :double :double]]]
+                                    ::user [:map
+                                            [:id ::user-id]
+                                            [:name :string]
+                                            [:friends {:optional true} [:set [:ref ::user]]]
+                                            [:address ::address]]}}
+                ::user]
+        expected [:map
+                  [:id :uuid]
+                  [:name :string]
+                  [:friends {:optional true} [:set [:ref :user/user]]]
+                  [:address [:map [:street :string] [:lonlat {:optional true} [:tuple :double :double]]]]]]
+    (= expected (m/form (mu/deref-recursive schema)))))

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -1006,5 +1006,7 @@
                   [:id :uuid]
                   [:name :string]
                   [:friends {:optional true} [:set [:ref ::user]]]
-                  [:address [:map [:street :string] [:lonlat {:optional true} [:tuple :double :double]]]]]]
+                  [:address [:map
+                             [:street :string]
+                             [:lonlat {:optional true} [:tuple :double :double]]]]]]
     (is (= expected (m/form (mu/deref-recursive schema))))))


### PR DESCRIPTION
Helper to de-ref schemas (not `:ref`s recursively):

```clojure
(deftest deref-recursive-test
  (let [schema [:schema {:registry {::user-id :uuid
                                    ::address [:map
                                               [:street :string]
                                               [:lonlat {:optional true} [:tuple :double :double]]]
                                    ::user [:map
                                            [:id ::user-id]
                                            [:name :string]
                                            [:friends {:optional true} [:set [:ref ::user]]]
                                            [:address ::address]]}}
                ::user]
        expected [:map
                  [:id :uuid]
                  [:name :string]
                  [:friends {:optional true} [:set [:ref ::user]]]
                  [:address [:map
                             [:street :string]
                             [:lonlat {:optional true} [:tuple :double :double]]]]]]
    (is (= expected (m/form (mu/deref-recursive schema))))))
```