### PR TITLE
Enforce entry specs in open map destructurings

### DIFF
--- a/src/malli/destructure.cljc
+++ b/src/malli/destructure.cljc
@@ -91,8 +91,8 @@
         ->arg (fn [[k t]] [:cat [:= k] (if (and references (qualified-keyword? k)) k t)])
         schema (cond-> [:map] closed-maps (conj {:closed true}) :always (into (map ->entry keys)))]
     (if (or rest sequential-maps)
-      [:altn [:map schema] [:args (-> (into [:alt] (map ->arg keys))
-                                      (cond-> (not closed-maps) (conj [:cat :any :any]))
+      [:altn [:map schema] [:args (-> (into [:alt] (map ->arg) keys)
+                                      (cond-> (not closed-maps) (conj [:cat [:not (into [:enum] (map first) keys)] :any]))
                                       (cond->> :always (conj [:*]) (not rest) (conj [:schema])))]]
       schema)))
 

--- a/test/malli/destructure_test.cljc
+++ b/test/malli/destructure_test.cljc
@@ -64,7 +64,7 @@
                         [:cat [:= :demo/f] :demo/f]
                         [:cat [:= :demo/g] :demo/g]
                         [:cat [:= 123] :any]
-                        [:cat :any :any]]]]]]]
+                        [:cat [:not [:enum :b "c" 'd 'demo/e :demo/f :demo/g 123]] :any]]]]]]]
     :errors '[[{::keysz [z]}]
               [{:kikka/keyz [z]}]]}
    {:name "map destructuring with required-keys"
@@ -80,7 +80,7 @@
                                    [:cat [:= :a] :any]
                                    [:cat [:= :demo/b] :demo/b]
                                    [:cat [:= :demo/c] :demo/c]
-                                   [:cat :any :any]]]]]]]}
+                                   [:cat [:not [:enum :a :demo/b :demo/c]] :any]]]]]]]}
    {:name "map destructuring with required-keys and closed-maps"
     :bind '[{:keys [a :demo/b] :demo/keys [c]}]
     :options {::md/required-keys true
@@ -144,7 +144,7 @@
                        [:cat [:= 'd] :any]
                        [:cat [:= :demo/e] :demo/e]
                        [:cat [:= 'demo/f] :any]
-                       [:cat :any :any]]]]]]}
+                       [:cat [:not [:enum :b "c" 'd :demo/e 'demo/f]] :any]]]]]]}
    {:name "Nested Keyword argument"
     :bind '[[& {:keys [a b] :as opts}]
             & {:keys [a b] :as opts}]
@@ -158,7 +158,7 @@
                 [:args [:* [:alt
                             [:cat [:= :a] :any]
                             [:cat [:= :b] :any]
-                            [:cat :any :any]]]]]]]
+                            [:cat [:not [:enum :a :b]] :any]]]]]]]
              [:altn
               [:map [:map
                      [:a {:optional true} :any]
@@ -166,7 +166,31 @@
               [:args [:* [:alt
                           [:cat [:= :a] :any]
                           [:cat [:= :b] :any]
-                          [:cat :any :any]]]]]]}])
+                          [:cat [:not [:enum :a :b]] :any]]]]]]}
+   {:name "Nest right-to-left map syntax"
+    :bind '[{{inner :inner} :outer}]
+    :schema [:cat
+             [:altn
+              [:map [:map
+                     [:outer
+                      {:optional true}
+                      [:altn
+                       [:map [:map
+                              [:inner {:optional true} :any]]]
+                       [:args [:schema
+                               [:* [:alt
+                                    [:cat [:= :inner] :any]
+                                    [:cat [:not [:enum :inner]] :any]]]]]]]]]
+              [:args [:schema
+                      [:* [:alt
+                           [:cat
+                            [:= :outer]
+                            [:altn
+                             [:map [:map [:inner {:optional true} :any]]]
+                             [:args [:schema [:* [:alt
+                                                  [:cat [:= :inner] :any]
+                                                  [:cat [:not [:enum :inner]] :any]]]]]]]
+                           [:cat [:not [:enum :outer]] :any]]]]]]]}])
 
 (def schematized-expectations
   [{:name "empty"

--- a/test/malli/experimental_test.clj
+++ b/test/malli/experimental_test.clj
@@ -38,6 +38,10 @@
   ([x :- [:int {:min 0}], y :- :int & zs :- [:* :int]] (apply + x y zs))
   {:more "meta"})
 
+(mx/defn inner-outer-no-schema
+  [{{inner :inner} :outer}]
+  inner)
+
 (def expectations
   [{:var #'f1
     :calls [[nil 1]
@@ -113,7 +117,10 @@
                    [[1 -2] ::throws]
                    [[-1 2] ::throws]
                    [[1 2 3 4] 10]
-                   [[-1 2 3 4] ::throws]]}])
+                   [[-1 2 3 4] ::throws]]}
+   {:var #'inner-outer-no-schema
+    :calls [[[(list :outer [:not-inner])] nil]]
+    :instrumented [[[(list :outer [:not-inner])] ::throws]]}])
 
 (defn -strument! [mode v]
   (with-out-str
@@ -127,13 +134,14 @@
 
     (testing "plain calls"
       (doseq [[arg ret] calls]
-        (if (= ::throws ret)
-          (is (thrown? Exception (apply var arg)))
-          (let [actual (try (apply var arg)
-                            (catch Throwable ex
-                              (println "Unexpected failure in plain call" e [arg ret])
-                              (throw ex)))]
-            (is (= ret actual))))))
+        (testing (pr-str (list* 'apply (-> var symbol name symbol) (vec arg)))
+          (if (= ::throws ret)
+            (is (thrown? Exception (apply var arg)))
+            (let [actual (try (apply var arg)
+                              (catch Throwable ex
+                                (println "Unexpected failure in plain call" e [arg ret])
+                                (throw ex)))]
+              (is (= ret actual)))))))
 
     (when-let [m (:meta e)]
       (testing "meta"
@@ -145,8 +153,9 @@
         (-strument! :instrument var)
         (try
           (doseq [[arg ret] instrumented]
-            (if (= ::throws ret)
-              (is (thrown? Exception (apply var arg)))
-              (is (= ret (apply var arg)))))
+            (testing (pr-str (list* 'apply (-> var symbol name symbol) (vec arg)))
+              (if (= ::throws ret)
+                (is (thrown? Exception (apply var arg)))
+                (is (= ret (apply var arg))))))
           (finally
             (-strument! :unstrument var)))))))


### PR DESCRIPTION
A spec of `[:altn [:cat k1 s1] ... [:cat kn sn] [:cat :any :any]]` is equivalent to `[:cat :any :any]`. This results in specs for destructured open maps that skip all entry checks when providing kw args.