### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1558,15 +1558,15 @@ For example, `UnionMaps` is equivalent to `[:map [:x [:or :int :string]] [:y [:o
 (def OrMaps
   (m/schema
     [:or
-     [:map [:x :int] [:x :string]]
-     [:map [:x :string] [:x :int]]]
+     [:map [:x :int] [:y :string]]
+     [:map [:x :string] [:y :int]]]
     {:registry registry}))
 
 (def UnionMaps
   (m/schema
     [:union
-     [:map [:x :int] [:x :string]]
-     [:map [:x :string] [:x :int]]]
+     [:map [:x :int] [:y :string]]
+     [:map [:x :string] [:y :int]]]
     {:registry registry}))
 
 (m/validate OrMaps {:x "kikka" :y "kikka"})


### PR DESCRIPTION
Fixed a typo in key names in the `UnionMaps` example snippet.

The example had me scratch my head a little as there was a typo. The combined schema used to verify a map with both `:x` and `:y` keys, while the schema only had descriptions for `:x`.