### PR TITLE
fix: explain :path of ref schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * Docs: elaborate optional-keys and required-keys [#1117](https://github.com/metosin/malli/pull/1117)
 * **BREAKING** Output of `parse` now uses new `malli.core.Tag` and `malli.core.Tags` records for `:orn`, `:multi`, `:altn`, `:catn` etc. [#1123](https://github.com/metosin/malli/issues/1123) [#1153](https://github.com/metosin/malli/issues/1153)
   * See [Parsing](#parsing-values) and [Unparsing](#unparsing-values) for docs.
+* FIX: `:path` when explaining `:ref` errors [#1106](https://github.com/metosin/malli/issues/1106)
 
 ## 0.17.0 (2024-12-08)
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1732,7 +1732,7 @@
              (let [validator (-memoize (fn [] (-validator (rf))))]
                (fn [x] ((validator) x))))
            (-explainer [_ path]
-             (let [explainer (-memoize (fn [] (-explainer (rf) (conj path 0))))]
+             (let [explainer (-memoize (fn [] (-explainer (rf) (into path [0 0]))))]
                (fn [x in acc] ((explainer) x in acc))))
            (-parser [_] (->parser -parser))
            (-unparser [_] (->parser -unparser))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -545,6 +545,8 @@
              (m/explain [1 2 :foo])
              (me/humanize)))))
 
+(def VarSchema [:map [:foo :int]])
+
 (deftest error-definion-lookup-test
   (is (= {:foo ["should be an integer"]}
          (-> [:map
@@ -629,7 +631,17 @@
                     (= password password2))]]
                (m/explain {:password "secret"
                            :password2 "faarao"})
-               (me/humanize {:resolve me/-resolve-root-error}))))))
+               (me/humanize {:resolve me/-resolve-root-error})))))
+
+  (testing "refs #1106"
+    (is (= {:foo ["should be an integer"]}
+           (me/humanize
+            (m/explain [:ref #'VarSchema] {:foo "2"})
+            {:resolve me/-resolve-direct-error})))
+    (is (= {:foo ["should be an integer"]}
+           (me/humanize
+            (m/explain [:ref #'VarSchema] {:foo "2"})
+            {:resolve me/-resolve-root-error})))))
 
 (deftest limits
   (is (= {:a [["should be an int"]]

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -276,6 +276,8 @@
 ;; LensSchemas
 ;;
 
+(def Var :string)
+
 (deftest basic-lens-schema-test
   (let [re #"kikka"
         int? (m/schema int?)]
@@ -333,6 +335,8 @@
 
         [:ref {:registry {::a int?, ::b string?}} ::a] 0 ::a
         [:ref {:registry {::a int?, ::b string?}} ::a] 1 nil
+        [:ref #'Var] 0 #'Var
+        [:ref #'Var] 1 nil
 
         [:schema int?] 0 int?
         [:schema int?] 1 nil)
@@ -439,7 +443,12 @@
   (is (form= (mu/get-in (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) [0]) ::a))
   (is (mu/equals (mu/get-in (m/schema [:ref {:registry {::a int?, ::b string?}} ::a]) [0 0]) int?))
   (is (form= (mu/get-in (m/schema [:schema {:registry {::a int?, ::b string?}} ::a]) [0]) ::a))
-  (is (mu/equals (mu/get-in (m/schema [:schema {:registry {::a int?, ::b string?}} ::a]) [0 0]) int?)))
+  (is (mu/equals (mu/get-in (m/schema [:schema {:registry {::a int?, ::b string?}} ::a]) [0 0]) int?))
+
+  (is (form= (mu/get-in (m/schema [:ref #'Var]) [0]) #'Var))
+  (is (form= (mu/get-in (m/schema [:ref #'Var]) [0 0]) :string))
+  (is (form= (mu/get-in (m/schema [:schema #'Var]) [0]) #'Var))
+  (is (form= (mu/get-in (m/schema [:schema #'Var]) [0 0]) :string)))
 
 (deftest dissoc-test
   (let [schema [:map {:title "map"}


### PR DESCRIPTION
The path from a [:ref ::kw] or a [:ref #'Var] to the referred schema
is [0 0] due to the intermediate -pointer. See additions to
get-in-test. Thus the -explainer of a -ref-schema needs to add [0 0]
to the path, instead of the previous [0]. This mirrors the [0 0]
already present in the -walk of -ref-schema.

fixes #1106