### PR TITLE
WIP: Deterministic and varied pure/impure fn gen

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -98,13 +98,6 @@
                                       (throw (m/-exception ::failed-to-recover-seed))))]
        (gen/call-gen seeded-gen rnd size)))))
 
-(comment
-  (gen/sample (seeded (fn [seed] (gen/return seed))))
-  ((requiring-resolve 'clojure.pprint/pprint) (gen/sample (seeded (fn [seed]
-                        (gen/tuple (gen/return seed)
-                                   (generator :int {:seed seed}))))))
-  )
-
 (defn ^:deprecated -recur [_schema options]
   (println (str `-recur " is deprecated, please update your generators. See instructions in malli.generator."))
   [true options])

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -16,9 +16,6 @@
 
 (declare generator generate -create sampling-eduction)
 
-; {'x {:last-nth 2 :examples [1 2 3 4]}}
-(def ^:private +type-variable-examples+ (atom {}))
-
 (defprotocol Generator
   (-generator [this options] "returns generator for schema"))
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -92,7 +92,7 @@
           [5327329620473603684 34]
           [8284970028005224634 12])"
   [seeded-gen]
-  (#'gen/make-gen
+  (#'gen/make-gen ;;FIXME bb
    (fn [^clojure.test.check.random.JavaUtilSplittableRandom rnd size]
      (let [seeded-gen (seeded-gen (or (.-state rnd)
                                       (throw (m/-exception ::failed-to-recover-seed))))]

--- a/test/malli/generator_debug.cljc
+++ b/test/malli/generator_debug.cljc
@@ -46,5 +46,6 @@
 (defn not-empty [gen] {:op :not-empty :gen gen})
 (defn generator? [& args] (assert nil "no stub for generator?"))
 (defn call-gen [& args] (assert nil "no stub for call-gen"))
+(defn make-gen [& args] (assert nil "no stub for make-gen"))
 (defn make-size-range-seq [& args] (assert nil "no stub for make-size-range-seq"))
 (defn lazy-random-states [& args] (assert nil "no stub for lazy-random-states"))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1066,3 +1066,25 @@
          (map #(%1 %2)
               (repeatedly (mg/generate [:=> :cat [:=> [:cat :int] :int]] {:seed 1 :size 30}))
               (range 10)))))
+(comment
+;; This sequence of results should be reproducible.
+(def pure   (mg/generate [:=>                    [:cat :int] :int] {:seed 0 :size 10}))
+(def impure (mg/generate [:=> {:gen/impure true} [:cat :int] :int] {:seed 0 :size 10}))
+(repeatedly 10 #(pure 2))
+;=> (-106 -106 -106 -106 -106 -106 -106 -106 -106 -106)
+(repeatedly 10 #(pure 2))
+;=> (-106 -106 -106 -106 -106 -106 -106 -106 -106 -106)
+(repeatedly 10 #(impure 2))
+;=> (0 -1 0 -3 0 1 16 0 7 3)
+(repeatedly 10 #(impure 2))
+;=> (0 -1 -1 1 2 3 -2 38 -5 -12)
+
+(mapv pure (range 10))
+;=> [5 511 -106 20 -51 -322 1 0 434 -1]
+(mapv pure (range 10))
+;=> [5 511 -106 20 -51 -322 1 0 434 -1]
+(mapv impure (range 10))
+;=> [-1 0 -2 -4 -3 -4 -15 -15 -16 -2]
+(mapv impure (range 10))
+;=> [-1 -1 -1 0 1 3 -12 30 -2 1]
+)


### PR DESCRIPTION
Close #1039 

FWIW I haven't worked out how to make functions shrinkable.

The implementation can be further simplified by using the private `gen/randomized` function instead of `seeded`. That might fix the babashka tests.

```clojure
;; This sequence of results should be reproducible.
(def pure   (mg/generate [:=>                    [:cat :int] :int] {:seed 0 :size 10}))
(def impure (mg/generate [:=> {:gen/impure true} [:cat :int] :int] {:seed 0 :size 10}))
(repeatedly 10 #(pure 2))
;=> (-106 -106 -106 -106 -106 -106 -106 -106 -106 -106)
(repeatedly 10 #(pure 2))
;=> (-106 -106 -106 -106 -106 -106 -106 -106 -106 -106)
(repeatedly 10 #(impure 2))
;=> (0 -1 0 -3 0 1 16 0 7 3)
(repeatedly 10 #(impure 2))
;=> (0 -1 -1 1 2 3 -2 38 -5 -12)

(mapv pure (range 10))
;=> [5 511 -106 20 -51 -322 1 0 434 -1]
(mapv pure (range 10))
;=> [5 511 -106 20 -51 -322 1 0 434 -1]
(mapv impure (range 10))
;=> [-1 0 -2 -4 -3 -4 -15 -15 -16 -2]
(mapv impure (range 10))
;=> [-1 -1 -1 0 1 3 -12 30 -2 1]
```