### PR TITLE
align :float and :double generators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Malli is in well matured [alpha](README.md#alpha).
   * previous behavior defaulted to a `nil`-returning generator, even if the schema doesn't accept `nil`
   * use `:gen/return nil` property to restore this behavior
 * FIX: `malli.registry/{mode,type}` not respected in Babashka [#1124](https://github.com/metosin/malli/issues/1124)
+* FIX: `:float` accepts doubles but never generates them [#1132](https://github.com/metosin/malli/issues/1132)
 * Updated dependencies:
 
 ```

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -87,8 +87,6 @@
   (let [{:gen/keys [infinite? NaN?]} (m/properties schema)]
     {:infinite? infinite? :NaN? NaN?}))
 
-(defn- -double-gen [schema options] (gen-double (into (inf-nan schema options) (-min-max schema options))))
-
 (defn- gen-fmap [f gen] (or (-unreachable gen) (gen/fmap f gen)))
 (defn- gen-fcat [gen] (gen-fmap #(apply concat %) gen))
 (defn- gen-tuple [gens] (or (some -unreachable gens) (apply gen/tuple gens)))


### PR DESCRIPTION
Close #1132 

My thinking is we should follow `clojure.spec.gen.alpha` where `float?` and `double?` generate the same (and thus the corresponding schemas).