### PR TITLE
Close #1006: choose non-null base for swagger

### DIFF
--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -14,14 +14,17 @@
 
 (defmethod accept :not [_ _ children _] {:x-not (first children)})
 
-(defn non-null-nth [schema children]
+(defn non-null-nth
+  "Attempts to find a non-null schema to use as base.
+  If all are nullable, picks the first. This usually works out
+  because children are processed first, but can fail on
+  schemas that only contain nil like [:or :nil :nil]."
+  [schema children]
   (let [[base] (keep-indexed (fn [i schema]
                                (when-not (m/validate schema nil)
                                  i))
                              children)]
-    (when-not base
-      (m/-fail! ::non-null-base-required {:schema schema}))
-    base))
+    (or base 0)))
 
 (defmethod accept :and [_ s children _]
   (let [base (nth children (non-null-nth s (m/children s)))]

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -13,7 +13,6 @@
 (defmethod accept 'nil? [_ _ _ _] {})
 
 (defmethod accept :not [_ _ children _] {:x-not (first children)})
-(defmethod accept :and [_ _ children _] (assoc (first children) :x-allOf children))
 
 (defn non-null-nth [schema children]
   (let [[base] (keep-indexed (fn [i schema]
@@ -24,9 +23,14 @@
       (m/-fail! ::non-null-base-required {:schema schema}))
     base))
 
+(defmethod accept :and [_ s children _]
+  (let [base (nth children (non-null-nth s (m/children s)))]
+    (assoc base :x-allOf children)))
+
 (defmethod accept :or [_ s children _]
   (let [base (nth children (non-null-nth s (m/children s)))]
     (assoc base :x-anyOf children)))
+
 (defmethod accept :multi [_ s children _]
   (let [cs (mapv last children)
         base (nth cs (non-null-nth s (map peek (m/children s))))]

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -14,7 +14,14 @@
 
 (defmethod accept :not [_ _ children _] {:x-not (first children)})
 (defmethod accept :and [_ _ children _] (assoc (first children) :x-allOf children))
-(defmethod accept :or [_ _ children _] (assoc (first children) :x-anyOf children))
+(defmethod accept :or [_ s children _]
+  (let [[base] (keep-indexed (fn [i s]
+                               (when-not (m/validate s nil)
+                                 i))
+                             (m/children s))]
+    (when-not base
+      (m/-fail! ::non-nil-or-base-required {:schema s}))
+    (assoc (nth children base) :x-anyOf children)))
 (defmethod accept :multi [_ _ children _] (let [cs (mapv last children)] (assoc (first cs) :x-anyOf cs)))
 
 (defmethod accept :maybe [_ _ children {:keys [type in]}]

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -18,7 +18,11 @@
   "Attempts to find a non-null schema to use as base.
   If all are nullable, picks the first. This usually works out
   because children are processed first, but can fail on
-  schemas that only contain nil like [:or :nil :nil]."
+  schemas that only contain nil like [:or :nil :nil].
+
+  Since swagger has no null schema, there's no correct
+  schema to generate in this case, and we generate an
+  incorrect schema which will be flagged by swagger."
   [schema children]
   (let [[base] (keep-indexed (fn [i schema]
                                (when-not (m/validate schema nil)

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -32,6 +32,24 @@
                      :format "int64"
                      :x-anyOf [{:type "null"}
                                {:type "integer", :format "int64"}]}]
+   [[:multi {:dispatch :whatever}
+     [:a int?]
+     [:b :nil]]
+    {:type "integer"
+     :format "int64"
+     :x-anyOf [{:type "integer", :format "int64"}
+               {:type "null"}]}]
+   [[:multi {:dispatch :whatever}
+     [:a :nil]
+     [:b int?]]
+    {:type "integer"
+     :format "int64"
+     :x-anyOf [{:type "null"}
+               {:type "integer", :format "int64"}]}]
+   [[:or :nil int?] {:type "integer"
+                     :format "int64"
+                     :x-anyOf [{:type "null"}
+                               {:type "integer", :format "int64"}]}]
    [[:map
      [:a string?]
      [:b {:optional true} string?]

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -32,10 +32,6 @@
                      :format "int64"
                      :x-anyOf [{:type "null"}
                                {:type "integer", :format "int64"}]}]
-   [[:or :nil int?] {:type "integer"
-                     :format "int64"
-                     :x-anyOf [{:type "null"}
-                               {:type "integer", :format "int64"}]}]
    [[:or [:or :nil int?] [:or :nil int?]] {:type "integer"
                                            :format "int64"
                                            :x-anyOf [{:type "integer", :format "int64", :x-anyOf [{:type "null"} {:type "integer", :format "int64"}]}

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -32,6 +32,14 @@
                      :format "int64"
                      :x-anyOf [{:type "null"}
                                {:type "integer", :format "int64"}]}]
+   [[:and int? :nil] {:type "integer"
+                      :format "int64"
+                      :x-allOf [{:type "integer", :format "int64"}
+                                {:type "null"}]}]
+   [[:and :nil int?] {:type "integer"
+                      :format "int64"
+                      :x-allOf [{:type "null"}
+                                {:type "integer", :format "int64"}]}]
    [[:multi {:dispatch :whatever}
      [:a int?]
      [:b :nil]]
@@ -46,10 +54,6 @@
      :format "int64"
      :x-anyOf [{:type "null"}
                {:type "integer", :format "int64"}]}]
-   [[:or :nil int?] {:type "integer"
-                     :format "int64"
-                     :x-anyOf [{:type "null"}
-                               {:type "integer", :format "int64"}]}]
    [[:map
      [:a string?]
      [:b {:optional true} string?]

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -210,6 +210,19 @@
                    :json-schema/example 422
                    :swagger/example 4222} int?])))))
 
+(deftest null-base-test
+  (is (thrown-with-msg?
+        Exception
+        #":malli\.swagger/non-null-base-needed"
+        (swagger/transform
+          [:or :nil :nil])))
+  (is (thrown-with-msg?
+        Exception
+        #":malli\.swagger/non-null-base-needed"
+        (swagger/transform
+          :nil)))
+)
+
 (deftest util-schemas-test
   (let [registry (merge (m/default-schemas) (mu/schemas))]
 

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -221,7 +221,11 @@
         #":malli\.swagger/non-null-base-needed"
         (swagger/transform
           :nil)))
-)
+  (is (thrown-with-msg?
+        Exception
+        #":malli\.swagger/non-null-base-needed"
+        (swagger/transform
+          [:maybe :nil]))))
 
 (deftest util-schemas-test
   (let [registry (merge (m/default-schemas) (mu/schemas))]

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -32,6 +32,14 @@
                      :format "int64"
                      :x-anyOf [{:type "null"}
                                {:type "integer", :format "int64"}]}]
+   [[:or :nil int?] {:type "integer"
+                     :format "int64"
+                     :x-anyOf [{:type "null"}
+                               {:type "integer", :format "int64"}]}]
+   [[:or [:or :nil int?] [:or :nil int?]] {:type "integer"
+                                           :format "int64"
+                                           :x-anyOf [{:type "integer", :format "int64", :x-anyOf [{:type "null"} {:type "integer", :format "int64"}]}
+                                                     {:type "integer", :format "int64", :x-anyOf [{:type "null"} {:type "integer", :format "int64"}]}]}]
    [[:and int? :nil] {:type "integer"
                       :format "int64"
                       :x-allOf [{:type "integer", :format "int64"}


### PR DESCRIPTION
Also adds logic to catch top-level usage of `:type "null"`.