### PR TITLE
Introduce schemas for map key constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * Docs: elaborate optional-keys and required-keys [#1117](https://github.com/metosin/malli/pull/1117)
 * **BREAKING** Output of `parse` now uses new `malli.core.Tag` and `malli.core.Tags` records for `:orn`, `:multi`, `:altn`, `:catn` etc. [#1123](https://github.com/metosin/malli/issues/1123) [#1153](https://github.com/metosin/malli/issues/1153)
   * See [Parsing](#parsing-values) and [Unparsing](#unparsing-values) for docs.
+* Introduce new schemas for map key constraints: `:xor`, `:disjoint`, `:if`, `:iff`, `:implies`, and `:has`
 
 ## 0.17.0 (2024-12-08)
 

--- a/README.md
+++ b/README.md
@@ -415,6 +415,224 @@ default branching can be arbitrarily nested:
 ; => true
 ```
 
+## Constraining keys
+
+_Note_: the schemas in this section may not yet yield reliable generators. This is under development.
+However, it is recommended to use these schemas over `:fn` whenever possible to support future enhancements.
+
+The `:and` schema can be used to constrain an existing schema to be more specific.
+In this section we show how to constrain a `:map` schema with more specific keys.
+
+The schema `[:has K]` asserts the key `K` must be present.
+This is the main building block for key constraints that will be combined
+with other schemas.
+
+```clojure
+(me/humanize
+  (m/explain
+    [:and :map [:has :x]]
+    {}))
+; => {:x ["missing required key"]}
+
+(me/humanize
+  (m/explain
+    [:and :map [:has nil nil] [:has []]]
+    {}))
+; => ["missing required key"]
+```
+
+The `:or` schema asserts that at least one of its children is satisfied.
+
+```clojure
+;; at least one padding direction must be provided
+(def Padding
+  [:and
+   [:map
+    [:top {:optional true} number?]
+    [:bottom {:optional true} number?]
+    [:left {:optional true} number?]
+    [:right {:optional true} number?]]
+   [:or
+    [:has :top]
+    [:has :bottom]
+    [:has :left]
+    [:has :right]])
+
+(m/validate Padding {:left 1 :right 10 :up 25 :down 50}) ;=> true
+(me/humanize
+  (m/explain Padding {}))
+; => {:top ["missing required key"],
+;     :bottom ["missing required key"],
+;     :left ["missing required key"],
+;     :right ["missing required key"]}
+```
+
+The `:xor` schema requires exactly one of its children to be satisfied.
+
+```clojure
+;; :mvn/version or :git/sha must be provided, but not both
+(def GitOrMvn
+  [:and
+   [:map
+    [:mvn/version {:optional true} :string]
+    [:git/sha {:optional true} :string]]
+   [:xor
+    [:has :mvn/version]
+    [:has :git/sha]]])
+
+(m/validate GitOrMvn {:mvn/version "1.0.0"}) ; => true
+
+(m/validate GitOrMvn {:mvn/version "1.0.0" :git/sha "123"})) ; => false
+
+(me/humanize
+  (m/explain GitOrMvn
+             {:mvn/version "1.0.0"
+              :git/sha "123"}))
+; => ["should not have key :git/sha"]
+
+(me/humanize
+  (m/explain GitOrMvn
+             {}))
+; => {:mvn/version ["missing required key"],
+;     :git/sha ["missing required key"]}
+```
+
+The `:iff` schema requires either all or none of its children to be satisfied.
+
+```clojure
+;; either both :user and :pass are provided, or neither
+(def UserPass
+  [:and
+   [:map
+    [:user {:optional true} string?]
+    [:pass {:optional true} string?]]
+   [:iff [:has :user] [:has :pass]]])
+
+(m/validate UserPass {}) ; => true
+(m/validate UserPass {:user "a" :pass "b"}) ; => true
+
+(me/humanize
+  (m/explain UserPass {:user "a"}))
+; => {:pass ["missing required key"], :malli/error ["should not have key :user"]}
+```
+
+The `:implies` schema is satisfied if either its first child is _not_ satisfied or
+all of its children are satisfied.
+
+
+```clojure
+;; if :git/tag is provided, then so should :git/sha
+(def TagImpliesSha
+  [:and
+   [:map
+    [:git/sha {:optional true} :string]
+    [:git/tag {:optional true} :string]]
+   [:implies [:has :git/tag] [:has :git/sha]]])
+
+(m/validate TagImpliesSha {:git/sha "abc123"}) ;=> true
+(m/validate TagImpliesSha {:git/tag "v1.0.0" :git/sha "abc123"}) ; => true
+
+(me/humanize
+  (m/explain TagImpliesSha {:git/tag "v1.0.0"}))
+; => {:git/sha ["missing required key"], :malli/error ["should not have key :git/tag"]}
+```
+
+The `:disjoint` schema is similar to `:xor` but also permits zero schemas to match.
+
+```clojure
+;; :mvn/* and :git/* keys should not coexist
+(def SeparateMvnGit
+  [:and
+   [:map
+    [:mvn/version {:optional true} :string]
+    [:git/sha {:optional true} :string]
+    [:git/tag {:optional true} :string]
+    [:git/url {:optional true} :string]]
+   [:disjoint
+    [:has :mvn/version]
+    [:or
+     [:has :git/sha]
+     [:has :git/url]
+     [:has :git/tag]]]])
+
+(m/validate SeparateMvnGit {}) ; => true
+(m/validate SeparateMvnGit {:mvn/version "1.0.0"}) ; => true
+(m/validate SeparateMvnGit {:git/sha "1.0.0"}) ; => true
+(m/validate SeparateMvnGit {:mvn/version "1.0.0" :git/sha "abc123"}) ; => false
+
+(me/humanize
+  (m/explain SeparateMvnGit
+             {:mvn/version "1.0.0"
+              :git/sha "abc123"}))
+; => ["should not have key :git/sha"]
+```
+
+For multiple sets of disjoint keys, use multiple `:disjoint` schemas.
+
+```clojure
+;; cannot hold :up + :down or :left + :right
+(def DPad
+  [:and
+   [:map
+    [:down {:optional true} [:= 1]]
+    [:left {:optional true} [:= 1]]
+    [:right {:optional true} [:= 1]]
+    [:up {:optional true} [:= 1]]]
+   [:disjoint [:has :down] [:has :up]]
+   [:disjoint [:has :left] [:has :right]]])
+
+(m/validate DPad {}) ; => true
+(m/validate DPad {:up 1}) ; => true
+(m/validate DPad {:down 1}) ; => true
+(m/validate DPad {:right 1}) ; => true
+(m/validate DPad {:left 1}) ; => true
+(m/validate DPad {:up 1 :left 1}) ; => true
+(m/validate DPad {:down 1 :left 1}) ; => true
+(m/validate DPad {:up 1 :right 1}) ; => true
+(m/validate DPad {:down 1 :right 1}) ; => true
+
+(me/humanize
+  (m/explain DPad {:up 1 :down 1}))
+; => ["should not have key :up"]
+
+(me/humanize
+  (m/explain DPad {:left 1 :right 1}))
+; => ["should not have key :right"]
+```
+
+In this example, we nest `:and` in `:or` to assert that either a secret or
+user/pass must be provided. The `:disjoint` schema is used to ensure
+both are not provided. Even if we used `:xor` instead of `:or`, it
+would still be legal to provide `{:secret "1234" :user "user"}` without
+this additional constraint.
+
+```clojure
+(def SecretOrCreds
+  [:and
+   [:map
+    [:secret {:optional true} string?]
+    [:user {:optional true} string?]
+    [:pass {:optional true} string?]]
+   [:or
+    [:has :secret]
+    [:and [:has :user] [:has :pass]]]
+   [:disjoint
+    [:has :secret]
+    [:or [:has :user] [:has :pass]]]])
+
+(m/validate SecretOrCreds {:secret "1234"}) ; => true
+(m/validate SecretOrCreds {:user "user" :pass "hello"}) ; => true
+
+(me/humanize
+  (m/explain SecretOrCreds {:user "user"}))
+; => {:secret ["missing required key"], :pass ["missing required key"]}
+
+;; combining :or with :disjoint helps enforce this case
+(me/humanize
+  (m/explain SecretOrCreds {:secret "1234" :user "user"}))
+;=> ["should not have key :user"]
+```
+
 ## Seqable schemas
 
 The `:seqable` and `:every` schemas describe `seqable?` collections. They

--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -71,3 +71,29 @@
 (def ^{:arglists '([[& preds]])} -some-pred
   #?(:clj  (-pred-composer or 16)
      :cljs (fn [preds] (fn [x] (boolean (some #(% x) preds))))))
+
+(defn -one-pred
+  [preds]
+  (partial (reduce (fn [acc f]
+                     (fn [found v]
+                       (if (f v)
+                         (if found
+                           false
+                           (acc true v))
+                         (acc found v))))
+                   (fn [found _] found)
+                   preds)
+           false))
+
+(defn -zero-or-one-pred
+  [preds]
+  (partial (reduce (fn [acc f]
+                     (fn [found v]
+                       (if (f v)
+                         (if found
+                           false
+                           (acc true v))
+                         (acc found v))))
+                   (fn [_ _] true)
+                   preds)
+           false))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3547,3 +3547,344 @@
   (is (not (m/validate [:sequential {:min 11} :int] (eduction identity (range 10)))))
   (is (not (m/validate [:seqable {:min 11} :int] (eduction identity (range 10)))))
   (is (nil? (m/explain [:sequential {:min 9} :int] (eduction identity (range 10))))))
+
+(deftest xor-test
+  (is (= [:xor [:= 1] [:= 2]]
+         (m/form (m/schema [:xor [:= 1] [:= 2]] {:registry (merge (mu/schemas) (m/default-schemas))}))))
+  (is (true? (m/validate [:xor [:enum 1 2] [:enum 2 3]] 1 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:xor [:enum 1 2] [:enum 2 3]] 3 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:xor [:enum 1 2] [:enum 2 3]] 2 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:xor [:enum 1 2] [:enum 2 3]] nil {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (nil? (m/explain [:xor [:enum 1 2] [:enum 2 3]] 1 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (nil? (m/explain [:xor [:enum 1 2] [:enum 2 3]] 3 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (m/explain [:xor [:enum 1 2] [:enum 2 3]] 2 {:registry (merge (mu/schemas) (m/default-schemas))}))
+  (is (m/explain [:xor [:enum 1 2] [:enum 2 3]] nil {:registry (merge (mu/schemas) (m/default-schemas))})))
+
+(deftest has-test
+  (is (= [:has :foo]
+         (m/form (m/schema [:has :foo] {:registry (merge (mu/schemas) (m/default-schemas))}))))
+  (is (true? (m/validate [:has :foo] {:foo 1} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:has :foo] {} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:has :foo] 1 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (nil? (m/explain [:has :foo] {:foo 1} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (m/explain [:has :foo] {} {:registry (merge (mu/schemas) (m/default-schemas))}))
+  (is (m/explain [:has :foo] 1 {:registry (merge (mu/schemas) (m/default-schemas))})))
+
+(deftest if-test
+  (is (= [:if [:has :user] [:has :pass] [:has :secret]]
+         (m/form (m/schema [:if [:has :user] [:has :pass] [:has :secret]] {:registry (merge (mu/schemas) (m/default-schemas))}))))
+  (is (true? (m/validate [:if [:has :user] [:has :pass] [:has :secret]] {:user nil :pass nil} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:if [:has :user] [:has :pass] [:has :secret]] {:secret nil} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:if [:has :user] [:has :pass] [:has :secret]] {:user nil :pass nil :secret nil} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:if [:has :user] [:has :pass] [:has :secret]] {:pass nil :secret nil} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:if [:has :user] [:has :pass] [:has :secret]] {} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:if [:has :user] [:has :pass] [:has :secret]] {:user nil} {:registry (merge (mu/schemas) (m/default-schemas))}))))
+
+(deftest disjoint-test
+  (is (= [:disjoint
+          [:= 2]
+          [:or [:= 1] [:= 2] [:= 3]]]
+         (m/form (m/schema [:disjoint
+                            [:= 2]
+                            [:or [:= 1] [:= 2] [:= 3]]] {:registry (merge (mu/schemas) (m/default-schemas))}))))
+  (is (true? (m/validate [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 1 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 3 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 4 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 2 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (nil? (m/explain [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 1 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (nil? (m/explain [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 3 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (nil? (m/explain [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 4 {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (m/explain [:disjoint [:= 2] [:or [:= 1] [:= 2] [:= 3]]] 2 {:registry (merge (mu/schemas) (m/default-schemas))})))
+
+(deftest iff-test
+  (is (= [:iff [:has :user] [:has :pass]]
+         (m/form (m/schema [:iff [:has :user] [:has :pass]] {:registry (merge (mu/schemas) (m/default-schemas))}))))
+  (is (true? (m/validate [:iff [:has :user] [:has :pass]] {:user nil :pass nil} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:iff [:has :user] [:has :pass]] {:secret nil} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (true? (m/validate [:iff [:has :user] [:has :pass]] {} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:iff [:has :user] [:has :pass]] {:pass nil} {:registry (merge (mu/schemas) (m/default-schemas))})))
+  (is (false? (m/validate [:iff [:has :user] [:has :pass]] {:user nil} {:registry (merge (mu/schemas) (m/default-schemas))}))))
+
+(def Address
+  [:and
+   [:map
+    [:street {:optional true} string?]
+    [:city {:optional true} string?]
+    [:zip {:optional true} int?]]
+   [:iff
+    [:has :street]
+    [:has :city]
+    [:has :zip]]])
+
+(def GitOrMvn
+  [:and
+   [:map
+    [:mvn/version {:optional true} :string]
+    [:git/sha {:optional true} :string]]
+   [:xor
+    [:has :mvn/version]
+    [:has :git/sha]]])
+
+(def TagImpliesSha
+  [:and
+   [:map
+    [:git/sha {:optional true} :string]
+    [:git/tag {:optional true} :string]]
+   [:implies [:has :git/tag] [:has :git/sha]]])
+
+(def UserPass
+  [:and
+   [:map
+    [:user {:optional true} string?]
+    [:pass {:optional true} string?]]
+   [:iff [:has :user] [:has :pass]]])
+
+(def SeparateMvnGit
+  [:and
+   [:map
+    [:mvn/version {:optional true} :string]
+    [:git/sha {:optional true} :string]
+    [:git/tag {:optional true} :string]
+    [:git/url {:optional true} :string]]
+   [:disjoint
+    [:has :mvn/version]
+    [:or
+     [:has :git/sha]
+     [:has :git/url]
+     [:has :git/tag]]]])
+
+(def SecretOrCreds
+  [:and
+   [:map
+    [:secret {:optional true} string?]
+    [:user {:optional true} string?]
+    [:pass {:optional true} string?]]
+   [:or
+    [:has :secret]
+    [:and [:has :user] [:has :pass]]]
+   [:disjoint
+    [:has :secret]
+    [:or [:has :user] [:has :pass]]]])
+
+(def DPad
+  [:and
+   [:map
+    [:down {:optional true} [:= 1]]
+    [:left {:optional true} [:= 1]]
+    [:right {:optional true} [:= 1]]
+    [:up {:optional true} [:= 1]]]
+   [:disjoint [:has :down] [:has :up]]
+   [:disjoint [:has :left] [:has :right]]])
+
+(def DPadNot
+  [:and
+   [:map
+    [:down {:optional true} [:= 1]]
+    [:left {:optional true} [:= 1]]
+    [:right {:optional true} [:= 1]]
+    [:up {:optional true} [:= 1]]]
+   [:not [:and [:has :down] [:has :up]]]
+   [:not [:and [:has :left] [:has :right]]]])
+
+(def DPadDeMorgan
+  [:and
+   [:map
+    [:down {:optional true} [:= 1]]
+    [:left {:optional true} [:= 1]]
+    [:right {:optional true} [:= 1]]
+    [:up {:optional true} [:= 1]]]
+   [:or
+    [:not [:has :down]]
+    [:not [:has :up]]]
+   [:or
+    [:not [:has :left]]
+    [:not [:has :right]]]])
+
+(def Padding
+  [:and
+   [:map
+    [:top {:optional true} number?]
+    [:bottom {:optional true} number?]
+    [:left {:optional true} number?]
+    [:right {:optional true} number?]]
+   [:or
+    [:has :top]
+    [:has :bottom]
+    [:has :left]
+    [:has :right]]])
+
+(deftest map-keyset-readme-examples-test
+  (is (= (me/humanize
+           (m/explain
+             [:and :map [:has :x]]
+             {}))
+         {:x ["missing required key"]}))
+  (is (not (m/validate [:and :map [:has :a]] {})))
+  (is (not (m/validate [:and :map [:has "a"]] {})))
+  (is (not (m/validate [:and :map [:has []]] {})))
+  (is (m/validate [:and :map [:has []]] {[] nil}))
+  (is (not (m/validate [:and :map [:has nil nil]] {})))
+  (is (m/validate [:and :map [:has nil nil]] {nil nil}))
+  (is (= (me/humanize
+           (m/explain
+             [:and :map [:has nil nil]]
+             {}))
+         ["missing required key"]))
+  (is (= (me/humanize
+           (m/explain
+             [:and :map [:has nil nil] [:has []]]
+             {}))
+         ["missing required key"]))
+  (is (= (me/humanize
+           (m/explain
+             [:and
+              [:map
+               [:x {:optional true} :int]]
+              [:has :x]]
+             {}))
+         {:x ["missing required key"]}))
+  (is (= (me/humanize
+           (m/explain
+             [:and
+              [:map
+               [:a1 {:optional true} :string]
+               [:a2 {:optional true} :string]]
+              [:or
+               [:has :a1]
+               [:has :a2]]]
+             {}))
+         ;; TODO really a disjunction of problems
+         {:a1 ["missing required key"], :a2 ["missing required key"]}))
+  (is (m/validate Address {}))
+  (is (= (me/humanize (m/explain Address {:zip 5555}))
+         {:street ["missing required key"],
+          :city ["missing required key"],
+          :malli/error ["should not have key :zip"]}
+         #_
+         [[:xor
+           [:and
+            "should provide key: :street"
+            "should provide key: :city"]
+           "should not provide key: :zip"]]))
+  (testing "GitOrMvn"
+    (is (m/validate GitOrMvn {:mvn/version "1.0.0"}))
+    (is (false? (m/validate GitOrMvn {:mvn/version "1.0.0" :git/sha "123"})))
+    (is (= (me/humanize
+             (m/explain GitOrMvn
+                        {:mvn/version "1.0.0"
+                         :git/sha "123"}))
+           ["should not have key :git/sha"]
+           #_
+           [[:xor
+             "should not provide key: :mvn/version"
+             "should not provide key: :git/sha"]]))
+    (is (= (me/humanize
+             (m/explain GitOrMvn {}))
+           {:mvn/version ["missing required key"],
+            :git/sha ["missing required key"]}
+           #_
+           [[:xor
+             "should provide key: :mvn/version"
+             "should provide key: :git/sha"]])))
+  (testing "TagImpliesSha"
+    (is (m/validate TagImpliesSha {:git/sha "abc123"}))
+    (is (m/validate TagImpliesSha {:git/tag "v1.0.0" :git/sha "abc123"}))
+    (is (false? (m/validate TagImpliesSha {:git/tag "v1.0.0"})))
+    (is (= (me/humanize
+             (m/explain TagImpliesSha {:git/tag "v1.0.0"}))
+           {:git/sha ["missing required key"], :malli/error ["should not have key :git/tag"]}
+           #_
+           [["should provide key: :git/sha"]])))
+  (testing "UserPass"
+    (is (m/validate UserPass {}))
+    (is (m/validate UserPass {:user "a" :pass "b"}))
+    (is (false? (m/validate UserPass {:user "a"})))
+    (is (= (me/humanize
+             (m/explain UserPass {:user "a"}))
+           {:pass ["missing required key"], :malli/error ["should not have key :user"]}
+           #_
+           [[:xor
+             "should provide key: :pass"
+             "should not provide key: :user"]])))
+  (testing "SeparateMvnGit"
+    (is (m/validate SeparateMvnGit {}))
+    (is (m/validate SeparateMvnGit {:mvn/version "1.0.0"}))
+    (is (m/validate SeparateMvnGit {:git/sha "1.0.0"}))
+    (is (false? (m/validate SeparateMvnGit {:mvn/version "1.0.0" :git/sha "abc123"})))
+    (is (= (me/humanize
+             (m/explain SeparateMvnGit
+                        {:mvn/version "1.0.0"
+                         :git/sha "abc123"}))
+           ["should not have key :git/sha"]
+           #_
+           ["should not combine key :mvn/version with key: :git/sha"])))
+  (testing "SecretOrCreds"
+    (is (m/validate SecretOrCreds {:secret "1234"}))
+    (is (m/validate SecretOrCreds {:user "user" :pass "hello"}))
+    (is (not (m/validate SecretOrCreds {:user "user"})))
+    (is (= (me/humanize
+             (m/explain SecretOrCreds {:user "user"}))
+           {:secret ["missing required key"], :pass ["missing required key"]}
+           #_
+           ;;FIXME should say: either remove user and add secret, or add pass, but not both
+           [[:or
+             "should provide key: :secret"
+             "should provide key: :pass"]]))
+    (is (false? (m/validate SecretOrCreds {:secret "1234" :user "user"})))
+    (is (= (me/humanize
+             (m/explain SecretOrCreds {:secret "1234" :user "user"}))
+           ["should not have key :user"]
+           #_
+           ["should not combine key :secret with key: :user"])))
+
+  (testing "DPad"
+    (doseq [DPad [DPad DPadNot DPadDeMorgan]]
+      (is (m/validate DPad {}))
+      (is (m/validate DPad {:up 1}))
+      (is (m/validate DPad {:down 1}))
+      (is (m/validate DPad {:right 1}))
+      (is (m/validate DPad {:left 1}))
+      (is (m/validate DPad {:up 1 :left 1}))
+      (is (m/validate DPad {:down 1 :left 1}))
+      (is (m/validate DPad {:up 1 :right 1}))
+      (is (m/validate DPad {:down 1 :right 1}))
+      (is (not (m/validate DPad {:up 1 :down 1})))
+      (is (not (m/validate DPad {:left 1 :right 1}))))
+    #_
+    (doseq [DPad [DPadNot DPadDeMorgan]]
+      (is (= (me/humanize
+               (m/explain DPad {:up 1 :down 1}))
+             ["should not have key :up"]))
+      (is (= (me/humanize
+               (m/explain DPad {:left 1 :right 1}))
+             ["should not have key :right"])))
+    (is (= (me/humanize
+             (m/explain DPad {:up 1 :down 1}))
+           ["should not have key :up"]
+           #_
+           ["should not combine key :down with key: :up"]))
+    (is (= (me/humanize
+             (m/explain DPad {:left 1 :right 1}))
+           ["should not have key :right"]
+           #_
+           ["should not combine key :left with key: :right"])))
+  (testing "Padding"
+    (is (m/validate Padding {:left 1 :right 10 :up 25 :down 50}))
+    (is (= (me/humanize
+             (m/explain Padding {}))
+           {:top ["missing required key"],
+            :bottom ["missing required key"],
+            :left ["missing required key"],
+            :right ["missing required key"]}
+           #_
+           [[:or
+             "should provide key: :top"
+             "should provide key: :bottom"
+             "should provide key: :left"
+             "should provide key: :right"]]))
+    (is (= '({:top -2.0, :right 0}
+             {:top 0.5, :bottom -1, :left -1, :right 2.0}
+             {:top -2, :left -0.5, :right -1}
+             {:top 6, :left -1, :right -1}
+             {:top 0, :left -1})
+           (mg/sample Padding {:size 5 :seed 0})))))


### PR DESCRIPTION
This PR adds some schemas to help constrain the keysets of `:map` schemas. Instead of `[:and [:map ..] [:fn <OPAQUE>]]`, you now write `[:and [:map ...] [:xor ..] [:iff ..] ...]`.

The next step is to improve the generators for these schemas. The basic strategy to generate `[:and S T]` will be to generate `S` but propagate `T` as a hint to the `S` generator. Most of the work will be to canonicalize `T` by expanding into disjunctive normal form.

There are more general abstractions here (like the idea of simplifying a schema) but we can build towards that later. I have sketches of using such abstractions to compile optimal validators and generators. For now, concentrating on map keyset constraints is helping move this work along.