### PR TITLE
Support Var-refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Malli is in well matured [alpha](README.md#alpha).
   * `malli.dev/start!` captures all malli-thrown exceptions, see [README](README.md#development-mode) for details
   * does not log individual re-instrumentation of function vars
   * **BREAKING**: changes in `malli.dev.virhe` and `malli.pretty` extension apis, wee [#980](https://github.com/metosin/malli/pull/980) for details
+* Support for Var references [#985](https://github.com/metosin/malli/pull/985), see [guide](README.md#var-registry) for details.
 * **BREAKING**: `m/coerce` and `m/coercer` throw `::m/coercion` instead of `::m/invalid-input`
 * **BREAKING**: qualified symbols are valid reference types [#984](https://github.com/metosin/malli/pull/984) 
 * Fixing `mt/strip-extra-keys-transformer` for recursive map encoding [#963](https://github.com/metosin/malli/pull/963)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Malli is in well matured [alpha](README.md#alpha).
   * **BREAKING**: changes in `malli.dev.virhe` and `malli.pretty` extension apis, wee [#980](https://github.com/metosin/malli/pull/980) for details
 * Support for Var references [#985](https://github.com/metosin/malli/pull/985), see [guide](README.md#var-registry) for details.
 * **BREAKING**: `m/coerce` and `m/coercer` throw `::m/coercion` instead of `::m/invalid-input`
+* New Guide for [Reusable Schemas](docs/reusable-schemas.md)
 * **BREAKING**: qualified symbols are valid reference types [#984](https://github.com/metosin/malli/pull/984) 
 * Fixing `mt/strip-extra-keys-transformer` for recursive map encoding [#963](https://github.com/metosin/malli/pull/963)
 * Support passing custom `:type` in into-schema opt for `:map` and `:map-of` [#968](https://github.com/metosin/malli/pull/968)

--- a/README.md
+++ b/README.md
@@ -2630,6 +2630,39 @@ Just a `Map`.
   {:maybe "sheep"})
 ; => true
 ```
+### Var registry
+
+Var is a valid reference type in Malli. To support auto-resolving Var references to Vars, `mr/var-registry` is needed.
+
+```clojure
+(mr/set-default-registry!
+ (mr/composite-registry
+  (m/default-schemas)
+  (mr/var-registry)))
+```
+
+Vars can be usedlike any other reference, recursion included:
+
+```clojure
+(def UserId :string)
+
+(def User
+  [:map
+   [:id #'UserId]
+   [:friends {:optional true} [:set [:ref #'User]]]])
+
+(mg/sample User {:seed 0})
+;({:id ""}
+; {:id "6", :friends #{{:id ""}}}
+; {:id ""}
+; {:id "4", :friends #{}}
+; {:id "24b7"}
+; {:id "Uo"}
+; {:id "8"}
+; {:id "z5b"}
+; {:id "R9f"}
+; {:id "lUm6Wj9gR"})
+```
 
 ### Mutable registry
 

--- a/README.md
+++ b/README.md
@@ -2632,16 +2632,7 @@ Just a `Map`.
 ```
 ### Var registry
 
-Var is a valid reference type in Malli. To support auto-resolving Var references to Vars, `mr/var-registry` is needed.
-
-```clojure
-(mr/set-default-registry!
- (mr/composite-registry
-  (m/default-schemas)
-  (mr/var-registry)))
-```
-
-Vars can be usedlike any other reference, recursion included:
+Var is a valid reference type in Malli. To support auto-resolving Var references to Vars, `mr/var-registry` is needed. It is enabled by default.
 
 ```clojure
 (def UserId :string)

--- a/docs/reusable-schemas.md
+++ b/docs/reusable-schemas.md
@@ -186,6 +186,7 @@ Here's a comparison matrix of the two different ways:
 |----------------------------------|:----:|:---------------:|:--------------:|
 | Supported by Malli               |  ✅   |        ✅        |       ✅        |
 | Explicit require of Schemas      |  ✅   |        ❌        |       ✅        |
+| Support Recursive Schemas        |  ✅   |        ✅        |       ✅        |
 | Decomplect Maps, Keys and Values |  ❌   |        ✅        |       ✅        |
 
 You should pick the way what works best for your project. 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -167,7 +167,7 @@
 
 (defn -pointer [id schema options] (-into-schema (-schema-schema {:id id}) nil [schema] options))
 
-(defn -reference? [?schema] (or (string? ?schema) (qualified-ident? ?schema)))
+(defn -reference? [?schema] (or (string? ?schema) (qualified-ident? ?schema) (var? ?schema)))
 
 (defn -lazy [ref options] (-into-schema (-ref-schema {:lazy true}) nil [ref] options))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2490,7 +2490,8 @@
 
 (def default-registry
   (let [strict (identical? mr/mode "strict")
-        registry (mr/fast-registry (if (identical? mr/type "custom") {} (default-schemas)))]
+        custom (identical? mr/type "custom")
+        registry (mr/fast-registry (if custom {} (default-schemas)))]
     (when-not strict (mr/set-default-registry! registry))
     (mr/registry (if strict registry (mr/custom-default-registry)))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2535,9 +2535,7 @@
    (try
      (swap! -function-schemas* assoc-in [key ns name] (merge data {:schema (f ?schema), :ns ns, :name name}))
      (catch #?(:clj Throwable :cljs :default) ex
-       (throw (ex-info
-               (str "Schema error when instrumenting function: " ns "/" name " - " (ex-message ex))
-               (ex-data ex)))))))
+       (-fail! ::register-function-schema {:ns ns, :name name, :schema ?schema, :data data, :key key, :exception ex})))))
 
 #?(:clj
    (defmacro => [given-sym value]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2491,7 +2491,7 @@
 (def default-registry
   (let [strict (identical? mr/mode "strict")
         custom (identical? mr/type "custom")
-        registry (mr/fast-registry (if custom {} (default-schemas)))]
+        registry (if custom (mr/fast-registry {}) (mr/composite-registry (mr/fast-registry (default-schemas)) (mr/var-registry)))]
     (when-not strict (mr/set-default-registry! registry))
     (mr/registry (if strict registry (mr/custom-default-registry)))))
 

--- a/src/malli/dev/pretty.cljc
+++ b/src/malli/dev/pretty.cljc
@@ -71,6 +71,15 @@
           #?(:cljs (v/-block "Function Var:" (v/-visit fn-name printer) printer)) :break :break
           (v/-block "More information:" (v/-link "https://cljdoc.org/d/metosin/malli/CURRENT/doc/function-schemas" printer) printer)]})
 
+(defmethod v/-format ::m/register-function-schema [_ {:keys [ns name schema _data key _exception]} printer]
+  {:title "Error in registering a Function Schema"
+   :body [:group
+          (v/-block "Function Var:" [:group
+                                     (v/-visit (symbol (str ns) (str name)) printer)
+                                     " (" (v/-visit key printer) ")"] printer) :break :break
+          (v/-block "Function Schema:" (v/-visit schema printer) printer) :break :break
+          (v/-block "More information:" (v/-link "https://cljdoc.org/d/metosin/malli/CURRENT/doc/function-schemas" printer) printer)]})
+
 (defmethod v/-format ::m/invalid-ref [_ {:keys [ref]} printer]
   {:body [:group
           (v/-block "Invalid Reference" (v/-visit [:ref ref] printer) printer) :break :break

--- a/src/malli/dev/pretty.cljc
+++ b/src/malli/dev/pretty.cljc
@@ -29,8 +29,9 @@
 (defn -ref-text [printer]
   [:group "Reference should be one of the following:" :break :break
    "- a qualified keyword, " (v/-visit [:ref :user/id] printer) :break
-   "- a qualified symbol,  " (v/-visit [:ref 'user/id] printer) :break
-   "- a string,            " (v/-visit [:ref "user/id"] printer)])
+   "- a qualified symbol,  " (v/-visit [:ref (symbol "'user" "id")] printer) :break
+   "- a string,            " (v/-visit [:ref "user/id"] printer) :break
+   "- a Var,               " (v/-visit [:ref (symbol "#'user" "id")] printer)])
 
 ;;
 ;; formatters

--- a/src/malli/dev/virhe.cljc
+++ b/src/malli/dev/virhe.cljc
@@ -133,11 +133,8 @@
 #?(:clj
    (defn -location [e ss]
      (try
-       (let [start-with (fn [f s] (-> f first str (str/starts-with? s)))
-             [target _ file line] (loop [[f :as fs] (-> e Throwable->map :trace), [s :as ss] ss]
-                                    (cond (start-with f s) (recur (rest fs) ss)
-                                          (seq (rest ss)) (recur fs (rest ss))
-                                          :else f))]
+       (let [[target _ file line] (some (fn [[s :as line]] (if (not-any? #(str/starts-with? (str s) %) ss) line))
+                                        (-> e Throwable->map :trace))]
          (let [file-name (str/replace file #"(.*?)\.\S[^\.]+" "$1")
                target-name (name target)
                ns (str (subs target-name 0 (or (str/index-of target-name (str file-name "$")) 0)) file-name)]

--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -3,8 +3,12 @@
   (:require [edamame.core :as edamame]
             [malli.core :as m]))
 
-(defn -parse-string [x]
-  (edamame/parse-string x {:regex true, :fn true, #_#_:var identity}))
+(defn -var-symbol [s] (symbol (str "#'" s)))
+(defn -fail! [s] (fn [v] (m/-fail! ::var-parsing-not-supported {:var (-var-symbol v), :string s})))
+
+(defn -parse-string
+  ([x] (-parse-string x nil))
+  ([x options] (edamame/parse-string x (or options {:regex true, :fn true, :var (-fail! x)}))))
 
 (defn write-string
   ([?schema]
@@ -15,5 +19,5 @@
 (defn read-string
   ([form]
    (read-string form nil))
-  ([form options]
-   (m/schema (-parse-string form) options)))
+  ([form {::keys [edamame-options] :as options}]
+   (m/schema (-parse-string form edamame-options) options)))

--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -4,7 +4,7 @@
             [malli.core :as m]))
 
 (defn -parse-string [x]
-  (edamame/parse-string x {:dispatch {\# {\" #(re-pattern %)}}}))
+  (edamame/parse-string x {:var resolve, :regex true, :fn true}))
 
 (defn write-string
   ([?schema]

--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -4,7 +4,7 @@
             [malli.core :as m]))
 
 (defn -parse-string [x]
-  (edamame/parse-string x {:var resolve, :regex true, :fn true}))
+  (edamame/parse-string x {:regex true, :fn true, :var identity}))
 
 (defn write-string
   ([?schema]

--- a/src/malli/edn.cljc
+++ b/src/malli/edn.cljc
@@ -4,7 +4,7 @@
             [malli.core :as m]))
 
 (defn -parse-string [x]
-  (edamame/parse-string x {:regex true, :fn true, :var identity}))
+  (edamame/parse-string x {:regex true, :fn true, #_#_:var identity}))
 
 (defn write-string
   ([?schema]

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -10,7 +10,8 @@
 
 (defn -ref [schema {::keys [transform definitions] :as options}]
   (let [ref (as-> (m/-ref schema) $
-              (cond (var? $) (str (.toSymbol $))
+              (cond (var? $) (let [{:keys [ns name]} (meta $)]
+                               (str (symbol (str ns) (str name))))
                     (qualified-ident? $) (str (namespace $) "/" (name $))
                     :else (str $)))]
     (when-not (contains? @definitions ref)

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -1,5 +1,6 @@
 (ns malli.json-schema
   (:require [clojure.set :as set]
+            [clojure.string :as str]
             [malli.core :as m]))
 
 (declare -transform)
@@ -8,20 +9,16 @@
   (-accept [this children options] "transforms schema to JSON Schema"))
 
 (defn -ref [schema {::keys [transform definitions] :as options}]
-  (let [x (m/-ref schema)]
-    (when-not (contains? @definitions x)
+  (let [ref (as-> (m/-ref schema) $
+              (cond (var? $) (str (.toSymbol $))
+                    (qualified-ident? $) (str (namespace $) "/" (name $))
+                    :else (str $)))]
+    (when-not (contains? @definitions ref)
       (let [child (m/deref schema)]
-        (swap! definitions assoc x ::recursion-stopper)
-        (swap! definitions assoc x (transform child options))))
-    {:$ref (apply str "#/definitions/"
-                  (cond
-                    ;; / must be encoded as ~1 in JSON Schema
-                    ;; https://json-schema.org/draft/2019-09/relative-json-pointer.html
-                    ;; https://www.rfc-editor.org/rfc/rfc6901
-                    (qualified-keyword? x) [(namespace x) "~1"
-                                            (name x)]
-                    (keyword? x) [(name x)]
-                    :else [x]))}))
+        (swap! definitions assoc ref ::recursion-stopper)
+        (swap! definitions assoc ref (transform child options))))
+    ;; '/' must be encoded as '~1' in JSON Schema - https://www.rfc-editor.org/rfc/rfc6901
+    {:$ref (apply str "#/definitions/" (str/replace ref #"/" "~1"))}))
 
 (defn -schema [schema {::keys [transform] :as options}]
   (if (m/-ref schema)

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -63,6 +63,12 @@
     (-schema [_ type] (-schema (registry @db) type))
     (-schemas [_] (-schemas (registry @db)))))
 
+(defn var-registry []
+  (reify
+    Registry
+    (-schema [_ type] (if (var? type) @type))
+    (-schemas [_])))
+
 (def ^:dynamic *registry* {})
 
 (defn dynamic-registry []

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -63,10 +63,15 @@
     (-schema [_ type] (-schema (registry @db) type))
     (-schemas [_] (-schemas (registry @db)))))
 
+(defn -find-loaded-var [s]
+  (->> (all-ns) (mapcat ns-publics) (some (fn [[_ v]] (if (= s (.toSymbol v)) v)))))
+
 (defn var-registry []
   (reify
     Registry
-    (-schema [_ type] (if (var? type) @type))
+    (-schema [_ type] (cond
+                        (var? type) @type
+                        (and (list? type) (= 'var (first type)) (= 2 (count type))) (-find-loaded-var (second type))))
     (-schemas [_])))
 
 (def ^:dynamic *registry* {})

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3009,7 +3009,7 @@
    [:id #'UserId]
    [:friends {:optional true} [:set [:ref #'User]]]])
 
-(deftest roundrobin-var-references
+#_(deftest roundrobin-var-references
   (let [registry (mr/composite-registry
                   (m/default-schemas)
                   (mr/var-registry))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3009,12 +3009,8 @@
    [:id #'UserId]
    [:friends {:optional true} [:set [:ref #'User]]]])
 
-(def registry (mr/composite-registry
-               (m/default-schemas)
-               (mr/var-registry)))
-
 (deftest var-registry-test
-  (let [schema (m/schema User {:registry registry})]
+  (let [schema (m/schema User)]
 
     (testing "getting schema over Var works"
       (is (= UserId (mr/-schema (mr/var-registry) #'UserId)))
@@ -3029,23 +3025,19 @@
 
 #?(:clj
    (deftest roundrobin-var-references
+     (let [schema (m/schema User)]
 
-     (testing "default options with var-registry fails"
-       (let [options {:registry registry}
-             schema (m/schema User options)]
+       (testing "default options with var-registry fails"
          (is (thrown? Exception
                       (as-> schema $
                         (edn/write-string $)
-                        (edn/read-string $ options)
-                        (every? (m/validator $) (mg/sample schema)))))))
+                        (edn/read-string $)
+                        (every? (m/validator $) (mg/sample schema))))))
 
-     (testing "with custom edamame options with var-registry succeeds"
-       (let [options {:registry registry
-                      ::edn/edamame-options {:fn true,
-                                             :regex true,
-                                             :var resolve}}
-             schema (m/schema User options)]
+       (testing "with custom edamame options with var-registry succeeds"
          (is (as-> schema $
                (edn/write-string $)
-               (edn/read-string $ options)
+               (edn/read-string $ {::edn/edamame-options {:fn true,
+                                                          :regex true,
+                                                          :var resolve}})
                (every? (m/validator $) (mg/sample schema))))))))

--- a/test/malli/dev_err_test.clj
+++ b/test/malli/dev_err_test.clj
@@ -1,7 +1,6 @@
 (ns malli.dev-err-test
   (:require [clojure.test :refer [deftest is testing]]
-            [malli.dev :as md]
-            [malli.dev.pretty :as pretty]))
+            [malli.dev :as dev]))
 
 (defn plus-err
   [x] (inc x))
@@ -19,9 +18,8 @@
       (alter-meta! #'plus-err #(assoc % :malli/schema [:=> [:cat [:vector]] [:int {:max 6}]]))
       (try
         (is (thrown-with-msg?
-             Exception #"Schema error when instrumenting function: malli.dev-err-test/plus-err - :malli.core/child-error"
-             (md/start! {:ns *ns*})))
-        (catch Throwable _
-          (md/stop!)))
+             Exception #":malli.core/register-function-schema"
+             (dev/start! {:ns *ns*, :report (fn [& _args])})))
+        (finally
+          (with-out-str (dev/stop!))))
       (alter-meta! #'plus-err #(dissoc % :malli/schema)))))
-

--- a/test/malli/experimental/time/json_schema_test.cljc
+++ b/test/malli/experimental/time/json_schema_test.cljc
@@ -7,17 +7,15 @@
 (t/deftest time-formats
   (t/is
    (= {:type "object",
-       :properties
-       {:date {:$ref "#/definitions/time~1local-date"},
-        :time {:$ref "#/definitions/time~1offset-time"},
-        :date-time {:$ref "#/definitions/time~1offset-date-time"},
-        :duration {:$ref "#/definitions/time~1duration"}},
+       :properties {:date {:$ref "#/definitions/time~1local-date"},
+                    :time {:$ref "#/definitions/time~1offset-time"},
+                    :date-time {:$ref "#/definitions/time~1offset-date-time"},
+                    :duration {:$ref "#/definitions/time~1duration"}},
        :required [:date :time :date-time :duration],
-       :definitions
-       #:time{:local-date {:type "string", :format "date"},
-              :offset-time {:type "string", :format "time"},
-              :offset-date-time {:type "string", :format "date-time"},
-              :duration {:type "string", :format "duration"}}}
+       :definitions {"time/local-date" {:type "string", :format "date"},
+                     "time/offset-time" {:type "string", :format "time"},
+                     "time/offset-date-time" {:type "string", :format "date-time"},
+                     "time/duration" {:type "string", :format "duration"}}}
       (json/transform
        [:map
         [:date :time/local-date]

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -358,8 +358,4 @@
                                                                               :uniqueItems true}},
                                                        :required [:id ::location `description]}}}
 
-         (json-schema/transform
-          User
-          {:registry (mr/composite-registry
-                      (m/default-schemas)
-                      (mr/var-registry))}))))
+         (json-schema/transform User))))

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -4,6 +4,7 @@
             [malli.core :as m]
             [malli.core-test]
             [malli.json-schema :as json-schema]
+            [malli.registry :as mr]
             [malli.util :as mu]))
 
 (def expectations
@@ -325,3 +326,40 @@
           :required [:name]
           :additionalProperties false}
          (json-schema/transform [:map {:closed true} [:name :string]]))))
+
+(def UserId :string)
+
+(def User
+  [:map {:registry {::location [:tuple :double :double]
+                    `description :string}}
+   [:id #'UserId]
+   ::location
+   `description
+   [:friends {:optional true} [:set [:ref #'User]]]])
+
+(deftest ref-test
+  (is (= {:type "object"
+          :properties {:id {:$ref "#/definitions/malli.json-schema-test~1UserId"},
+                       ::location {:$ref "#/definitions/malli.json-schema-test~1location"},
+                       `description {:$ref "#/definitions/malli.json-schema-test~1description"},
+                       :friends {:type "array", :items {:$ref "#/definitions/malli.json-schema-test~1User"}, :uniqueItems true}},
+          :required [:id :malli.json-schema-test/location `description],
+          :definitions {"malli.json-schema-test/UserId" {:type "string"},
+                        "malli.json-schema-test/location" {:type "array",
+                                                           :items [{:type "number"} {:type "number"}],
+                                                           :additionalItems false},
+                        "malli.json-schema-test/description" {:type "string"},
+                        "malli.json-schema-test/User" {:type "object",
+                                                       :properties {:id {:$ref "#/definitions/malli.json-schema-test~1UserId"},
+                                                                    ::location {:$ref "#/definitions/malli.json-schema-test~1location"},
+                                                                    `description {:$ref "#/definitions/malli.json-schema-test~1description"},
+                                                                    :friends {:type "array",
+                                                                              :items {:$ref "#/definitions/malli.json-schema-test~1User"},
+                                                                              :uniqueItems true}},
+                                                       :required [:id ::location `description]}}}
+
+         (json-schema/transform
+          User
+          {:registry (mr/composite-registry
+                      (m/default-schemas)
+                      (mr/var-registry))}))))

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -45,15 +45,18 @@
                   (m/default-schemas)
                   var-registry)
         schema (m/schema User {:registry registry})]
+
     (testing "getting schema over Var works"
       (is (= UserId (mr/-schema var-registry #'UserId)))
       (is (= User (mr/-schema var-registry #'User))))
+
     (testing "we do not list all Var schemas (yet)"
       (is (= nil (mr/-schemas var-registry))))
-    (testing "works!"
+
+    (testing "it works"
       (is (= [:map
-              [:id #'malli.registry-test/UserId]
-              [:friends {:optional true} [:set [:ref #'malli.registry-test/User]]]]
+              [:id #'UserId]
+              [:friends {:optional true} [:set [:ref #'User]]]]
              (m/form schema)))
       (is (every? (m/validator schema) (mg/sample schema {:seed 100}))))))
 

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -40,18 +40,17 @@
    [:friends {:optional true} [:set [:ref #'User]]]])
 
 (deftest var-registry-test
-  (let [var-registry (mr/var-registry)
-        registry (mr/composite-registry
+  (let [registry (mr/composite-registry
                   (m/default-schemas)
-                  var-registry)
+                  (mr/var-registry))
         schema (m/schema User {:registry registry})]
 
     (testing "getting schema over Var works"
-      (is (= UserId (mr/-schema var-registry #'UserId)))
-      (is (= User (mr/-schema var-registry #'User))))
+      (is (= UserId (mr/-schema (mr/var-registry) #'UserId)))
+      (is (= User (mr/-schema (mr/var-registry) #'User))))
 
     (testing "we do not list all Var schemas (yet)"
-      (is (= nil (mr/-schemas var-registry))))
+      (is (= nil (mr/-schemas (mr/var-registry)))))
 
     (testing "it works"
       (is (= User (m/form schema)))

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -54,10 +54,7 @@
       (is (= nil (mr/-schemas var-registry))))
 
     (testing "it works"
-      (is (= [:map
-              [:id #'UserId]
-              [:friends {:optional true} [:set [:ref #'User]]]]
-             (m/form schema)))
+      (is (= User (m/form schema)))
       (is (every? (m/validator schema) (mg/sample schema {:seed 100}))))))
 
 (deftest lazy-registry-test

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -1,7 +1,6 @@
 (ns malli.registry-test
   (:require [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
-            [malli.generator :as mg]
             [malli.registry :as mr]))
 
 (deftest mutable-test
@@ -31,30 +30,6 @@
                   {:maybe "sheep"}
                   {:registry registry})))
       (is (= #{:string :map :maybe} (-> registry (mr/-schemas) (keys) (set)))))))
-
-(def UserId :string)
-
-(def User
-  [:map
-   [:id #'UserId]
-   [:friends {:optional true} [:set [:ref #'User]]]])
-
-(deftest var-registry-test
-  (let [registry (mr/composite-registry
-                  (m/default-schemas)
-                  (mr/var-registry))
-        schema (m/schema User {:registry registry})]
-
-    (testing "getting schema over Var works"
-      (is (= UserId (mr/-schema (mr/var-registry) #'UserId)))
-      (is (= User (mr/-schema (mr/var-registry) #'User))))
-
-    (testing "we do not list all Var schemas (yet)"
-      (is (= nil (mr/-schemas (mr/var-registry)))))
-
-    (testing "it works"
-      (is (= User (m/form schema)))
-      (is (every? (m/validator schema) (mg/sample schema {:seed 100}))))))
 
 (deftest lazy-registry-test
   (let [loads (atom #{})

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -313,7 +313,7 @@
   (testing "generates swagger for ::parameters w/ basic schema + registry"
     (let [registry (merge (m/type-schemas)
                           {::body [:string {:min 1}]})]
-      (is (= {:definitions {::body {:minLength 1, :type "string"}}
+      (is (= {:definitions {"malli.swagger-test/body" {:minLength 1, :type "string"}}
               :parameters [{:description ""
                             :in "body"
                             :name "body"
@@ -327,9 +327,9 @@
     (let [registry (merge (m/base-schemas) (m/type-schemas)
                           {::success [:map-of :keyword :string]
                            ::error [:string {:min 1}]})]
-      (is (= {:definitions {::error {:minLength 1, :type "string"}
-                            ::success {:additionalProperties {:type "string"}
-                                       :type "object"}}
+      (is (= {:definitions {"malli.swagger-test/error" {:minLength 1, :type "string"}
+                            "malli.swagger-test/success" {:additionalProperties {:type "string"}
+                                                          :type "object"}}
               :responses {200 {:description ""
                                :schema {:$ref "#/definitions/malli.swagger-test~1success"}}
                           400 {:description ""
@@ -345,11 +345,11 @@
                           {::req-body [:map-of :keyword :any]
                            ::success-resp [:map [:it [:= "worked"]]]
                            ::error-resp [:string {:min 1}]})]
-      (is (= {:definitions {::error-resp {:minLength 1, :type "string"}
-                            ::req-body {:additionalProperties {}, :type "object"}
-                            ::success-resp {:properties {:it {:const "worked"}}
-                                            :required [:it]
-                                            :type "object"}}
+      (is (= {:definitions {"malli.swagger-test/error-resp" {:minLength 1, :type "string"}
+                            "malli.swagger-test/req-body" {:additionalProperties {}, :type "object"}
+                            "malli.swagger-test/success-resp" {:properties {:it {:const "worked"}}
+                                                               :required [:it]
+                                                               :type "object"}}
               :parameters [{:description ""
                             :in "body"
                             :name "body"
@@ -391,21 +391,21 @@
                            ::req-body [:map [:a ::a]]
                            ::success-resp [:map-of :keyword :string]
                            ::error-resp :string})]
-      (is (= {:definitions {::a {:type "string"
-                                 :x-anyOf [{:type "string"}
-                                           {:$ref "#/definitions/malli.swagger-test~1b"}]}
-                            ::b {:type "string"
-                                 :x-anyOf [{:type "string"}
-                                           {:$ref "#/definitions/malli.swagger-test~1c"}]}
-                            ::c {:type "string"
-                                 :x-anyOf [{:type "string"}
-                                           {:$ref "#/definitions/malli.swagger-test~1a"}]}
-                            ::error-resp {:type "string"}
-                            ::req-body {:properties {:a {:$ref "#/definitions/malli.swagger-test~1a"}}
-                                        :required [:a]
-                                        :type "object"}
-                            ::success-resp {:additionalProperties {:type "string"}
-                                            :type "object"}}
+      (is (= {:definitions {"malli.swagger-test/a" {:type "string"
+                                                    :x-anyOf [{:type "string"}
+                                                              {:$ref "#/definitions/malli.swagger-test~1b"}]}
+                            "malli.swagger-test/b" {:type "string"
+                                                    :x-anyOf [{:type "string"}
+                                                              {:$ref "#/definitions/malli.swagger-test~1c"}]}
+                            "malli.swagger-test/c" {:type "string"
+                                                    :x-anyOf [{:type "string"}
+                                                              {:$ref "#/definitions/malli.swagger-test~1a"}]}
+                            "malli.swagger-test/error-resp" {:type "string"}
+                            "malli.swagger-test/req-body" {:properties {:a {:$ref "#/definitions/malli.swagger-test~1a"}}
+                                                           :required [:a]
+                                                           :type "object"}
+                            "malli.swagger-test/success-resp" {:additionalProperties {:type "string"}
+                                                               :type "object"}}
               :parameters [{:description ""
                             :in "body"
                             :name "body"


### PR DESCRIPTION
## Open Questions

* [x] should var-registry be enabled by default? ❌ let's sleep over this one
* [x] is it ok user to remove the var-registry? we still accept Vars as references (via `m/-reference?`) and document them in pretty printing ✅ it's ok to remove
* [x] does this work with all runtimes? bb? cherry? cljs? ✅ tests included
* [x] can we serialize var refs with edamame/sci? ❌ just clojure, not enabled by default

## Sample 

```clojure
(require '[malli.core :as m])
(require '[malli.registry :as mr])
(require '[malli.generator :as mg])

;; enable var registry
(mr/set-default-registry!
 (mr/composite-registry
  (m/default-schemas)
  (mr/var-registry)))

(def UserId :string)

(def User
  [:map
   [:id #'UserId]
   [:friends {:optional true} [:set [:ref #'User]]]])

(m/form User)
;[:map 
; [:id #'user/UserId]
; [:friends {:optional true} [:set [:ref #'user/User]]]]

(m/validate User {:id "123", :friends #{{:id "234"}}})
; => true

(mg/sample User {:seed 42})
;({:id ""}
; {:id "5"}
; {:id ""}
; {:id "B62"}
; {:id "Vc16", :friends #{}}
; {:id "E",
;  :friends #{{:id ""}
;             {:id "u", :friends #{}}
;             {:id "", :friends #{}}
;             {:id "GL", :friends #{{:id "i"} {:id "o", :friends #{}}}}
;             {:id "d"}}}
; {:id "", :friends #{{:id ""} {:id "0Ql1", :friends #{{:id "3", :friends #{}}}}}}
; {:id "l"}
; {:id "",
;  :friends #{{:id "R8p", :friends #{}}
;             {:id "d8"}
;             {:id "A2u5k9G6"}
;             {:id ""}
;             {:id "C2", :friends #{{:id "33"} {:id "", :friends #{}} {:id "g4"}}}}}
; {:id "IrcCSYwSO"})
```

## Invalid ref error

```clojure
((requiring-resolve 'malli.dev/start!))

(m/schema [:ref 123])
```

<img width="735" alt="invalid-ref" src="https://github.com/metosin/malli/assets/567532/1ca05ac7-6f03-4987-918b-5dfdd108bf42">
