### PR TITLE
Update json-schema for :tuple for 2020-12 draft

### DIFF
--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -150,7 +150,7 @@
 
 (defmethod accept :enum [_ _ children options] (merge (some-> (m/-infer children) (-transform options)) {:enum children}))
 (defmethod accept :maybe [_ _ children _] {:oneOf (conj children {:type "null"})})
-(defmethod accept :tuple [_ _ children _] {:type "array", :items children, :additionalItems false})
+(defmethod accept :tuple [_ _ children _] {:type "array", :prefixItems children, :items false})
 (defmethod accept :re [_ schema _ options] {:type "string", :pattern (first (m/children schema options))})
 (defmethod accept :fn [_ _ _ _] {})
 

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -91,8 +91,8 @@
    [[:enum 'kikka 'kukka] {:type "string" :enum ['kikka 'kukka]}]
    [[:maybe string?] {:oneOf [{:type "string"} {:type "null"}]}]
    [[:tuple string? string?] {:type "array"
-                              :items [{:type "string"} {:type "string"}]
-                              :additionalItems false}]
+                              :prefixItems [{:type "string"} {:type "string"}]
+                              :items false}]
    [[:re "^[a-z]+\\.[a-z]+$"] {:type "string", :pattern "^[a-z]+\\.[a-z]+$"}]
    [[:fn {:gen/elements [1]} int?] {}]
    [:any {}]
@@ -355,8 +355,8 @@
           :required [:id :malli.json-schema-test/location `description],
           :definitions {"malli.json-schema-test/UserId" {:type "string"},
                         "malli.json-schema-test/location" {:type "array",
-                                                           :items [{:type "number"} {:type "number"}],
-                                                           :additionalItems false},
+                                                           :prefixItems [{:type "number"} {:type "number"}],
+                                                           :items false},
                         "malli.json-schema-test/description" {:type "string"},
                         "malli.json-schema-test/User" {:type "object",
                                                        :properties {:id {:$ref "#/definitions/malli.json-schema-test~1UserId"},


### PR DESCRIPTION
The current implementation was done in 2019, before the latest JSON Schema draft (2020-12). This PR updates the generated schema to match the recommended way - https://json-schema.org/understanding-json-schema/reference/array#additionalitems
>In Draft 4 - 2019-09, tuple validation was handled by an alternate form of the items keyword. When items was an array of schemas instead of a single schema, it behaved the way prefixItems behaves.

\+

> Before to Draft 2020-12, you would use the additionalItems keyword to constrain additional items on a tuple. It works the same as items, only the name has changed.