### PR TITLE
goog/mixin was deprecated and is now removed

### DIFF
--- a/src/malli/instrument/cljs.cljs
+++ b/src/malli/instrument/cljs.cljs
@@ -12,7 +12,7 @@
   ;; Because the current MetaFn implementation can cause quirky errors in CLJS
   [f m]
   (let [new-f (goog/bind f #js{})]
-    (goog/mixin new-f f)
+    (js/Object.assign new-f f)
     (specify! new-f IMeta #_:clj-kondo/ignore (-meta [_] m))
     new-f))
 


### PR DESCRIPTION
This is same fix as https://github.com/metosin/malli/pull/890

[See slack discussion for some more context](https://clojurians.slack.com/archives/CLDK6MFMK/p1709638318412439). Short version: This code is still useful for instrumenting advanced compile code, so we might want to keep it around.