### PR TITLE
Multi keyword dispatch gen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Malli is in well matured [alpha](README.md#alpha).
 
 * Fix ClojureScript [arithmetic warning](https://github.com/metosin/malli/issues/1093)
 * Distribute `:merge` over `:multi` [#1086](https://github.com/metosin/malli/pull/1086), see [documentation](README.md#distributive-schemas)
-* allow `m/-proxy-schema` child to be a `delay`
+* allow `m/-proxy-schema` child to be a `delay` [#1090](https://github.com/metosin/malli/pull/1090)
+* `:multi` with keyword `:dispatch` accumulates data to generated values [#1095](https://github.com/metosin/malli/pull/1095)
 
 ## 0.16.3 (2024-08-05)
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -172,7 +172,7 @@
        #(map (fn [[k :as e]]
                (cond-> e
                  (not= ::m/default k)
-                 (update 2 mu/merge [:map [dispatch [:= k]]]))) %)
+                 (update 2 mu/merge [:map [dispatch [:= nil k]]]))) %)
        (m/options schema)))))
 
 (defn -multi-gen [schema options]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -49,7 +49,7 @@
                     :symbol
                     :qualified-keyword
                     :qualified-symbol]]
-      (is (every? (partial m/validate schema) (mg/sample schema {:size 1000})))))
+      (is (every? (m/validator schema) (mg/sample schema {:size 1000})))))
 
   (testing "double properties"
     (let [infinity? #(or (= % ##Inf)
@@ -165,16 +165,16 @@
     (testing "recursion"
       (let [schema [:schema {:registry {::cons [:maybe [:tuple int? [:ref ::cons]]]}}
                     ::cons]]
-        (is (every? (partial m/validate schema) (mg/sample schema {:size 100})))))
+        (is (every? (m/validator schema) (mg/sample schema {:size 100})))))
     (testing "mutual recursion"
       (let [schema [:schema
                     {:registry {::ping [:maybe [:tuple [:= "ping"] [:ref ::pong]]]
                                 ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
                     ::ping]]
-        (is (every? (partial m/validate schema) (mg/sample schema {:size 100})))))
+        (is (every? (m/validator schema) (mg/sample schema {:size 100})))))
     (testing "recursion limiting"
       (are [schema]
-        (every? (partial m/validate schema) (mg/sample schema {:size 100}))
+        (every? (m/validator schema) (mg/sample schema {:size 100}))
 
         [:schema {:registry {::rec [:maybe [:ref ::rec]]}} ::rec]
         [:schema {:registry {::rec [:map [:rec {:optional true} [:ref ::rec]]]}} ::rec]
@@ -369,7 +369,7 @@
                      [:map [:x int?] [:y int?]]
                      [:x]]]
             :let [schema (m/schema schema {:registry registry})]]
-      (is (every? (partial m/validate schema) (mg/sample schema {:size 1000}))))))
+      (is (every? (m/validator schema) (mg/sample schema {:size 1000}))))))
 
 #?(:clj
    (deftest function-schema-test

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1095,3 +1095,25 @@
 (deftest double-with-long-min-test
   (is (m/validate :double (shrink [:double {:min 3}])))
   (is (= 3.0 (shrink [:double {:min 3}]))))
+
+(deftest multi-keyword-dispatch-test
+  (testing "keyword dispatch value accumulates to generated value"
+    (let [schema [:multi {:dispatch :type}
+                  ["duck" :map]
+                  ["boss" :map]]]
+      (is (every? #{{:type "duck"} {:type "boss"}} (mg/sample schema)))
+      (is (m/validator schema) (mg/sample schema))))
+
+  (testing "non keyword doesn't accumulate data"
+    (let [schema [:multi {:dispatch (fn [x] (:type x))}
+                  ["duck" :map]
+                  ["boss" :map]]]
+      (is (every? #{{}} (mg/sample schema)))
+      (is (m/validator schema) (mg/sample schema))))
+
+  (testing "::m/default works too"
+    (let [schema [:multi {:dispatch :type}
+                  ["duck" :map]
+                  [::m/default [:= "boss"]]]]
+      (is (every? #{{:type "duck"} "boss"} (mg/sample schema)))
+      (is (m/validator schema) (mg/sample schema)))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1116,4 +1116,11 @@
                   ["duck" :map]
                   [::m/default [:= "boss"]]]]
       (is (every? #{{:type "duck"} "boss"} (mg/sample schema)))
+      (is (every? (m/validator schema) (mg/sample schema)))))
+
+  (testing "works with nil & {} too"
+    (let [schema [:multi {:dispatch :type}
+                  [nil :map]
+                  [{} :map]]]
+      (is (every? #{{:type nil} {:type {}}} (mg/sample schema)))
       (is (every? (m/validator schema) (mg/sample schema))))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1102,18 +1102,18 @@
                   ["duck" :map]
                   ["boss" :map]]]
       (is (every? #{{:type "duck"} {:type "boss"}} (mg/sample schema)))
-      (is (m/validator schema) (mg/sample schema))))
+      (is (every? (m/validator schema) (mg/sample schema)))))
 
   (testing "non keyword doesn't accumulate data"
     (let [schema [:multi {:dispatch (fn [x] (:type x))}
                   ["duck" :map]
                   ["boss" :map]]]
       (is (every? #{{}} (mg/sample schema)))
-      (is (m/validator schema) (mg/sample schema))))
+      (is (not (every? (m/validator schema) (mg/sample schema))))))
 
   (testing "::m/default works too"
     (let [schema [:multi {:dispatch :type}
                   ["duck" :map]
                   [::m/default [:= "boss"]]]]
       (is (every? #{{:type "duck"} "boss"} (mg/sample schema)))
-      (is (m/validator schema) (mg/sample schema)))))
+      (is (every? (m/validator schema) (mg/sample schema))))))


### PR DESCRIPTION
# Before

```clojure
(mg/sample
 [:multi {:dispatch :type}
  ["duck" :map]
  ["boss" :map]])
;({}
; {}
; {}
; {}
; {}
; {}
; {}
; {}
; {}
; {})
```

# After

```clojure
(mg/sample
 [:multi {:dispatch :type}
  ["duck" :map]
  ["boss" :map]])
;({:type "boss"}
; {:type "boss"}
; {:type "boss"}
; {:type "boss"}
; {:type "boss"}
; {:type "duck"}
; {:type "duck"}
; {:type "duck"}
; {:type "duck"}
; {:type "boss"})
```

... especially nice with new `:multi` merging:

```clojure
(mg/sample
 [:merge
  [:map [:name :string]]
  [:multi {:dispatch :type}
   ["duck" [:map [:speed :int]]]
   ["boss" [:map [:level :int]]]]])
;({:name "", :level 0, :type "boss"}
; {:name "", :speed -1, :type "duck"}
; {:name "", :level -1, :type "boss"}
; {:name "24m", :level -1, :type "boss"}
; {:name "8ou9", :level 4, :type "boss"}
; {:name "o", :speed -3, :type "duck"}
; {:name "", :speed 2, :type "duck"}
; {:name "", :speed -1, :type "duck"}
; {:name "", :level -15, :type "boss"}
; {:name "HWw6", :level 1, :type "boss"})
``` 