### PR TITLE
docs: use project relative links for malli content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ borkdude/edamame '1.4.25' to '1.4.27'
 
 ## 0.16.3 (2024-08-05)
 
-* `:->` added to default registry, see [documentation](https://github.com/metosin/malli/blob/master/docs/function-schemas.md#flat-arrow-function-schemas).
+* `:->` added to default registry, see [documentation](/docs/function-schemas.md#flat-arrow-function-schemas).
 * New `:seqable` and `:every` schemas [#1041](https://github.com/metosin/malli/pull/1041), see [docs](https://github.com/metosin/malli#seqable-schemas)
 * Fix OOM error with infinitely expanding schema [#1069](https://github.com/metosin/malli/pull/1069)
 * Correctly form prop-less schemas that have map/nil as first child [#1071](https://github.com/metosin/malli/pull/1071)
@@ -111,9 +111,9 @@ borkdude/edamame '1.4.25' to '1.4.27'
 
 ```clojure
 ;; function of arg:int -> ret:int, where arg < ret
-[:=> 
- [:cat :int] 
- :int 
+[:=>
+ [:cat :int]
+ :int
  [:fn (fn [[[arg] ret]] (< arg ret))]]
 ```
 
@@ -454,7 +454,7 @@ borkdude/edamame 0.0.18 -> 0.0.19
 
 * `malli.dev.pretty/explain` for pretty-printing explanations
 
-<img src="https://github.com/metosin/malli/blob/master/docs/img/pretty-explain.png" width=800>
+<img src="docs/img/pretty-explain.png" width=800>
 
 * updated dependencies:
 
@@ -760,7 +760,8 @@ No need to play with Compiler options or JVM properties to swap the default regi
 
 * New experimental pretty printer for schema errors, using [fipp](https://github.com/brandonbloom/fipp).
 
-<img src="https://github.com/metosin/malli/blob/master/docs/img/defn-schema.png">
+    ![](/docs/img/defn-schema.png)
+
 
 ### Extender API
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Data-driven Schemas for Clojure/Script and [babashka](#babashka).
 
 [Metosin Open Source Status: Active](https://github.com/metosin/open-source/blob/main/project-status.md#active). Stability: well matured [*alpha*](#alpha).
 
-<img src="https://raw.githubusercontent.com/metosin/malli/master/docs/img/malli.png" width=130 align="right"/>
+<img src="docs/img/malli.png" width=130 align="right"/>
 
 - Schema definitions as data
 - [Vector](#vector-syntax), [Map](#map-syntax) and [Lite](#lite) syntaxes
@@ -46,7 +46,7 @@ Try the [online demo](https://malli.io), see also some [3rd Party Libraries](#3r
 
 Want to contribute? See the [Development](#development) guide.
 
-<img src="https://raw.githubusercontent.com/metosin/malli/master/docs/img/malli-defn.png" width="600" />
+<img src="docs/img/malli-defn.png" width="600" />
 
 > Hi! We are [Metosin](https://metosin.fi), a consulting company. These libraries have evolved out of the work we do for our clients.
 > We maintain & develop this project, for you, for free. Issues and pull requests welcome!
@@ -1022,11 +1022,11 @@ Now, any exception thrown via `malli.core/-fail!` is being captured and pretty p
 
 Pretty Coercion:
 
-<img src="https://github.com/metosin/malli/blob/master/docs/img/pretty-coerce.png" width=800>
+<img src="docs/img/pretty-coerce.png" width=800>
 
 Custom exception (with default layout):
 
-<img src="https://github.com/metosin/malli/blob/master/docs/img/bats-in-the-attic.png" width=800>
+<img src="docs/img/bats-in-the-attic.png" width=800>
 
 Pretty printing in being backed by `malli.dev.virhe/-format` multimethod using `(-> exception (ex-data) :data)` as the default dispatch key. As fallback, exception class - or exception subclass can be used, e.g. the following will handle all `java.sql.SQLException` and it's parent exceptions:
 
@@ -1044,7 +1044,7 @@ Pretty printing in being backed by `malli.dev.virhe/-format` multimethod using `
 
 For pretty development-time error printing, try `malli.dev.pretty/explain`
 
-<img src="https://github.com/metosin/malli/blob/master/docs/img/pretty-explain.png" width=800>
+<img src="docs/img/pretty-explain.png" width=800>
 
 ## Value transformation
 
@@ -3277,7 +3277,7 @@ Transforming Schemas into [DOT Language](https://en.wikipedia.org/wiki/DOT_(grap
 
 Visualized with [Graphviz](https://graphviz.org/):
 
-<img src="https://raw.githubusercontent.com/metosin/malli/master/docs/img/dot.png"/>
+![Graphviz image output](/docs/img/dot.png)
 
 ### PlantUML
 
@@ -3292,7 +3292,7 @@ Transforming Schemas into [PlantUML](https://plantuml.com/):
 
 Visualized with [PlantText](https://www.planttext.com/):
 
-<img src="https://raw.githubusercontent.com/metosin/malli/master/docs/img/plantuml.png"/>
+![PlanText image output](/docs/img/plantuml.png)
 
 ## Lite
 


### PR DESCRIPTION
Mostly images, but also fixed one doc link from changelog.

Closes #1164