### PR TITLE
Propagate options to 1-child -reducing, disallow 0-child

### DIFF
--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -378,8 +378,8 @@
 ;;
 
 (defn -reducing [f]
-  (fn [_ [first & rest :as children] options]
-    (let [children (mapv #(m/schema % options) children)]
+  (fn [_ children options]
+    (let [[first & rest :as children] (mapv #(m/schema % options) children)]
       [children (mapv m/form children) (delay (reduce #(f %1 %2 options) first rest))])))
 
 (defn -applying [f]
@@ -390,8 +390,8 @@
 
 (defn -util-schema [m] (m/-proxy-schema m))
 
-(defn -merge [] (-util-schema {:type :merge, :fn (-reducing merge)}))
-(defn -union [] (-util-schema {:type :union, :fn (-reducing union)}))
+(defn -merge [] (-util-schema {:type :merge, :fn (-reducing merge), :min 1}))
+(defn -union [] (-util-schema {:type :union, :fn (-reducing union), :min 1}))
 (defn -select-keys [] (-util-schema {:type :select-keys, :childs 1, :min 2, :max 2, :fn (-applying select-keys)}))
 
 (defn schemas [] {:merge (-merge)

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -379,6 +379,8 @@
 
 (defn -reducing [f]
   (fn [_ children options]
+    (when (empty? children)
+      (m/-fail! ::reducing-children-must-be-non-empty))
     (let [[first & rest :as children] (mapv #(m/schema % options) children)]
       [children (mapv m/form children) (delay (reduce #(f %1 %2 options) first rest))])))
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -1112,3 +1112,15 @@
            {}
            {:registry (merge (mu/schemas) (m/default-schemas))}
            (mt/default-value-transformer {::mt/add-optional-keys true})))))
+
+(deftest -reducing-test
+  (is (= :map (m/form (m/deref-all (m/schema [:merge [:merge :map]] {:registry (merge (mu/schemas) (m/default-schemas))})))))
+  (is (= :map (m/form (m/deref-all (m/schema [:union [:union :map]] {:registry (merge (mu/schemas) (m/default-schemas))})))))
+  (is (thrown-with-msg?
+        #?(:clj Exception, :cljs js/Error)
+        #":malli\.core/child-error"
+        (m/schema :merge {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (thrown-with-msg?
+        #?(:clj Exception, :cljs js/Error)
+        #":malli\.core/child-error"
+        (m/schema :union {:registry (merge (mu/schemas) (m/default-schemas))}))))


### PR DESCRIPTION
`:union` and `:merge` don't work well with 0 and 1 children.

For 1 child, they don't propagate options to the child. This happens because the `reduce` call in `-reducing` returns init, which is a `?schema`.
- this pr ensures options are always propagated

For 0 children, deref'ing returns nil. This is because the `reduce` call in `-reducing` is passed `nil` init.
- this pr adds checks for non-empty children to `:merge` and `:union`
- fallback error for other users of `-reducing`

```clojure
(m/form (m/deref-all (m/schema [:merge [:merge :map]] {:registry (merge (mu/schemas) (m/default-schemas))})))
; (err) Execution error (ExceptionInfo) at malli.core/-exception (core.cljc:157).
; (err) :malli.core/invalid-schema

(m/deref (m/schema :merge {:registry (merge (mu/schemas) (m/default-schemas))}))
;=> nil
```