### PR TITLE
Corrected DEPRECATED warning for -simple-schema

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -676,7 +676,7 @@
          :or {min 0, max 0, from-ast -from-value-ast, to-ast -to-type-ast}} props]
     (if (fn? props)
       (do
-        (-deprecated! "-simple-schema doesn't take fn-props, use :compiled property instead")
+        (-deprecated! "-simple-schema doesn't take fn-props, use :compile property instead")
         (-simple-schema {:compile (fn [c p _] (props c p))}))
       ^{:type ::into-schema}
       (reify


### PR DESCRIPTION
Fix for #1076 

-simple-schema DEPRECATED warning incorrectly states :compiled instead of :compile