### PR TITLE
Close #1124: only assume string interning in cljs

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2724,8 +2724,10 @@
   (merge (predicate-schemas) (class-schemas) (comparator-schemas) (type-schemas) (sequence-schemas) (base-schemas)))
 
 (def default-registry
-  (let [strict (identical? mr/mode "strict")
-        custom (identical? mr/type "custom")
+  (let [strict #?(:cljs (identical? mr/mode "strict")
+                  :default (= mr/mode "strict"))
+        custom #?(:cljs (identical? mr/type "custom")
+                  :default (= mr/type "custom"))
         registry (if custom (mr/fast-registry {}) (mr/composite-registry (mr/fast-registry (default-schemas)) (mr/var-registry)))]
     (when-not strict (mr/set-default-registry! registry))
     (mr/registry (if strict registry (mr/custom-default-registry)))))

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -3,10 +3,10 @@
   #?(:clj (:import (java.util HashMap Map))))
 
 #?(:cljs (goog-define mode "default")
-   :clj  (def mode (as-> (or (System/getProperty "malli.registry/mode") "default") $ (.intern $))))
+   :clj  (def mode (or (System/getProperty "malli.registry/mode") "default")))
 
 #?(:cljs (goog-define type "default")
-   :clj  (def type (as-> (or (System/getProperty "malli.registry/type") "default") $ (.intern $))))
+   :clj  (def type (or (System/getProperty "malli.registry/type") "default")))
 
 (defprotocol Registry
   (-schema [this type] "returns the schema from a registry")
@@ -40,7 +40,8 @@
 (def ^:private registry* (atom (simple-registry {})))
 
 (defn set-default-registry! [?registry]
-  (if-not (identical? mode "strict")
+  (if-not #?(:cljs (identical? mode "strict")
+             :default (= mode "strict"))
     (reset! registry* (registry ?registry))
     (throw (ex-info "can't set default registry, invalid mode" {:mode mode, :type type}))))
 


### PR DESCRIPTION
Close #1124

I think the string interning is for JS dead-code elimination purposes. This doesn't work in bb and I'm not sure if other platforms guarantee string interning. Since there isn't much (any?) benefit, perhaps we could use the safer `=` on other platforms.

I'm not sure how to test CLJS and verify the js bundle size.

```clojure
$ bb -Dmalli.registry/mode=strict
Babashka v1.12.194 REPL.
Use :repl/quit or :repl/exit to quit the REPL.
Clojure rocks, Bash reaches.

user=> (System/getProperty "malli.registry/mode")
"strict"
user=> (require 'malli.core)
nil
user=> (malli.registry/-schemas (malli.registry/custom-default-registry))
{}
user=>
```

```clojure
$ clj -J-Dmalli.registry/mode=strict
Clojure 1.11.4
user=> (System/getProperty "malli.registry/mode")
"strict"
user=> (require 'malli.core)
nil
user=> (malli.registry/-schemas (malli.registry/custom-default-registry))
{}
```