### PR TITLE
Fix :map-of :min and unreachable generator, explain such-that failures

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -113,7 +113,7 @@
         child (-> schema m/children first)
         gen (generator child options)]
     (if (-unreachable-gen? gen)
-      (if (<= (or min 0) 0 (or max 0))
+      (if (= 0 (or min 0))
         (gen/fmap f (gen/return []))
         (-never-gen options))
       (gen/fmap f (cond
@@ -127,11 +127,11 @@
   (let [{:keys [min max]} (-min-max schema options)
         child (-> schema m/children first)
         gen (generator child options)]
-    (gen/fmap f (if (-unreachable-gen? gen)
-                  (if (<= (or min 0) 0 (or max 0))
-                    (gen/return [])
-                    (-never-gen options))
-                  (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100
+    (if (-unreachable-gen? gen)
+      (if (= 0 (or min 0))
+        (gen/return (f []))
+        (-never-gen options))
+      (gen/fmap f (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100
                                             :ex-fn #(ex-info (str "Could not generate enough distinct elements for schema "
                                                                   (pr-str (m/form schema))
                                                                   ". Consider providing a custom generator.")

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -202,7 +202,7 @@
   (let [{:keys [min max]} (-min-max schema options)
         [k-gen v-gen :as gs] (map #(generator % options) (m/children schema options))]
     (if (some -unreachable-gen? gs)
-      (if (= 0 (or min 0) (or max 0))
+      (if (= 0 (or min 0))
         (gen/return {})
         (-never-gen options))
       (let [opts (-> (cond

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -53,15 +53,10 @@
 (defn -never-gen
   "Return a generator of no values that is compatible with -unreachable-gen?."
   [{::keys [original-generator-schema] :as _options}]
-  (with-meta (gen/such-that (fn [_]
-                              (throw (ex-info
-                                      (str "Cannot generate values due to infinitely expanding schema: "
-                                           (if original-generator-schema
-                                             (m/form original-generator-schema)
-                                             "<no schema form>"))
-                                      (cond-> {}
-                                        original-generator-schema (assoc :schema (m/form original-generator-schema))))))
-                            gen/any)
+  (with-meta (gen/sized (fn [_]
+                          (m/-fail! ::infinitely-expanding-schema
+                                    (cond-> {}
+                                      original-generator-schema (assoc :schema original-generator-schema)))))
              {::never-gen true
               ::original-generator-schema original-generator-schema}))
 
@@ -132,19 +127,15 @@
         (gen/return (f []))
         (-never-gen options))
       (gen/fmap f (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100
-                                            :ex-fn #(ex-info (str "Could not generate enough distinct elements for schema "
-                                                                  (pr-str (m/form schema))
-                                                                  ". Consider providing a custom generator.")
-                                                             %)})))))
+                                            :ex-fn #(m/-exception ::distinct-generator-failure
+                                                                  (assoc % :schema schema))})))))
 
 (defn -and-gen [schema options]
   (if-some [gen (-not-unreachable (-> schema (m/children options) first (generator options)))]
     (gen/such-that (m/validator schema options) gen
                    {:max-tries 100
-                    :ex-fn #(ex-info (str "Could not generate a value for schema "
-                                          (pr-str (m/form schema))
-                                          ". Consider providing a custom generator.")
-                                     %)})
+                    :ex-fn #(m/-exception ::and-generator-failure
+                                          (assoc % :schema schema))})
     (-never-gen options)))
 
 (defn- gen-one-of [gs]
@@ -210,10 +201,7 @@
                        (and min max) {:min-elements min :max-elements max}
                        min {:min-elements min}
                        max {:max-elements max})
-                     (assoc :ex-fn #(ex-info (str "Could not generate enough distinct keys for schema "
-                                                  (pr-str (m/form schema))
-                                                  ". Consider providing a custom generator.")
-                                             %)))]
+                     (assoc :ex-fn #(m/-exception ::distinct-generator-failure (assoc % :schema schema))))]
         (gen/fmap #(into {} %) (gen/vector-distinct-by first (gen/tuple k-gen v-gen) opts))))))
 
 #?(:clj
@@ -402,10 +390,7 @@
 (defn -qualified-ident-gen [schema mk-value-with-ns value-with-ns-gen-size pred gen]
   (if-let [namespace-unparsed (:namespace (m/properties schema))]
     (gen/fmap (fn [k] (mk-value-with-ns (name namespace-unparsed) (name k))) value-with-ns-gen-size)
-    (gen/such-that pred gen {:ex-fn #(ex-info (str "Could not generate a value for schema "
-                                                   (pr-str (m/form schema))
-                                                   ". Consider providing a custom generator.")
-                                              %)})))
+    (gen/such-that pred gen {:ex-fn #(m/-exception ::qualified-ident-gen-failure (assoc % :schema schema))})))
 
 (defn -qualified-keyword-gen [schema]
   (-qualified-ident-gen schema keyword gen/keyword qualified-keyword? gen/keyword-ns))
@@ -429,19 +414,13 @@
 (defmethod -schema-generator := [schema options] (gen/return (first (m/children schema options))))
 (defmethod -schema-generator :not= [schema options] (gen/such-that #(not= % (-> schema (m/children options) first)) gen/any-printable
                                                                    {:max-tries 100
-                                                                    :ex-fn #(ex-info (str "Could not generate a value for schema "
-                                                                                          (pr-str (m/form schema))
-                                                                                          ". Consider providing a custom generator.")
-                                                                                     %)}))
+                                                                    :ex-fn #(m/-exception ::not=-generator-failure (assoc % :schema schema))}))
 (defmethod -schema-generator 'pos? [_ _] (gen/one-of [(-double-gen {:min 0.00001}) (gen/fmap inc gen/nat)]))
 (defmethod -schema-generator 'neg? [_ _] (gen/one-of [(-double-gen {:max -0.0001}) (gen/fmap (comp dec -) gen/nat)]))
 
 (defmethod -schema-generator :not [schema options] (gen/such-that (m/validator schema options) (ga/gen-for-pred any?)
                                                                   {:max-tries 100
-                                                                   :ex-fn #(ex-info (str "Could not generate a value for schema "
-                                                                                         (pr-str (m/form schema))
-                                                                                         ". Consider providing a custom generator.")
-                                                                                    %)}))
+                                                                   :ex-fn #(m/-exception ::not-generator-failure (assoc % :schema schema))}))
 (defmethod -schema-generator :and [schema options] (-and-gen schema options))
 (defmethod -schema-generator :or [schema options] (-or-gen schema options))
 (defmethod -schema-generator :orn [schema options] (-or-gen (m/into-schema :or (m/properties schema) (map last (m/children schema)) (m/options schema)) options))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -131,11 +131,20 @@
                   (if (<= (or min 0) 0 (or max 0))
                     (gen/return [])
                     (-never-gen options))
