### PR TITLE
Allow qualified symbols as references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Malli is in well matured [alpha](README.md#alpha).
   * does not log individual re-instrumentation of function vars
   * **BREAKING**: changes in `malli.dev.virhe` and `malli.pretty` extension apis, wee [#980](https://github.com/metosin/malli/pull/980) for details
 * **BREAKING**: `m/coerce` and `m/coercer` throw `::m/coercion` instead of `::m/invalid-input`
-* **BREAKING**: qualified symbols are valid reference types 
+* **BREAKING**: qualified symbols are valid reference types [#984](https://github.com/metosin/malli/pull/984) 
 * Fixing `mt/strip-extra-keys-transformer` for recursive map encoding [#963](https://github.com/metosin/malli/pull/963)
 * Support passing custom `:type` in into-schema opt for `:map` and `:map-of` [#968](https://github.com/metosin/malli/pull/968)
 * `mu/path->in` works with `:orn`, `:catn` and `:altn`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Malli is in well matured [alpha](README.md#alpha).
   * does not log individual re-instrumentation of function vars
   * **BREAKING**: changes in `malli.dev.virhe` and `malli.pretty` extension apis, wee [#980](https://github.com/metosin/malli/pull/980) for details
 * **BREAKING**: `m/coerce` and `m/coercer` throw `::m/coercion` instead of `::m/invalid-input`
+* **BREAKING**: qualified symbols are valid reference types 
 * Fixing `mt/strip-extra-keys-transformer` for recursive map encoding [#963](https://github.com/metosin/malli/pull/963)
 * Support passing custom `:type` in into-schema opt for `:map` and `:map-of` [#968](https://github.com/metosin/malli/pull/968)
 * `mu/path->in` works with `:orn`, `:catn` and `:altn`.

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -167,7 +167,7 @@
 
 (defn -pointer [id schema options] (-into-schema (-schema-schema {:id id}) nil [schema] options))
 
-(defn -reference? [?schema] (or (string? ?schema) (qualified-keyword? ?schema)))
+(defn -reference? [?schema] (or (string? ?schema) (qualified-ident? ?schema)))
 
 (defn -lazy [ref options] (-into-schema (-ref-schema {:lazy true}) nil [ref] options))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -1948,21 +1948,21 @@
                  options))))))
 
 (deftest custom-registry-qualified-keyword-in-map-test
-  (let [schema [:map {:registry {::id int?
-                                 ::location [:tuple :int :int]
-                                 ::country string?}}
-                ::id
-                [::location]
+  (let [schema [:map {:registry {:user/id int?
+                                 "user/location" [:tuple :int :int]
+                                 'user/country string?}}
+                :user/id
+                ["user/location"]
                 [:name string?]
-                [::country {:optional true}]]]
+                ['user/country {:optional true}]]]
 
-    (testing "Example with qualified keyword + optional, regular key"
-      (is (m/validate schema {::id 123 ::location [1 1] ::country "Finland" :name "Malli"})))
+    (testing "Example with references + optional, regular key"
+      (is (m/validate schema {:user/id 123 "user/location" [1 1] 'user/country "Finland" :name "Malli"})))
 
     (testing "Optional qualified keyword is optional"
-      (is (m/validate schema {::id 123 ::location [1 1] :name "Malli"}))))
+      (is (m/validate schema {:user/id 123 "user/location" [1 1] :name "Malli"}))))
 
-  (testing "invalid ref"
+  (testing "invalid entry"
     (is (thrown-with-msg?
          #?(:clj Exception, :cljs js/Error) #":malli.core/invalid-entry"
          (m/schema [:map {:registry {:kikka :int}} :int])))))


### PR DESCRIPTION
```clojure
(m/validate
 [:map {:registry {:user/id :int
                   "user/name" :string
                   'user/country [:enum "UA"]}}
  :user/id 
  "user/name" 
  'user/country]
 {:user/id 123
  "user/name" "Tiina"
  'user/country "UA"})
; => true
```