### PR TITLE
Require generator for `:gen/fmap`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## NEXT
+
+* **BREAKING**: `:gen/fmap` property requires its schema to create a generator.
+  * previous behavior defaulted to a `nil`-returning generator, even if the schema doesn't accept `nil`
+  * use `:gen/return nil` property to restore this behavior
+
 ## 0.16.4 (2024-08-30)
 
 * Distribute `:merge` over `:multi` [#1086](https://github.com/metosin/malli/pull/1086), see [documentation](README.md#distributive-schemas)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -552,25 +552,22 @@
 (defn- -create-from-schema [props options]
   (some-> (:gen/schema props) (generator options)))
 
-(defn- -create-from-fmap [props schema options]
+(defn- -create-from-fmap [gen props schema options]
   (when-some [fmap (:gen/fmap props)]
     (gen/fmap (m/eval fmap (or options (m/options schema)))
-              (or (-create-from-return props)
-                  (-create-from-elements props)
-                  (-create-from-schema props options)
-                  (-create-from-gen props schema options)
-                  nil-gen))))
+              gen)))
 
 (defn- -create [schema options]
   (let [props (-merge (m/type-properties schema)
-                      (m/properties schema))]
-    (or (-create-from-fmap props schema options)
-        (-create-from-return props)
-        (-create-from-elements props)
-        (-create-from-schema props options)
-        (-create-from-gen props schema options)
-        (m/-fail! ::no-generator {:options options
-                                  :schema schema}))))
+                      (m/properties schema))
+        gen (or (-create-from-return props)
+                (-create-from-elements props)
+                (-create-from-schema props options)
+                (-create-from-gen props schema options)
+                (m/-fail! ::no-generator {:options options
+                                          :schema schema}))]
+    (or (-create-from-fmap gen props schema options)
+        gen)))
 
 ;;
 ;; public api

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1010,6 +1010,10 @@
         (<= (int \A) i (int \Z))
         (<= (int \0) i (int \9)))))
 
+(deftest alphanumeric-char?-test
+  (is (alphanumeric-char? \a))
+  (is (not (alphanumeric-char? \-))))
+
 (defn alphanumeric-string? [s]
   {:pre [(string? s)]}
   (every? alphanumeric-char? s))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1002,7 +1002,10 @@
 
 (defn alphanumeric-char? [c]
   {:pre [(char? c)]}
-  (let [i (int c)]
+  (let [int (fn [c]
+              #?(:clj (int c)
+                 :cljs (.charCodeAt c 0)))
+        i (int c)]
     (or (<= (int \a) i (int \z))
         (<= (int \A) i (int \Z))
         (<= (int \0) i (int \9)))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -241,11 +241,14 @@
 
   (testing "generator override"
     (testing "without generator"
-      (let [schema [:fn {:gen/fmap '(fn [_] (rand-int 10))}
+      (let [schema [:fn {:gen/elements [5]
+                         :gen/fmap '(fn [i] (rand-int i))}
                     '(fn [x] (<= 0 x 10))]
             generator (mg/generator schema)]
         (dotimes [_ 100]
-          (m/validate schema (mg/generate generator)))))
+          (let [v (mg/generate generator)]
+            (is (m/validate schema v))
+            (is (<= 0 v 5))))))
     (testing "with generator"
       (is (re-matches #"kikka_\d+" (mg/generate [:and {:gen/fmap '(partial str "kikka_")} pos-int?])))))
 


### PR DESCRIPTION
`:gen/fmap` is fed `nil` if its schema cannot create a generator. This does not seem like desirable semantics because silent failures could happen if the `:gen/fmap` function is permissive, like `first` or a keyword, making the entire generator return `nil`s.

Could we reconsider this? Perhaps `:gen/fmap` predated `:gen/return` and `:gen/elements`, but we can certainly now force the user to be explicit here. Importantly, is this worth the risk breaking things by fixing it?

Also includes a fix for the CLJS version of `alphanumeric-char?` in the tests.