### PR TITLE
Fix Quickstart example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ Malli is tested with the LTS releases Java 8, 11, 17 and 21.
 
 (def User
   [:map
-   [:id #'UserId]
-   [:address #'Address]
-   [:friends [:set {:gen/max 2} [:ref #'User]]]])
+   [:id UserId]
+   [:address Address]
+   [:friends [:set {:gen/max 2} [:ref User]]]])
 
 (require '[malli.generator :as mg])
 


### PR DESCRIPTION
Hello,

Problem:

In the Quickstart of the README, you reference other schema with the `#'<SCHEMA>` syntax. But it doesn't work, it gives `:malli.core/invalid-schema` error.

Steps to reproduce:

1. Start a new REPL with malli in the `deps.edn` file
2. Paste the code of the Quickstart
3. When generating with `malli.generator` or validating a handcrafted User object, it always gives the following error : `; :malli.core/invalid-schema {:schema #'user/UserId}`

How to fix:

Just remove the `#'` from schema references. Note that I still get another error `:malli.core/invalid-ref {:ref [:map [:id :string] [:address [:map [:street :string] [:country [:enum "FI" "UA"]]]] [:friends [:set #:gen{:max 2} [:ref #'user/User]]]]}`. It maybe because I don't know how to use `:ref`. But in my real world app removing `#'` totally fixed the problem.

Further suggestion (if I may) :

The Quickstart is the only place I found where you compose a schema out of smaller schema and demonstrate composition through schema reuse. Is it because it's limited? I think it deserves at least a formal documentation like : "You can create a schema with any Schema syntax and just reuse it to compose bigger schema and avoid code duplication` or something like that. You get the point I hope.

Thanks!