-                  (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100})))))
+                  (gen/vector-distinct gen {:min-elements min, :max-elements max, :max-tries 100
+                                            :ex-fn #(ex-info (str "Could not generate enough distinct elements for schema "
+                                                                  (pr-str (m/form schema))
+                                                                  ". Consider providing a custom generator.")
+                                                             %)})))))
 
 (defn -and-gen [schema options]
   (if-some [gen (-not-unreachable (-> schema (m/children options) first (generator options)))]
-    (gen/such-that (m/validator schema options) gen 100)
+    (gen/such-that (m/validator schema options) gen
+                   {:max-tries 100
+                    :ex-fn #(ex-info (str "Could not generate a value for schema "
+                                          (pr-str (m/form schema))
+                                          ". Consider providing a custom generator.")
+                                     %)})
     (-never-gen options)))
 
 (defn- gen-one-of [gs]
@@ -191,18 +200,21 @@
 
 (defn -map-of-gen [schema options]
   (let [{:keys [min max]} (-min-max schema options)
-        [k-gen v-gen :as gs] (map #(generator % options) (m/children schema options))
-        opts (cond
-               (and min (= min max)) {:num-elements min}
-               (and min max) {:min-elements min :max-elements max}
-               min {:min-elements min}
-               max {:max-elements max}
-               :else {})]
+        [k-gen v-gen :as gs] (map #(generator % options) (m/children schema options))]
     (if (some -unreachable-gen? gs)
       (if (= 0 (or min 0) (or max 0))
         (gen/return {})
         (-never-gen options))
-      (gen/fmap #(into {} %) (gen/vector-distinct (gen/tuple k-gen v-gen) opts)))))
+      (let [opts (-> (cond
+                       (and min (= min max)) {:num-elements min}
+                       (and min max) {:min-elements min :max-elements max}
+                       min {:min-elements min}
+                       max {:max-elements max})
+                     (assoc :ex-fn #(ex-info (str "Could not generate enough distinct keys for schema "
+                                                  (pr-str (m/form schema))
+                                                  ". Consider providing a custom generator.")
+                                             %)))]
+        (gen/fmap #(into {} %) (gen/vector-distinct-by first (gen/tuple k-gen v-gen) opts))))))
 
 #?(:clj
    (defn -re-gen [schema options]
@@ -390,7 +402,10 @@
 (defn -qualified-ident-gen [schema mk-value-with-ns value-with-ns-gen-size pred gen]
   (if-let [namespace-unparsed (:namespace (m/properties schema))]
     (gen/fmap (fn [k] (mk-value-with-ns (name namespace-unparsed) (name k))) value-with-ns-gen-size)
-    (gen/such-that pred gen)))
+    (gen/such-that pred gen {:ex-fn #(ex-info (str "Could not generate a value for schema "
+                                                   (pr-str (m/form schema))
+                                                   ". Consider providing a custom generator.")
+                                              %)})))
 
 (defn -qualified-keyword-gen [schema]
   (-qualified-ident-gen schema keyword gen/keyword qualified-keyword? gen/keyword-ns))
@@ -412,11 +427,21 @@
 (defmethod -schema-generator :< [schema options] (-double-gen {:max (-> schema (m/children options) first dec)}))
 (defmethod -schema-generator :<= [schema options] (-double-gen {:max (-> schema (m/children options) first)}))
 (defmethod -schema-generator := [schema options] (gen/return (first (m/children schema options))))
-(defmethod -schema-generator :not= [schema options] (gen/such-that #(not= % (-> schema (m/children options) first)) gen/any-printable 100))
+(defmethod -schema-generator :not= [schema options] (gen/such-that #(not= % (-> schema (m/children options) first)) gen/any-printable
+                                                                   {:max-tries 100
+                                                                    :ex-fn #(ex-info (str "Could not generate a value for schema "
+                                                                                          (pr-str (m/form schema))
+                                                                                          ". Consider providing a custom generator.")
+                                                                                     %)}))
 (defmethod -schema-generator 'pos? [_ _] (gen/one-of [(-double-gen {:min 0.00001}) (gen/fmap inc gen/nat)]))
 (defmethod -schema-generator 'neg? [_ _] (gen/one-of [(-double-gen {:max -0.0001}) (gen/fmap (comp dec -) gen/nat)]))
 
-(defmethod -schema-generator :not [schema options] (gen/such-that (m/validator schema options) (ga/gen-for-pred any?) 100))
+(defmethod -schema-generator :not [schema options] (gen/such-that (m/validator schema options) (ga/gen-for-pred any?)
+                                                                  {:max-tries 100
+                                                                   :ex-fn #(ex-info (str "Could not generate a value for schema "
+                                                                                         (pr-str (m/form schema))
+                                                                                         ". Consider providing a custom generator.")
+                                                                                    %)}))
 (defmethod -schema-generator :and [schema options] (-and-gen schema options))
 (defmethod -schema-generator :or [schema options] (-or-gen schema options))
 (defmethod -schema-generator :orn [schema options] (-or-gen (m/into-schema :or (m/properties schema) (map last (m/children schema)) (m/options schema)) options))

--- a/test/malli/generator_debug.cljc
+++ b/test/malli/generator_debug.cljc
@@ -15,6 +15,7 @@
   ([generator min-elements max-elements]
    {:op :vector :generator generator :min-elements min-elements :max-elements max-elements}))
 (defmacro vector-distinct [& args] (let [args (vec args)] `{:op :vector-distinct :args-form '~args :args ~args}))
+(defmacro vector-distinct-by [& args] (let [args (vec args)] `{:op :vector-distinct-by :args-form '~args :args ~args}))
 (def char {:op :char})
 (def nat {:op :nat})
 (def char-alphanumeric {:op :char-alphanumeric})

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -844,37 +844,44 @@
                       {:seed 0})))))
 
 (deftest map-of-schema-simplify-test
-  (is (= '({} {} {{} {}} {{} {}} {} {{} {}} {} {{} {}} {{} {}} {{{} {}} {{} {}}, {} {}})
-         (mg/sample [:schema {:registry {::rec [:map-of [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
-                    {:seed 0})
-         (mg/sample (gen/recursive-gen
-                      (fn [rec]
-                        (gen/fmap #(into {} %)
-                                  (gen/vector-distinct-by first (gen/tuple rec rec))))
-                      (gen/return {}))
-                    {:seed 0})))
-  (is (thrown-with-msg?
-        #?(:clj Exception, :cljs js/Error)
-        #"Cannot generate values due to infinitely expanding schema: \[:map-of \{:min 1\} \[:ref :malli\.generator-test/rec\] \[:ref :malli\.generator-test/rec\]\]"
-        (mg/generate [:schema {:registry {::rec [:map-of {:min 1} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
-                     {:seed 0})))
-  (is (= '({{} {}} {{} {}} {{} {}} {{} {}} {} {{} {}} {} {{} {}} {{} {}} {{{} {}} {{} {}}, {} {}})
-         (mg/sample [:schema {:registry {::rec [:map-of {:max 3} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
-                    {:seed 0})
-         (mg/sample [:schema {:registry {::rec [:map-of {:min 0 :max 3} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
-                    {:seed 0}))))
+  (testing "empty maps allowed if :min is not positive"
+    (is (= '({} {} {{} {}} {{} {}} {} {{} {}} {} {{} {}} {{} {}} {{{} {}} {{} {}}, {} {}})
+           (mg/sample [:schema {:registry {::rec [:map-of [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample [:schema {:registry {::rec [:map-of {:min 0} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample (gen/recursive-gen
+                        (fn [rec]
+                          (gen/fmap #(into {} %)
+                                    (gen/vector-distinct-by first (gen/tuple rec rec))))
+                        (gen/return {}))
+                      {:seed 0}))))
+  (testing "cannot generate empty for positive :min"
+    (is (thrown-with-msg?
+          #?(:clj Exception, :cljs js/Error)
+          #"Cannot generate values due to infinitely expanding schema: \[:map-of \{:min 1\} \[:ref :malli\.generator-test/rec\] \[:ref :malli\.generator-test/rec\]\]"
+          (mg/generate [:schema {:registry {::rec [:map-of {:min 1} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
+                       {:seed 0}))))
+  (testing "can generate empty regardless of :max"
+    (is (= '({{} {}} {{} {}} {{} {}} {{} {}} {} {{} {}} {} {{} {}} {{} {}} {{{} {}} {{} {}}, {} {}})
+           (mg/sample [:schema {:registry {::rec [:map-of {:max 3} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample [:schema {:registry {::rec [:map-of {:min 0 :max 3} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})))))
 
 (deftest vector-schema-simplify-test
-  (testing "empty vectors allowed"
+  (testing "empty vectors allowed if :min is not positive"
     (is (= '([] [] [[] []] [[] []] [] [[]] [] [[] []] [[]] [[[] []] [[] []]])
            (mg/sample [:schema {:registry {::rec [:vector [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample [:schema {:registry {::rec [:vector {:min 0} [:ref ::rec]]}} [:ref ::rec]]
                       {:seed 0})
            (mg/sample (gen/recursive-gen
                        (fn [rec]
                          (gen/vector rec))
                        (gen/return []))
                       {:seed 0}))))
-  (testing "no empty vectors allowed"
+  (testing "no empty vectors allowed with positive :min"
     (is (= [nil nil [nil nil nil] [nil] nil [nil nil] nil [nil nil nil] nil [[nil nil nil]]]
            (mg/sample [:schema {:registry {::rec [:maybe [:vector {:min 1} [:ref ::rec]]]}} [:ref ::rec]]
                       {:seed 0})
@@ -883,6 +890,72 @@
                          (gen/one-of [(gen/return nil)
                                       (gen/sized #(gen/vector rec 1 (+ 1 %)))]))
                        (gen/one-of [(gen/return nil)]))
+                      {:seed 0}))))
+  (testing "can generate empty regardless of :max"
+    (is (= '([[] [] [] []] [[] [] [] []] [[] [] [] [] [] [] []] [[] [] [] [] [] [] [] []] [[] []]
+             [[] [] [] [] []] [] [[] [] [] [] [] [] [] []] [[] [] [] []]
+             [[[] [] [] [] [] [] [] []] [[] [] []] [] [[] [] [] []] [] [[] [] [] [] [] [] [] []] [[] [] []]])
+           (mg/sample [:schema {:registry {::rec [:vector {:max 10} [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample [:schema {:registry {::rec [:vector {:min 0 :max 10} [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})))))
+
+(deftest sequential-schema-simplify-test
+  (testing "empty sequentials allowed"
+    (is (= '([] [] [[] []] [[] []] [] [[]] [] [[] []] [[]] [[[] []] [[] []]])
+           (mg/sample [:schema {:registry {::rec [:sequential [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample (gen/recursive-gen
+                       (fn [rec]
+                         (gen/vector rec))
+                       (gen/return []))
+                      {:seed 0}))))
+  (testing "no empty sequentials allowed with positive :min"
+    (is (= [nil nil [nil nil nil] [nil] nil [nil nil] nil [nil nil nil] nil [[nil nil nil]]]
+           (mg/sample [:schema {:registry {::rec [:maybe [:sequential {:min 1} [:ref ::rec]]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample (gen/recursive-gen
+                       (fn [rec]
+                         (gen/one-of [(gen/return nil)
+                                      (gen/sized #(gen/vector rec 1 (+ 1 %)))]))
+                       (gen/one-of [(gen/return nil)]))
+                      {:seed 0}))))
+  (testing "can generate empty regardless of :max"
+    (is (= '([[] [] [] []] [[] [] [] []] [[] [] [] [] [] [] []] [[] [] [] [] [] [] [] []] [[] []]
+             [[] [] [] [] []] [] [[] [] [] [] [] [] [] []] [[] [] [] []]
+             [[[] [] [] [] [] [] [] []] [[] [] []] [] [[] [] [] []] [] [[] [] [] [] [] [] [] []] [[] [] []]])
+           (mg/sample [:schema {:registry {::rec [:sequential {:max 10} [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample [:schema {:registry {::rec [:sequential {:min 0 :max 10} [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})))))
+
+(deftest set-schema-simplify-test
+  (testing "empty sets allowed if :min is not positive"
+    (is (= '(#{} #{} #{#{}} #{#{}} #{} #{#{}} #{} #{#{}} #{#{}} #{#{} #{#{}}})
+           (mg/sample [:schema {:registry {::rec [:set [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample [:schema {:registry {::rec [:set {:min 0} [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample (gen/recursive-gen
+                        (fn [rec]
+                          (gen/fmap set (gen/vector-distinct rec)))
+                        (gen/return #{}))
+                      {:seed 0}))))
+  (testing "no empty sets allowed with positive :min"
+    (is (= '(nil nil #{nil} #{nil} nil #{nil} nil #{nil} nil #{#{nil}})
+           (mg/sample [:schema {:registry {::rec [:maybe [:set {:min 1} [:ref ::rec]]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample (gen/recursive-gen
+                       (fn [rec]
+                         (gen/one-of [(gen/return nil)
+                                      (gen/fmap set (gen/vector-distinct rec {:min-elements 1}))]))
+                       (gen/one-of [(gen/return nil)]))
+                      {:seed 0}))))
+  (testing "can generate empty regardless of :max"
+    (is (= '(#{#{}} #{#{}} #{#{}} #{#{}} #{#{}} #{#{}} #{} #{#{}} #{#{}} #{#{} #{#{}}})
+           (mg/sample [:schema {:registry {::rec [:set {:max 10} [:ref ::rec]]}} [:ref ::rec]]
+                      {:seed 0})
+           (mg/sample [:schema {:registry {::rec [:set {:min 0 :max 10} [:ref ::rec]]}} [:ref ::rec]]
                       {:seed 0})))))
 
 (defn alphanumeric-char? [c]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -852,6 +852,16 @@
                         (gen/fmap #(into {} %)
                                   (gen/vector-distinct-by first (gen/tuple rec rec))))
                       (gen/return {}))
+                    {:seed 0})))
+  (is (thrown-with-msg?
+        #?(:clj Exception, :cljs js/Error)
+        #"Cannot generate values due to infinitely expanding schema: \[:map-of \{:min 1\} \[:ref :malli\.generator-test/rec\] \[:ref :malli\.generator-test/rec\]\]"
+        (mg/generate [:schema {:registry {::rec [:map-of {:min 1} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
+                     {:seed 0})))
+  (is (= '({{} {}} {{} {}} {{} {}} {{} {}} {} {{} {}} {} {{} {}} {{} {}} {{{} {}} {{} {}}, {} {}})
+         (mg/sample [:schema {:registry {::rec [:map-of {:max 3} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
+                    {:seed 0})
+         (mg/sample [:schema {:registry {::rec [:map-of {:min 0 :max 3} [:ref ::rec] [:ref ::rec]]}} [:ref ::rec]]
                     {:seed 0}))))
 
 (deftest vector-schema-simplify-test


### PR DESCRIPTION
1. The `:map-of` generator should use `(gen/vector-distinct-by first ..)` in order to satisfy `:min`, otherwise it can generate less than the minimum number of entries by generating the same key multiple times with different vals.

2. `such-that` and functions built on it accept a custom error message on generation failures. It's very helpful to have the precise schema that failed in the error message.

3. The unreachable elements case for `:map-of` disallows generating the empty map if `:max` was non-zero. It's perfectly fine to generate empty regardless of `:max`. Other collection generators almost made this mistake by checking `(<= (or min 0) 0 (or max 0))`, which is technically correct but simplifiable to `(= 0 (or min 0))`.

4. `coll-distinct-gen` nested generators incorrectly in the unreachable elements case. We want `(-never-gen options)`, not `(gen/fmap f (-never-gen options))` which defeats our simplification logic of checking for `-never-gen`'s metadata.