### PR TITLE
Fix heading levels in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3429,19 +3429,19 @@ The transformation engine is smart enough to just transform parts of the schema 
 
 ## Built-in schemas
 
-#### `malli.core/predicate-schemas`
+### `malli.core/predicate-schemas`
 
 Contains both function values and unqualified symbol representations for all relevant core predicates. Having both representations enables reading forms from both code (function values) and EDN-files (symbols): `any?`, `some?`, `number?`, `integer?`, `int?`, `pos-int?`, `neg-int?`, `nat-int?`, `pos?`, `neg?`, `float?`, `double?`, `boolean?`, `string?`, `ident?`, `simple-ident?`, `qualified-ident?`, `keyword?`, `simple-keyword?`, `qualified-keyword?`, `symbol?`, `simple-symbol?`, `qualified-symbol?`, `uuid?`, `uri?`, `decimal?`, `inst?`, `seqable?`, `indexed?`, `map?`, `vector?`, `list?`, `seq?`, `char?`, `set?`, `nil?`, `false?`, `true?`, `zero?`, `rational?`, `coll?`, `empty?`, `associative?`, `sequential?`, `ratio?`, `bytes?`, `ifn?` and `fn?`.
 
-#### `malli.core/class-schemas`
+### `malli.core/class-schemas`
 
 Class-based schemas, contains `java.util.regex.Pattern` & `js/RegExp`.
 
-#### `malli.core/comparator-schemas`
+### `malli.core/comparator-schemas`
 
 Comparator functions as keywords: `:>`, `:>=`, `:<`, `:<=`, `:=` and `:not=`.
 
-#### `malli.core/type-schemas`
+### `malli.core/type-schemas`
 
 Type-like schemas: `:any`, `:some`, `:nil`, `:string`, `:int`, `:double`, `:boolean`, `:keyword`, `:qualified-keyword`, `:symbol`, `:qualified-symbol`, and `:uuid`.
 


### PR DESCRIPTION
The parent heading is at level 2, so these should be at level 3 rather than level 4, to match later headings in this section.