### PR TITLE
Fix OOM error with infinitely expanding schema

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -264,7 +264,11 @@
 (defn- -lookup [?schema options]
   (let [registry (-registry options)]
     (or (mr/-schema registry ?schema)
-        (some-> registry (mr/-schema (c/type ?schema)) (-into-schema nil [?schema] options)))))
+        (when-some [p (some-> registry (mr/-schema (c/type ?schema)))]
+          (when (schema? ?schema)
+            (when (= p (-parent ?schema))
+              (-fail! ::infinitely-expanding-schema {:schema ?schema})))
+          (-into-schema p nil [?schema] options)))))
 
 (defn- -lookup! [?schema ?form f rec options]
   (or (and f (f ?schema) ?schema)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3376,5 +3376,6 @@
 (deftest catch-infinitely-expanding-schema
   (is (thrown-with-msg?
         #?(:clj Exception, :cljs js/Error)
-        #":malli\.core/infinitely-expanding-schema"
+        #?(:clj #":malli\.core/infinitely-expanding-schema"
+           :cljs #":malli\.core/invalid-schema")
         (m/schema [(m/schema :any)]))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3372,3 +3372,9 @@
                    :errors [{:path [::m/in :y], :in [:y], :schema y-schema, :value "2"}]}
                   explain))
     (is (form= y-schema (mu/get-in schema (-> explain :errors first :path))))))
+
+(deftest catch-infinitely-expanding-schema
+  (is (thrown-with-msg?
+        #?(:clj Exception, :cljs js/Error)
+        #":malli\.core/infinitely-expanding-schema"
+        (m/schema [(m/schema :any)]))))

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -4,13 +4,19 @@
             [malli.registry :as mr]))
 
 (deftest mutable-test
-  (let [registry* (atom {})
+  (let [registry* (atom (m/default-schemas))
         registry (mr/mutable-registry registry*)
         register! (fn [t ?s] (swap! registry* assoc t ?s))]
     (testing "default registy"
       (is (thrown? #?(:clj Exception, :cljs js/Error) (m/validate :str "kikka" {:registry registry})))
       (register! :str (m/-string-schema))
-      (is (true? (m/validate :str "kikka" {:registry registry}))))))
+      (is (true? (m/validate :str "kikka" {:registry registry}))))
+    (register! ::int-pair (m/schema [:tuple :int :int]))
+    (is (thrown-with-msg?
+          #?(:clj Exception, :cljs js/Error)
+          #?(:clj #":malli\.core/infinitely-expanding-schema"
+             :cljs #":malli\.core/invalid-schema")
+          (m/schema [::int-pair {:foo :bar}] {:registry registry})))))
 
 (deftest composite-test
   (let [registry* (atom {})

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -4,7 +4,7 @@
             [malli.registry :as mr]))
 
 (deftest mutable-test
-  (let [registry* (atom (m/default-schemas))
+  (let [registry* (atom {})
         registry (mr/mutable-registry registry*)
         register! (fn [t ?s] (swap! registry* assoc t ?s))]
     (testing "default registy"

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -4,7 +4,7 @@
             [malli.registry :as mr]))
 
 (deftest mutable-test
-  (let [registry* (atom {})
+  (let [registry* (atom (m/default-schemas))
         registry (mr/mutable-registry registry*)
         register! (fn [t ?s] (swap! registry* assoc t ?s))]
     (testing "default registy"


### PR DESCRIPTION
Close #1061 

The call `(m/schema [(m/schema :any)])` infinitely wraps `:any` using `::schema` until memory is exhausted. Stop as soon as we detect the first wrapping.

In CLJS this doesn't seem to be allowed in the first place.