### PR TITLE
Better error handling when passing IntoSchema to `m/schema`

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -257,7 +257,7 @@
   (let [options (assoc options ::allow-invalid-refs true)]
     (reduce-kv (fn [acc k v]
                  (let [s (try (schema v options)
-                              (catch Exception e
+                              (catch #?(:clj Exception, :cljs js/Error) e
                                 (if (= ::error-creating-schema-from-into-schema-without-children (:type (ex-data e)))
                                   (-fail! ::schema-definition-must-be-in-options-not-properties
                                           {:bad-property-registry-entry k
@@ -2056,7 +2056,7 @@
    (cond
      (schema? ?schema) ?schema
      (into-schema? ?schema) (try (-into-schema ?schema nil nil options)
-                                 (catch Exception e
+                                 (catch #?(:clj Exception, :cljs js/Error) e
                                    (if (= ::child-error (:type (ex-data e)))
                                      (-fail! ::error-creating-schema-from-into-schema-without-children
                                              {:schema ?schema

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -260,8 +260,9 @@
                               (catch #?(:clj Exception, :cljs js/Error) e
                                 (if (= ::error-creating-schema-from-into-schema-without-children (:type (ex-data e)))
                                   (-fail! ::schema-definition-must-be-in-options-not-properties
-                                          {:bad-property-registry-entry k
-                                           :bad-registry m})
+                                          (into (:data (ex-data e) {})
+                                                {:bad-property-registry-entry k
+                                                 :bad-registry m}))
                                   (throw e))))]
                    (assoc acc k (f s))))
                {} m)))
@@ -2059,10 +2060,7 @@
                                  (catch #?(:clj Exception, :cljs js/Error) e
                                    (if (= ::child-error (:type (ex-data e)))
                                      (-fail! ::error-creating-schema-from-into-schema-without-children
-                                             {:schema ?schema
-                                              :message (str "When passing an IntoSchema to m/schema, a schema is constructed"
-                                                            " without children. " (-type ?schema)
-                                                            " does not seem to support zero children.")})
+                                             {:schema-not-supporting-zero-children ?schema})
                                      (throw e))))
      (vector? ?schema) (let [v #?(:clj ^IPersistentVector ?schema, :cljs ?schema)
                              t (-lookup! #?(:clj (.nth v 0), :cljs (nth v 0)) v into-schema? true options)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2047,7 +2047,7 @@
   "Creates a Schema object from any of the following:
 
    - Schema instance (just returns it)
-   - IntoSchema instance (calls -into-schema with no children or properties)
+   - IntoSchema instance (attempts to construct a Schema with no children)
    - Schema vector syntax, e.g. [:string {:min 1}]
    - Qualified Keyword or String, using a registry lookup"
   ([?schema]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3224,3 +3224,13 @@
                                              ::xymap [:merge ::xmap ::ymap]}}
                          ::xymap]
                         {:registry registry, ::m/ref-key :id}))))))))
+
+(deftest property-registry-cannot-take-into-schema-test
+  (is (thrown-with-msg?
+        #?(:clj Exception, :cljs js/Error)
+        #":malli\.core/error-creating-schema-from-into-schema-without-children"
+        (m/schema (:enum (m/default-schemas)))))
+  (is (thrown-with-msg?
+        #?(:clj Exception, :cljs js/Error)
+        #":malli\.core/schema-definition-must-be-in-options-not-properties"
+        (m/schema [:= {:registry {:enum (:enum (m/default-schemas))}} "foo"]))))


### PR DESCRIPTION
Related https://github.com/metosin/malli/issues/780
Related https://github.com/metosin/malli/issues/1048

For backwards-compatibility, don't throw if an IntoSchema is provided as a property and happens to coerce to schema. Maybe we should warn in this case, because I don't think it has much utility.