### PR TITLE
Make clj-kondo dir configurable

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -206,7 +206,9 @@
    {:linters {:unresolved-symbol {:exclude ['(malli.core/=>)]}}} xs))
 
 #?(:clj
-   (defn emit! [] (-> (collect) (linter-config) (save!)) nil))
+   (defn emit!
+     ([] (emit! {}))
+     ([options] (->> (collect) (linter-config) (merge options) (save!)) nil)))
 
 (defn collect-cljs
   ([] (collect-cljs nil))

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -159,12 +159,18 @@
 
 #?(:clj
    (defn save!
+     "config:
+      - :clj-kondo-dir-path : optional, path to the .clj-kondo directory"
      ([config]
       (save! config :clj))
      ([config key]
-      (let [cfg-file (io/file ".clj-kondo" "metosin" (str "malli-types-" (name key)) "config.edn")]
+      (let [cfg-file (apply io/file (conj
+                                     (get config :clj-kondo-dir-path [])
+                                     ".clj-kondo" "metosin" (str "malli-types-" (name key)) "config.edn"))]
         ;; delete the old file if exists (does not throw)
-        (.delete (io/file ".clj-kondo" "configs" "malli" "config.edn"))
+        (.delete (apply io/file (conj
+                                 (get config :clj-kondo-dir-path [])
+                                 ".clj-kondo" "configs" "malli" "config.edn")))
         (io/make-parents cfg-file)
         (spit cfg-file (with-out-str (fipp/pprint config {:width 120})))
         config))))

--- a/src/malli/dev.clj
+++ b/src/malli/dev.clj
@@ -56,9 +56,9 @@
                       (reduce-kv assoc-in {})
                       (assoc options :data)
                       (mi/instrument!))
-                 (clj-kondo/emit!))]
+                 (clj-kondo/emit! options))]
      (add-watch @#'m/-function-schemas* ::watch watch))
    (let [count (->> (mi/instrument! options) (count))]
      (when (pos? count) (-log! (format "instrumented %d function vars" count))))
-   (clj-kondo/emit!)
+   (clj-kondo/emit! options)
    (-log! "dev-mode started")))


### PR DESCRIPTION
Hello,
in a monorepo setting I had the need to configure the malli-kondo integration to accommodate the clj-kondo dir being in a non-standard location.

This can of course already be achieved by overwriting a few functions from `malli.clj-kondo` and `malli.dev`.
The following changes would make this kind of setup supported out of the box.

I'd also support merging only the first commit in case you don't want to merge the `instrument!` options and the `emit!` ones.


p.s. this is the monorepo structure in question:
```
├── apps
│   ├── app1    <- clj/cljs interpreter is started here
│   └── app2
└── clj_src
    ├── .clj-kondo
    └── my-corp     <- all code lives here
```