### PR TITLE
Add :-> to default registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Malli is in well matured [alpha](README.md#alpha).
 
 ## UNRELEASED
 
-* `:->` added to dedault registry, added to [documentation](docs/function-schemas.md#flat-arrow-function-schemas).
+* `:->` added to dedault registry, also to [documentation](docs/function-schemas.md#flat-arrow-function-schemas).
 
 ## 0.16.2 (2024-06-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* `:->` added to dedault registry, added to [documentation](docs/function-schemas.md#flat-arrow-function-schemas).
+
 ## 0.16.2 (2024-06-30)
 
 * Experimental `:->` for simpler function defintions (not available on default schema registry) [#1027](https://github.com/metosin/malli/pull/1027)

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ Examples:
 [:tuple {:title "location"} :double :double]
 
 ;; a function schema of :int -> :int
-[:-> :int :int]
 [:=> [:cat :int] :int]
+[:-> :int :int]
 ```
 
 Usage:

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Examples:
 [:tuple {:title "location"} :double :double]
 
 ;; a function schema of :int -> :int
+[:-> :int :int]
 [:=> [:cat :int] :int]
 ```
 
@@ -177,6 +178,8 @@ Alternative map-syntax, similar to [cljfx](https://github.com/cljfx/cljfx):
 {:type :=>
  :input {:type :cat, :children [{:type :int}]}
  :output :int}
+{:type :->
+ :children [{:type :int} {:type :int}]}
 ```
 
 Usage:
@@ -3296,7 +3299,7 @@ Sequence/regex-schemas: `:+`, `:*`, `:?`, `:repeat`, `:cat`, `:alt`, `:catn`, `:
 
 ### `malli.core/base-schemas`
 
-Contains `:and`, `:or`, `:orn`, `:not`, `:map`, `:map-of`, `:vector`, `:sequential`, `:set`, `:enum`, `:maybe`, `:tuple`, `:multi`, `:re`, `:fn`, `:ref`, `:=>`, `:function` and `:schema`.
+Contains `:and`, `:or`, `:orn`, `:not`, `:map`, `:map-of`, `:vector`, `:sequential`, `:set`, `:enum`, `:maybe`, `:tuple`, `:multi`, `:re`, `:fn`, `:ref`, `:=>`, `:->`, `:function` and `:schema`.
 
 ### `malli.util/schemas`
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1932,7 +1932,7 @@
         (reify
           Schema
           (-validator [_] (-validator schema))
-          (-explainer [_ path] (-explainer schema path))
+          (-explainer [_ path] (-explainer schema (conj path ::in)))
           (-parser [_] (-parser schema))
           (-unparser [_] (-unparser schema))
           (-transformer [this transformer method options]
@@ -1950,7 +1950,7 @@
           (-cache [_] cache)
           LensSchema
           (-keep [_])
-          (-get [_ key default] (get children key default))
+          (-get [_ key default] (if (= ::in key) schema (get children key default)))
           (-set [_ key value] (into-schema type properties (assoc children key value)))
           FunctionSchema
           (-function-schema? [_] (-function-schema? schema))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2625,7 +2625,7 @@
    :fn (-fn-schema)
    :ref (-ref-schema)
    :=> (-=>-schema)
-   ;:-> (-->-schema nil)
+   :-> (-->-schema nil)
    :function (-function-schema nil)
    :schema (-schema-schema nil)
    ::schema (-schema-schema {:raw true})})

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1974,6 +1974,7 @@
   [_]
   (-proxy-schema {:type :->
                   :fn (fn [{:keys [guard] :as p} c o]
+                        (-check-children! :-> p c 1 nil)
                         (let [c (mapv #(schema % o) c)
                               cc (cond-> [(into [:cat] (pop c)) (peek c)]
                                    guard (conj [:fn guard]))]

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -4,9 +4,6 @@
             [malli.core :as m]
             [malli.util :as mu]))
 
-;; not part of default registry
-(def --> (m/-->-schema nil))
-
 (def Schema
   (m/schema
    [:map {:registry {::id string?
@@ -44,8 +41,8 @@
   ([x y & z] (apply + (* x y) z)))
 
 (m/=> kikka2 [:function
-              [--> :int [:int {:min 0}]]
-              [--> :int :int [:* :int] :int]])
+              [:-> :int [:int {:min 0}]]
+              [:-> :int :int [:* :int] :int]])
 
 (defn siren [f coll]
   (into {} (map (juxt f identity) coll)))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -15,9 +15,6 @@
   #?(:clj  (:import (clojure.lang IFn PersistentArrayMap PersistentHashMap))
      :cljs (:require-macros [malli.test-macros :refer [when-env]])))
 
-;; not part of default registry
-(def --> (m/-->-schema nil))
-
 (defn with-schema-forms [result]
   (some-> result
           (update :schema m/form)
@@ -2458,7 +2455,7 @@
           :output :int
           :guard nil}
          (fn-schema-info [:=> [:cat :int :int] :int])
-         (fn-schema-info [--> :int :int :int])))
+         (fn-schema-info [:-> :int :int :int])))
 
   (testing ":=>"
     (let [?schema [:=> [:cat int? int?] int?]
@@ -2513,7 +2510,7 @@
                (m/ast schema1))))))
 
   (testing ":->"
-    (let [?schema [--> int? int? int?]
+    (let [?schema [:-> int? int? int?]
           valid-f (fn [x y] (unchecked-subtract x y))
           schema1 (m/schema ?schema)
           schema2 (m/schema ?schema {::m/function-checker mg/function-checker})]
@@ -2565,11 +2562,11 @@
 
   (testing ":function"
     (is (= nil
-           (fn-schema-info (m/schema [:function [--> :int :int :int]]))))
+           (fn-schema-info (m/schema [:function [:-> :int :int :int]]))))
     (is (= [[:-> :int :int :int]
             [:=> [:cat :int] :int]]
            (map m/form (m/-function-schema-arities (m/schema [:function
-                                                              [--> :int :int :int]
+                                                              [:-> :int :int :int]
                                                               [:=> [:cat :int] :int]])))))
     (doseq [s [[:function :cat]]]
       (is (thrown-with-msg?
@@ -2589,7 +2586,7 @@
                   [:=> :cat nil?]
                   [:=> :cat nil?]]
                  [:function
-                  [--> nil?]
+                  [:-> nil?]
                   [:=> :cat nil?]]]]
         (is (thrown-with-msg?
              #?(:clj Exception, :cljs js/Error)
@@ -2646,7 +2643,7 @@
                            [:=> [:cat :int :int] :string [:fn guard]]
                            {::m/function-checker mg/function-checker})
                   schema2 (m/schema
-                           [--> {:guard guard} :int :int :string]
+                           [:-> {:guard guard} :int :int :string]
                            {::m/function-checker mg/function-checker})
                   valid (fn [x y] (str x y))
                   invalid (fn [x y] (str x "-" y))]
@@ -2694,7 +2691,7 @@
 
               (testing "instrument"
                 (doseq [schema [[:=> [:cat :any] :any [:fn (fn [[[arg] ret]] (not= arg ret))]]
-                                [--> {:guard (fn [[[arg] ret]] (not= arg ret))} :any :any]]]
+                                [:-> {:guard (fn [[[arg] ret]] (not= arg ret))} :any :any]]]
                   (let [fn (m/-instrument {:schema schema} str)]
 
                     (is (= "2" (fn 2)))

--- a/test/malli/experimental/describe_test.cljc
+++ b/test/malli/experimental/describe_test.cljc
@@ -1,10 +1,6 @@
 (ns malli.experimental.describe-test
   (:require [clojure.test :refer [deftest is testing]]
-            [malli.core :as m]
             [malli.experimental.describe :as med]))
-
-;; not part of default registry
-(def --> (m/-->-schema nil))
 
 (deftest descriptor-test
   (testing "vector"
@@ -20,7 +16,7 @@
     (is (= "function that takes input: [integer] and returns integer"
            (med/describe [:=> [:cat int?] int?])))
     (is (= "function that takes input: [integer] and returns integer"
-           (med/describe [--> int? int?]))))
+           (med/describe [:-> int? int?]))))
 
   (testing "map"
     (is (= "map" (med/describe map?)))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -12,9 +12,6 @@
                :cljs ["@js-joda/timezone/dist/js-joda-timezone-10-year-range"]))
   #?(:cljs (:require-macros [malli.test-macros :refer [when-env]])))
 
-;; not part of default registry
-(def --> (m/-->-schema nil))
-
 (defn shrink [?schema]
   (-> (quick-check 1 (for-all [s (mg/generator ?schema)] false) {:seed 0})
       :shrunk
@@ -377,7 +374,7 @@
 #?(:clj
    (deftest function-schema-test
      (doseq [?schema [[:=> [:cat int? int?] int?]
-                      [--> int? int? int?]]]
+                      [:-> int? int? int?]]]
        (let [f (m/schema ?schema)
              {:keys [input output]} (m/-function-info f)]
          (is (every? #(m/validate output (apply % (mg/generate input))) (mg/sample f {:size 1000})))))
@@ -386,8 +383,8 @@
                        [:=> [:cat int?] int?]
                        [:=> [:cat int? int?] int?]]
                       [:function
-                       [--> int? int?]
-                       [--> int? int? int?]]]]
+                       [:-> int? int?]
+                       [:-> int? int? int?]]]]
        (is (every? #(m/validate int? (apply % (mg/generate [:or [:cat int?] [:cat int? int?]]))) (mg/sample ?schema {:size 1000}))))))
 
 (deftest recursive-schema-generation-test-307

--- a/test/malli/instrument/fn_schemas.cljs
+++ b/test/malli/instrument/fn_schemas.cljs
@@ -1,11 +1,6 @@
 (ns malli.instrument.fn-schemas
-  (:require
-   [malli.core :as m]
-   [malli.experimental :as mx]
-   [malli.instrument.fn-schemas2 :as schemas :refer [small-int int-arg VecOfStrings]]))
-
-;; not part of default registry
-(def --> (m/-->-schema nil))
+  (:require [malli.experimental :as mx]
+            [malli.instrument.fn-schemas2 :as schemas :refer [small-int int-arg VecOfStrings]]))
 
 (def VecOfInts [:vector :int])
 
@@ -27,7 +22,7 @@
 (def str-join-schema [:=> [:cat VecOfStrings] schemas/string])
 
 (defn str-join2
-  {:malli/schema [--> VecOfStrings schemas/string]}
+  {:malli/schema [:-> VecOfStrings schemas/string]}
   [args]
   (apply str args))
 

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -6,9 +6,6 @@
             [malli.json-schema :as json-schema]
             [malli.util :as mu]))
 
-;; not part of default registry
-(def --> (m/-->-schema nil))
-
 (def expectations
   [;; predicates
    [pos-int? {:type "integer", :minimum 1}]
@@ -112,7 +109,7 @@
    [:uuid {:type "string", :format "uuid"}]
 
    [[:=> :cat int?] {} :fn]
-   [[--> :cat int?] {} :fn]
+   [[:-> :cat int?] {} :fn]
    [[:function [:=> :cat int?]] {} :fn]
    [ifn? {}]
 


### PR DESCRIPTION
`:->` was not part of the default registry as the explain results did not conform to the schema lens laws (given explain error path to `mu/get-in`, you should get the schema in error). Now fixed using `::m/in` path pointer.