### PR TITLE
don't generate :definitions nil in swagger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Malli is in well matured [alpha](README.md#alpha).
 
 ## 0.17.0 (UNRELEASED)
 
+* Don't output `:definitions nil` in swagger. [#1134](https://github.com/metosin/malli/issues/1134)
 * **BREAKING**: `:gen/fmap` property requires its schema to create a generator.
   * previous behavior defaulted to a `nil`-returning generator, even if the schema doesn't accept `nil`
   * use `:gen/return nil` property to restore this behavior

--- a/src/malli/swagger.cljc
+++ b/src/malli/swagger.cljc
@@ -184,11 +184,12 @@
                     parameters (:parameters expanded)
                     responses (:responses expanded)
                     definitions (apply merge
+                                       (:definitions acc)
                                        (concat
                                         (->> responses vals (map (comp :definitions :schema)))
                                         (->> parameters (map (comp :definitions :schema)))))]
                 (-> acc (dissoc k) (merge expanded)
-                    (update :definitions merge definitions)
+                    (merge (when-not (empty? definitions) [:definitions definitions]))
                     dissoc-non-root-definitions))
               acc))
           x x)

--- a/test/malli/swagger_test.cljc
+++ b/test/malli/swagger_test.cljc
@@ -333,8 +333,7 @@
 
 (deftest swagger-spec-test
   (testing "generates swagger for ::parameters and ::responses w/ basic schema"
-    (is (= {:definitions nil
-            :parameters [{:description ""
+    (is (= {:parameters [{:description ""
                           :in "body"
                           :name "body"
                           :required true
@@ -439,8 +438,7 @@
                                                             {:registry registry})}}})))))
 
   (testing "no schema in responses ignored"
-    (is (= {:definitions nil
-            :responses {200 {:description "" :schema {:type "string"}}
+    (is (= {:responses {200 {:description "" :schema {:type "string"}}
                         500 {:description "fail"}}}
            (swagger/swagger-spec {::swagger/responses
                                   {500 {:description "fail"}
@@ -518,8 +516,7 @@
                                   ::swagger/responses {200 {:schema #'Success}}}))))
   (testing "::parameters :query w/ var schema"
     ;; NB! all refs get inlined!
-    (is (= {:definitions nil
-            :parameters [{:description ""
+    (is (= {:parameters [{:description ""
                           :in "query"
                           :name :a
                           :required true


### PR DESCRIPTION
fixes #1134