### PR TITLE
Add :gen/resolve property

### DIFF
--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -236,7 +236,13 @@
 
   (testing "gen/gen"
     (is (every? #{1 2} (mg/sample [:and {:gen/gen (gen/elements [1 2])} int?] {:size 1000})))
-    (is (every? #{"1" "2"} (mg/sample [:and {:gen/gen (gen/elements [1 2]) :gen/fmap str} int?] {:size 1000})))))
+    (is (every? #{"1" "2"} (mg/sample [:and {:gen/gen (gen/elements [1 2]) :gen/fmap str} int?] {:size 1000}))))
+  (testing "gen/resolve"
+    (is (every? #{1 2} (mg/sample [:and {:gen/resolve 'malli.generator-test/resolvable-gen} int?] {:size 1000})))
+    (is (every? #{"1" "2"} (mg/sample [:and {:gen/resolve 'malli.generator-test/resolvable-gen :gen/fmap str} int?] {:size 1000})))))
+
+(def resolvable-gen
+  (gen/elements [1 2]))
 
 (defn- schema+coll-gen [type children-gen]
   (gen/let [children children-gen]


### PR DESCRIPTION
This works much like `:gen/gen`, but will first attempt to resolve the fully-qualified symbol. 

This separation means that malli schemas are free to carry around this extra data about where generators live, without having to have them loaded at runtime. Instead, generators declared in this way are dynamically loaded when used.
