### PR TITLE
Fix #836 clj-kondo linter generation when using pred :fn's

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -103,7 +103,7 @@
 (defmethod accept :tuple [_ _ _ _] :seqable)
 (defmethod accept :multi [_ _ _ _] :any) ;;??
 (defmethod accept :re [_ _ _ _] :string)
-(defmethod accept :fn [_ _ _ _] :fn)
+(defmethod accept :fn [_ _ _ _] :any)
 (defmethod accept :ref [_ _ _ _] :any) ;;??
 (defmethod accept :=> [_ _ _ _] :fn)
 (defmethod accept :function [_ _ _ _] :fn)

--- a/test/malli/instrument_test.clj
+++ b/test/malli/instrument_test.clj
@@ -90,6 +90,11 @@
          (mi/-schema #'f2)))
   (is (= nil (mi/-schema #'f3))))
 
+(deftest check-test
+  (testing "all registered function schemas in this namespace"
+    (let [results (mi/check {:filters [(mi/-filter-ns 'malli.instrument-test)]})]
+      (is (map? results)))))
+
 (deftest instrument-external-test
 
   (testing "Without instrumentation"

--- a/test/malli/instrument_test.cljs
+++ b/test/malli/instrument_test.cljs
@@ -194,8 +194,9 @@
     (is (= 9 (minus-small-int 10)))))
 
 (deftest ^:simple check-test
-  (let [results (mi/check)]
-    (is (map? results))))
+  (testing "all registered function schemas in this namespace"
+    (let [results (mi/check {:filters [(mi/-filter-ns 'malli.instrument-test)]})]
+      (is (map? results)))))
 
 (deftest ^:simple instrument-external-test
 


### PR DESCRIPTION
Trying to fix #836 . When using a predicate fn schema inside of a function schema, it would output a the type as :fn, such that clj-kondo checked that the arg provided is a fn and not of type any.

Ex:
```clj
(defn times [x y z] (* x y z))
(m/=> times [:=> [:cat int? [:fn #(int? %)] int?] [:fn #(int? %)]])

(times 1 2 3)
;; clj-kondo warns that `2` should be a function, not an integer.
```