### PR TITLE
look inside :ref when searching for default for :map child

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -486,7 +486,9 @@
                                                                (when (or (not optional) add-optional-keys)
                                                                  (let [e (find p key)]
                                                                    (when-some [f (if e (constantly (val e))
-                                                                                       (get-default v))]
+                                                                                       (or (get-default v)
+                                                                                           (when (m/-ref-schema? v)
+                                                                                             (get-default (m/-deref v)))))]
                                                                      [k (fn [] (default-fn schema (f)))])))))
                                                        (m/children schema))]
                                     (when (seq defaults)

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -3,6 +3,7 @@
             [clojure.test :refer [are deftest is testing]]
             [malli.core :as m]
             [malli.core-test]
+            [malli.registry :as mr]
             [malli.transform :as mt])
   #?(:clj (:import (java.net URI))))
 
@@ -1032,7 +1033,20 @@
 
   (testing ":default/fn property on schema"
     (let [schema [:string {:default/fn (fn [] "called")}]]
-      (is (= "called" (m/decode schema nil mt/default-value-transformer))))))
+      (is (= "called" (m/decode schema nil mt/default-value-transformer)))))
+
+  (testing ":refs"
+    (let [opts {:registry (mr/composite-registry m/default-registry
+                                                 {"bing" :int})}
+          transformer (mt/default-value-transformer {:defaults {:int (constantly 7)}})]
+      (is (= 7 (m/decode [:ref "bing"] nil opts transformer)))
+      (is (= [7] (m/decode [:vector [:ref "bing"]] [nil] opts transformer)))
+      (is (= {:a 7} (m/decode [:map [:a [:ref "bing"]]] {:a nil} opts transformer)))
+      ;; TODO fails
+      #_(is (= {:a 7} (m/decode [:map [:a [:ref "bing"]]] {} opts transformer)))
+      (is (= {:a 8} (m/decode [:map [:a [:ref {:default 8} "bing"]]] {:a nil} opts transformer)))
+      ;; TODO fails
+      #_(is (= {:a 8} (m/decode [:map [:a [:ref {:default 8} "bing"]]] {} opts transformer))))))
 
 (deftest type-properties-based-transformations
   (is (= 12 (m/decode malli.core-test/Over6 "12" mt/string-transformer))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -1042,11 +1042,9 @@
       (is (= 7 (m/decode [:ref "bing"] nil opts transformer)))
       (is (= [7] (m/decode [:vector [:ref "bing"]] [nil] opts transformer)))
       (is (= {:a 7} (m/decode [:map [:a [:ref "bing"]]] {:a nil} opts transformer)))
-      ;; TODO fails
-      #_(is (= {:a 7} (m/decode [:map [:a [:ref "bing"]]] {} opts transformer)))
+      (is (= {:a 7} (m/decode [:map [:a [:ref "bing"]]] {} opts transformer)))
       (is (= {:a 8} (m/decode [:map [:a [:ref {:default 8} "bing"]]] {:a nil} opts transformer)))
-      ;; TODO fails
-      #_(is (= {:a 8} (m/decode [:map [:a [:ref {:default 8} "bing"]]] {} opts transformer))))))
+      (is (= {:a 8} (m/decode [:map [:a [:ref {:default 8} "bing"]]] {} opts transformer))))))
 
 (deftest type-properties-based-transformations
   (is (= 12 (m/decode malli.core-test/Over6 "12" mt/string-transformer))))


### PR DESCRIPTION
When a default value gets produced up via the normal transformer
    pipeline, the -transform method of -ref-schema will delegate to the
    child schema. However, when we're building up the default values for a
    :map in add-defaults, we're not using the transformer pipeline, but
    calling get-default manually. Thus, we need to manually deref.
    
fixes #1145