### PR TITLE
WIP: Support vector syntax for references

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -277,8 +277,8 @@
 (defn- -lookup-into-schema [?schema options]
   (if (into-schema? ?schema)
     ?schema
-    (when-some [?schema (-lookup ?schema options)]
-      (recur ?schema options))))
+    (some-> (-lookup ?schema options)
+            (recur options))))
 
 (defn -properties-and-options [properties options f]
   (if-let [r (:registry properties)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -275,12 +275,11 @@
         (-fail! ::invalid-schema {:schema ?schema, :form ?form}))))
 
 (defn- -lookup-into-schema [?schema options]
-  (let [registry (-registry options)]
-    (loop [?schema ?schema]
-      (if (into-schema? ?schema)
-        ?schema
-        (some-> (mr/-schema registry ?schema)
-                recur)))))
+  (if (into-schema? ?schema)
+    ?schema
+    (let [?schema (mr/-schema (-registry options) ?schema)]
+      (when (into-schema? ?schema)
+        ?schema))))
 
 (defn -properties-and-options [properties options f]
   (if-let [r (:registry properties)]
@@ -1693,7 +1692,7 @@
         (let [children (-vmap #(schema % options) children)
               child (nth children 0)
               form (delay (let [no-props? (empty? properties)]
-                            (or (if id
+                            (or (when id
                                   (if no-props?
                                     id
                                     [id properties]))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -275,10 +275,12 @@
         (-fail! ::invalid-schema {:schema ?schema, :form ?form}))))
 
 (defn- -lookup-into-schema [?schema options]
-  (if (into-schema? ?schema)
-    ?schema
-    (some-> (-lookup ?schema options)
-            (recur options))))
+  (let [registry (-registry options)]
+    (loop [?schema ?schema]
+      (if (into-schema? ?schema)
+        ?schema
+        (some-> (mr/-schema registry ?schema)
+                (-lookup-into-schema options))) )))
 
 (defn -properties-and-options [properties options f]
   (if-let [r (:registry properties)]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3376,6 +3376,9 @@
 (deftest local-registry-shadow-test
   (let [options {:registry (assoc (m/default-schemas) ::string (:string (m/default-schemas)))}
         validate #(m/validate %1 %2 options)]
+    (is (m/schema ::string options))
+    (is (m/schema [::string] options))
+    (is (m/schema [::string {:foo :bar}] options))
     (is (validate ::string "a"))
     (is (not (validate ::string 1)))
     (is (validate [:schema {:registry {::string :int}} [::string {:foo :bar}]] 1))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3379,9 +3379,20 @@
     (is (m/schema ::string options))
     (is (m/schema [::string] options))
     (is (m/schema [::string {:foo :bar}] options))
+    (is (m/schema [::string {:foo :bar}] options))
     (is (validate ::string "a"))
     (is (not (validate ::string 1)))
+    (is (validate [:schema {:registry {::string :int}} ::string] 1))
+    (is (= [:schema {:registry {::string :int}} ::string]
+           (-> [:schema {:registry {::string :int}} ::string]
+               (m/form options))))
     (is (validate [:schema {:registry {::string :int}} [::string {:foo :bar}]] 1))
+    (is (= [:schema {:registry {::string :int}} [::string {:foo :bar}]]
+           (-> [:schema {:registry {::string :int}} [::string {:foo :bar}]]
+               (m/form options))))
+    (is (= [:schema {:registry {::string [:tuple :int]}} [::string {:foo :bar}]]
+           (-> [:schema {:registry {::string [:tuple :int]}} [::string {:foo :bar}]]
+               (m/form options))))
     (is (not (validate [:schema {:registry {::string :int}} [::string]] "a")))
     (is (not (validate [:schema {:registry {::string :int}} [::string {:foo :bar}]] "a")))))
 

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -12,8 +12,19 @@
       (register! :str (m/-string-schema))
       (is (true? (m/validate :str "kikka" {:registry registry})))
       (register! ::foo (m/schema [:tuple :int]))
-      (is (m/schema ::foo {:registry registry}))
-      (is (m/schema [::foo {:doc ""}] {:registry registry})))))
+      (is (= ::foo
+             (-> (m/schema ::foo {:registry registry})
+                 m/form)))
+      (is (= [::foo {:doc ""}]
+             (-> (m/schema [::foo {:doc ""}] {:registry registry})
+                 m/form)))
+      (register! ::bare [:tuple :int])
+      (is (= ::bare
+             (-> (m/schema ::bare {:registry registry})
+                 m/form)))
+      (is (= [::bare {:doc ""}]
+             (-> (m/schema [::bare {:doc ""}] {:registry registry})
+                 m/form))))))
 
 (deftest composite-test
   (let [registry* (atom {})

--- a/test/malli/registry_test.cljc
+++ b/test/malli/registry_test.cljc
@@ -4,13 +4,16 @@
             [malli.registry :as mr]))
 
 (deftest mutable-test
-  (let [registry* (atom {})
+  (let [registry* (atom (m/default-schemas))
         registry (mr/mutable-registry registry*)
         register! (fn [t ?s] (swap! registry* assoc t ?s))]
-    (testing "default registy"
+    (testing "default registry"
       (is (thrown? #?(:clj Exception, :cljs js/Error) (m/validate :str "kikka" {:registry registry})))
       (register! :str (m/-string-schema))
-      (is (true? (m/validate :str "kikka" {:registry registry}))))))
+      (is (true? (m/validate :str "kikka" {:registry registry})))
+      (register! ::foo (m/schema [:tuple :int]))
+      (is (m/schema ::foo {:registry registry}))
+      (is (m/schema [::foo {:doc ""}] {:registry registry})))))
 
 (deftest composite-test
   (let [registry* (atom {})


### PR DESCRIPTION
Adds full support for vector syntax for `-reference?`'s that don't point to `IntoSchema`. This removes a point of confusion about the differences between using a reference and a schema.

Properties are attached to the `-pointer`. Children are not allowed.

This changes how registries resolve IntoSchema's. The code used to recursively resolve registry entries such that `{:string-alias :string, :string (-string-schema)}` would resolve `[:string-alias]` to an instance of `(-string-schema)`. Now it just returns a `-pointer` to `:string-alias` like the (non-vector) `:string-alias` syntax does.

I added a comment where future work could add support for user-defined "schema functions" that take and return schemas. I think we can reuse the same ideas as https://github.com/metosin/malli/pull/1053 to make these hygienic and serializable.