### PR TITLE
Explicitly check for CharSequence in -re-schema

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1466,6 +1466,8 @@
       (-check-children! :re properties children 1 1)
       (let [children (vec children)
             re (re-pattern child)
+            matches? #(and #?(:clj (instance? CharSequence %), :cljs (string? %))
+                           (re-find re %))
             form (delay (if class? re (-simple-form parent properties children identity options)))
             cache (-create-cache options)]
         ^{:type ::schema}
@@ -1474,11 +1476,11 @@
           (-to-ast [this _] (-to-value-ast this))
           Schema
           (-validator [_]
-            (-safe-pred #(re-find re %)))
+            (-safe-pred matches?))
           (-explainer [this path]
             (fn explain [x in acc]
               (try
-                (if-not (re-find re x)
+                (if-not (matches? x)
                   (conj acc (miu/-error path in this x))
                   acc)
                 (catch #?(:clj Exception, :cljs js/Error) e


### PR DESCRIPTION
The current behavior attempts to run `re-find` against any object in a `try/catch` block, fails with a ClassCastException on non-charsequence objects, the exception is caught and false is returned. The drawback is that the exception object is generated and its stacktrace is filled. Besides, throwing and catching an exception in Java is not free, it follows a quite slow path compared to the tight situations the validation might be used.

The profile looks like this:
<img width="1018" alt="image" src="https://github.com/user-attachments/assets/9e05f431-c3e5-4d01-a9f5-6a101dde12cf">
