### PR TITLE
allow `m/-proxy-schema` child to be a `delay`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## NEXT
+
+* allow `m/-proxy-schema` child to be a `delay`
+
 ## 0.16.3 (2024-08-05)
 
 * `:->` added to default registry, see [documentation](https://github.com/metosin/malli/blob/master/docs/function-schemas.md#flat-arrow-function-schemas).

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1990,17 +1990,18 @@
     (-into-schema [parent properties children options]
       (-check-children! type properties children min max)
       (let [[children forms schema] (fn properties (vec children) options)
+            schema (delay (force schema))
             form (delay (-create-form type properties forms options))
             cache (-create-cache options)]
         ^{:type ::schema}
         (reify
           Schema
-          (-validator [_] (-validator schema))
-          (-explainer [_ path] (-explainer schema (conj path ::in)))
-          (-parser [_] (-parser schema))
-          (-unparser [_] (-unparser schema))
+          (-validator [_] (-validator @schema))
+          (-explainer [_ path] (-explainer @schema (conj path ::in)))
+          (-parser [_] (-parser @schema))
+          (-unparser [_] (-unparser @schema))
           (-transformer [this transformer method options]
-            (-parent-children-transformer this [schema] transformer method options))
+            (-parent-children-transformer this [@schema] transformer method options))
           (-walk [this walker path options]
             (let [children (if childs (subvec children 0 childs) children)]
               (when (-accept walker this path options)
@@ -2014,24 +2015,24 @@
           (-cache [_] cache)
           LensSchema
           (-keep [_])
-          (-get [_ key default] (if (= ::in key) schema (get children key default)))
+          (-get [_ key default] (if (= ::in key) @schema (get children key default)))
           (-set [_ key value] (into-schema type properties (assoc children key value)))
           FunctionSchema
-          (-function-schema? [_] (-function-schema? schema))
-          (-function-info [_] (-function-info schema))
-          (-function-schema-arities [_] (-function-schema-arities schema))
-          (-instrument-f [_ props f options] (-instrument-f schema props f options))
+          (-function-schema? [_] (-function-schema? @schema))
+          (-function-info [_] (-function-info @schema))
+          (-function-schema-arities [_] (-function-schema-arities @schema))
+          (-instrument-f [_ props f options] (-instrument-f @schema props f options))
           RegexSchema
-          (-regex-op? [_] (-regex-op? schema))
-          (-regex-validator [_] (-regex-validator schema))
-          (-regex-explainer [_ path] (-regex-explainer schema path))
-          (-regex-unparser [_] (-regex-unparser schema))
-          (-regex-parser [_] (-regex-parser schema))
-          (-regex-transformer [_ transformer method options] (-regex-transformer schema transformer method options))
-          (-regex-min-max [_ nested?] (-regex-min-max schema nested?))
+          (-regex-op? [_] (-regex-op? @schema))
+          (-regex-validator [_] (-regex-validator @schema))
+          (-regex-explainer [_ path] (-regex-explainer @schema path))
+          (-regex-unparser [_] (-regex-unparser @schema))
+          (-regex-parser [_] (-regex-parser @schema))
+          (-regex-transformer [_ transformer method options] (-regex-transformer @schema transformer method options))
+          (-regex-min-max [_ nested?] (-regex-min-max @schema nested?))
           RefSchema
           (-ref [_])
-          (-deref [_] schema))))))
+          (-deref [_] @schema))))))
 
 (defn -->-schema
   "Experimental simple schema for :=> schema. AST and explain results subject to change."
@@ -2039,10 +2040,10 @@
   (-proxy-schema {:type :->
                   :fn (fn [{:keys [guard] :as p} c o]
                         (-check-children! :-> p c 1 nil)
-                        (let [c (mapv #(schema % o) c)
-                              cc (cond-> [(into [:cat] (pop c)) (peek c)]
-                                   guard (conj [:fn guard]))]
-                          [c (map -form c) (into-schema :=> (dissoc p :guard) cc o)]))}))
+                        (let [c (mapv #(schema % o) c)]
+                          [c (map -form c) (delay (let [cc (cond-> [(into [:cat] (pop c)) (peek c)]
+                                                             guard (conj [:fn guard]))]
+                                                    (into-schema :=> (dissoc p :guard) cc o)))]))}))
 
 (defn- regex-validator [schema] (re/validator (-regex-validator schema)))
 

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -374,13 +374,13 @@
 (defn -reducing [f]
   (fn [_ [first & rest :as children] options]
     (let [children (mapv #(m/schema % options) children)]
-      [children (mapv m/form children) (reduce #(f %1 %2 options) first rest)])))
+      [children (mapv m/form children) (delay (reduce #(f %1 %2 options) first rest))])))
 
 (defn -applying [f]
   (fn [_ children options]
     [(clojure.core/update children 0 #(m/schema % options))
      (clojure.core/update children 0 #(m/form % options))
-     (apply f (conj children options))]))
+     (delay (apply f (conj children options)))]))
 
 (defn -util-schema [m] (m/-proxy-schema m))
 


### PR DESCRIPTION
This is something that I found came in handy implementing lexical scope. In that case, there's a lot of substitution happening, and it doesn't make sense to compute the proxy child if you're just going to throw them away to replace the proxy with new children.

In general, it allows you to `-walk` a proxy schema without computing its child.