### PR TITLE
Add `-walk` option to inherit `::val` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## NEXT
+
+* add `::m/walk-inherit-entry-props` to `-walk` for unwrapping `::val` nodes and inheriting their props after walking
+
 ## 0.16.3 (2024-08-05)
 
 * `:->` added to default registry, see [documentation](https://github.com/metosin/malli/blob/master/docs/function-schemas.md#flat-arrow-function-schemas).

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -252,20 +252,14 @@ Example 2: if `:cost` is missing, try to calculate it from `:price` and `:qty`:
 
 ## Walking Schema and Entry Properties
 
-1. walk entries on the way in
-2. unwalk entries on the way out
-
 ```clojure
-(defn walk-properties [schema f]
+(defn walk-properties [?schema f & args]
   (m/walk
-    schema
+    ?schema
     (fn [s _ c _]
-      (m/into-schema
-        (m/-parent s)
-        (f (m/-properties s))
-        (cond->> c (m/entries s) (map (fn [[k p s]] [k (f p) (first (m/children s))])))
-        (m/options s)))
-    {::m/walk-entry-vals true}))
+      (apply m/-update-properties (m/-set-children s c) f args))
+    {::m/walk-inherit-entry-props true
+     ::m/walk-entry-vals true}))
 ```
 
 Stripping all swagger-keys:

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -35,7 +35,7 @@
   (-transformer [this transformer method options]
     "returns a function to transform the value for the given schema and method.
     Can also return nil instead of `identity` so that more no-op transforms can be elided.")
-  (-walk [this walker path options] "walks the schema and it's children, ::m/walk-entry-vals, ::m/walk-refs, ::m/walk-schema-refs options effect how walking is done.")
+  (-walk [this walker path options] "walks the schema and it's children, ::m/walk-entry-vals, ::m/walk-refs, ::m/walk-schema-refs, ::m/walk-inherit-entry-props options effect how walking is done.")
   (-properties [this] "returns original schema properties")
   (-options [this] "returns original options")
   (-children [this] "returns schema children")
@@ -329,8 +329,15 @@
 (defn -inner-indexed [walker path children options]
   (-vmap (fn [[i c]] (-inner walker c (conj path i) options)) (map-indexed vector children)))
 
-(defn -inner-entries [walker path entries options]
-  (-vmap (fn [[k s]] [k (-properties s) (-inner walker s (conj path k) options)]) entries))
+(defn -inner-entries [walker path entries {::keys [walk-inherit-entry-props] :as options}]
+  (-vmap (fn [[k s]]
+           (let [s' (-inner walker s (conj path k) options)]
+             (if (and walk-inherit-entry-props
+                      (schema? s')
+                      (= ::val (type s')))
+               [k (-properties s') (-deref s')]
+               [k (-properties s) s'])))
+         entries))
 
 (defn -walk-entries [schema walker path options]
   (when (-accept walker schema path options)


### PR DESCRIPTION
This simplifies `walk-properties`, but I'm not sure it's airtight enough to release as more than a suggestion.

I considered reusing `::walk-entry-vals` but it could be a breaking change.