### PR TITLE
Use `:orn` instead of `:altn` for map destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ You can use `:sequential` to describe homogeneous sequential Clojure collections
 ;; => false
 ```
 
-Malli also supports sequence regexes (also called sequence expresions) like [Seqexp](https://github.com/cgrand/seqexp) and Spec.
+Malli also supports sequence regexes (also called sequence expressions) like [Seqexp](https://github.com/cgrand/seqexp) and Spec.
 The supported operators are `:cat` & `:catn` for concatenation / sequencing
 
 ```clojure
@@ -454,7 +454,7 @@ while `:cat` and `:alt` just use numeric indices for paths:
 ;;              {:path [0 1 1], :in [3], :schema boolean?, :value 11})}
 ```
 
-As all these examples show, the sequence experssion (seqex) operators take any non-seqex child schema to
+As all these examples show, the sequence expression (seqex) operators take any non-seqex child schema to
 mean a sequence of one element that matches that schema. To force that behaviour for
 a seqex child `:schema` can be used:
 

--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -91,9 +91,9 @@
         ->arg (fn [[k t]] [:cat [:= k] (if (and references (qualified-keyword? k)) k t)])
         schema (cond-> [:map] closed-maps (conj {:closed true}) :always (into (map ->entry keys)))]
     (if (or rest sequential-maps)
-      [:altn [:map schema] [:args (-> (into [:alt] (map ->arg) keys)
-                                      (cond-> (not closed-maps) (conj [:cat [:not (into [:enum] (map first) keys)] :any]))
-                                      (cond->> :always (conj [:*]) (not rest) (conj [:schema])))]]
+      [:orn [:map schema] [:args (-> (into [:alt] (map ->arg) keys)
+                                     (cond-> (not closed-maps) (conj [:cat [:not (into [:enum] (map first) keys)] :any]))
+                                     (cond->> :always (conj [:*]) (not rest) (conj [:schema])))]]
       schema)))
 
 (defn -transform [{[k v] :arg schema :schema :as all} options rest]

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -45,7 +45,7 @@
                :as map}]
     :schema [:cat
              :any
-             [:altn
+             [:orn
               [:map [:map
                      [:b {:optional true} :any]
                      ["c" {:optional true} :any]
@@ -71,7 +71,7 @@
     :bind '[{:keys [a :demo/b] :demo/keys [c]}]
     :options {::md/required-keys true}
     :schema [:cat
-             [:altn
+             [:orn
               [:map [:map
                      [:a :any]
                      :demo/b
@@ -86,7 +86,7 @@
     :options {::md/required-keys true
               ::md/closed-maps true}
     :schema [:cat
-             [:altn
+             [:orn
               [:map [:map {:closed true}
                      [:a :any]
                      :demo/b
@@ -101,7 +101,7 @@
               ::md/closed-maps true
               ::md/references false}
     :schema [:cat
-             [:altn
+             [:orn
               [:map [:map {:closed true}
                      [:a :any]
                      [:demo/b :any]
@@ -130,7 +130,7 @@
     :options {::md/sequential-maps false} ;; no effect here
     :schema [:cat
              :any
-             [:altn
+             [:orn
               [:map [:map
                      [:b {:optional true} :any]
                      ["c" {:optional true} :any]
@@ -151,7 +151,7 @@
     :schema [:cat
              [:maybe
               [:cat
-               [:altn
+               [:orn
                 [:map [:map
                        [:a {:optional true} :any]
                        [:b {:optional true} :any]]]
@@ -159,7 +159,7 @@
                             [:cat [:= :a] :any]
                             [:cat [:= :b] :any]
                             [:cat [:not [:enum :a :b]] :any]]]]]]]
-             [:altn
+             [:orn
               [:map [:map
                      [:a {:optional true} :any]
                      [:b {:optional true} :any]]]
@@ -170,11 +170,11 @@
    {:name "Nest right-to-left map syntax"
     :bind '[{{inner :inner} :outer}]
     :schema [:cat
-             [:altn
+             [:orn
               [:map [:map
                      [:outer
                       {:optional true}
-                      [:altn
+                      [:orn
                        [:map [:map
                               [:inner {:optional true} :any]]]
                        [:args [:schema
@@ -185,7 +185,7 @@
                       [:* [:alt
                            [:cat
                             [:= :outer]
-                            [:altn
+                            [:orn
                              [:map [:map [:inner {:optional true} :any]]]
                              [:args [:schema [:* [:alt
                                                   [:cat [:= :inner] :any]

--- a/test/malli/experimental_test.clj
+++ b/test/malli/experimental_test.clj
@@ -119,8 +119,12 @@
                    [[1 2 3 4] 10]
                    [[-1 2 3 4] ::throws]]}
    {:var #'inner-outer-no-schema
-    :calls [[[(list :outer [:not-inner])] nil]]
-    :instrumented [[[(list :outer [:not-inner])] ::throws]]}])
+    :calls [[[(list :outer [:not-inner])] nil]
+            [[{:outer {:inner "here"}}] "here"]
+            [[{:outer {:not-inner 'foo}}] nil]]
+    :instrumented [[[(list :outer [:not-inner])] ::throws]
+                   [[{:outer {:inner "here"}}] "here"]
+                   [[{:outer {:not-inner 'foo}}] nil]]}])
 
 (defn -strument! [mode v]
   (with-out-str


### PR DESCRIPTION
Related https://github.com/metosin/malli/issues/1020

Map destructuring shouldn't convert to an `:altn` because it turns into a sequence spec when nested:

```clojure
(malli.generator/generate
  [:map [:outer [:altn
                 [:map [:map [:inner :any]]]]]])
;=> {:outer [{:inner nil}]}

(m/validate
  [:map [:outer [:altn
                 [:map [:map [:inner :any]]]
                 [:seq [:* :any]]]]]
  {:outer {:inner "a"}})
;=> false
```

`:orn` is better for the job here:

```clojure
(m/validate
  [:map [:outer [:orn
                 [:map [:map [:inner :any]]]
                 [:seq [:* :any]]]]]
  {:outer {:inner "a"}})
;=> true
```