### PR TITLE
Non-flowing `:and` parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -2508,6 +2508,32 @@ Parsing returns tagged values for `:orn`, `:catn`, `:altn` and `:multi`.
 ; => #malli.core.Tag{:key :malli.core/default, :value {:type "sized", :size 1}}
 ```
 
+### :and parsing
+
+By default parsing an `:and` schema allows the intermediate results of parsing the value
+flow left-to-right. For example, the following parse fails because the output of
+parsing `:catn` is a map, not a vector.
+
+```clojure
+(m/parse [:and
+          [:catn ["a" :int] ["b" :keyword]]
+          [:fn vector?]]
+         [3 :x])
+; => ::m/invalid
+```
+
+The property `{:parse :non-flowing}` changes the `:and` schema to parse each
+child schema using the original input value, returning the result of parsing
+the first child if all parsers succeed.
+
+```clojure
+(m/parse [:and {:parse :non-flowing}
+          [:catn ["a" :int] ["b" :keyword]]
+          [:fn vector?]]
+         [3 :x])
+; => (m/tags {"a" 3, "b" :x})
+```
+
 ## Unparsing values
 
 The inverse of parsing, using `m/unparse` and `m/unparser`:

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3547,3 +3547,15 @@
   (is (not (m/validate [:sequential {:min 11} :int] (eduction identity (range 10)))))
   (is (not (m/validate [:seqable {:min 11} :int] (eduction identity (range 10)))))
   (is (nil? (m/explain [:sequential {:min 9} :int] (eduction identity (range 10))))))
+
+(deftest non-flowing-and-test
+  (is (= (m/tags {"a" 3, "b" :x})
+         (m/parse [:and [:catn ["a" :int] ["b" :keyword]] [:fn any?]] [3 :x])))
+  (is (= ::m/invalid
+         (m/parse [:and [:catn ["a" :int] ["b" :keyword]]
+                   [:fn vector?]]
+                  [3 :x])))
+  (is (= (m/tags {"a" 3, "b" :x})
+         (m/parse [:and {:parse :non-flowing} [:catn ["a" :int] ["b" :keyword]]
+                   [:fn vector?]]
+                  [3 :x]))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3550,8 +3550,12 @@
 
 (deftest non-flowing-and-test
   (testing "flowing"
-    (is (= (m/tags {"a" 3, "b" :x})
-           (m/parse [:and [:catn ["a" :int] ["b" :keyword]] [:fn any?]] [3 :x])))
+    (testing "parses successfully"
+      (is (= (m/tags {"a" 3, "b" :x})
+             (m/parse [:and [:catn ["a" :int] ["b" :keyword]] [:fn any?]] [3 :x])))
+      (is (= [3 :x]
+             (let [s [:and [:catn ["a" :int] ["b" :keyword]] [:fn any?]]]
+               (m/unparse s (m/parse s [3 :x]))))))
     (testing "m/tags is not a vector, so fails second child"
       (is (= ::m/invalid
              (m/parse [:and
@@ -3570,7 +3574,11 @@
         (is (= (m/tags {"a" 3, "b" :x})
                (m/parse [:and {:parse :non-flowing}
                          [:catn ["a" :int] ["b" :keyword]]]
-                        [3 :x]))))
+                        [3 :x])))
+        (is (= [3 :x]
+               (let [s [:and {:parse :non-flowing}
+                        [:catn ["a" :int] ["b" :keyword]]]]
+                 (m/unparse s (m/parse s [3 :x]))))))
       (testing "first child fails"
         (is (= ::m/invalid
                (m/parse [:and {:parse :non-flowing}
@@ -3582,7 +3590,13 @@
                (m/parse [:and {:parse :non-flowing}
                          [:catn ["a" :int] ["b" :keyword]]
                          [:fn vector?]]
-                        [3 :x]))))
+                        [3 :x])))
+        ;;FIXME
+        (is (= (m/tags {"a" 3, "b" :x})
+               (let [s [:and {:parse :non-flowing}
+                        [:catn ["a" :int] ["b" :keyword]]
+                        [:fn vector?]]]
+                 (m/unparse s (m/parse s [3 :x]))))))
       (testing "first child fails"
         (is (= ::m/invalid
                (m/parse [:and {:parse :non-flowing}
@@ -3602,7 +3616,14 @@
                          [:catn ["a" :int] ["b" :keyword]]
                          [:fn vector?]
                          [:fn seq]]
-                        [3 :x]))))
+                        [3 :x])))
+        ;;FIXME
+        (is (= (m/tags {"a" 3, "b" :x})
+               (let [s [:and {:parse :non-flowing}
+                        [:catn ["a" :int] ["b" :keyword]]
+                        [:fn vector?]
+                        [:fn seq]]]
+                 (m/unparse s (m/parse s [3 :x]))))))
       (testing "first child fails"
         (is (= ::m/invalid
                (m/parse [:and {:parse :non-flowing}


### PR DESCRIPTION
Close https://github.com/metosin/malli/issues/1166

Could also provide a separate schema (called `and-` in spec2).

[Approach from spec2](https://github.com/clojure/spec-alpha2/blob/4cbfa677c4cd66339f18e1c122222c05c69e0d8e/src/main/clojure/clojure/alpha/spec.clj#L777)

[Original slack thread](https://clojurians.slack.com/archives/CLDK6MFMK/p1738099771219139
)

TODO
- unparsing (why is this invalid?)
```
               (let [s [:and {:parse :non-flowing}
                        [:catn ["a" :int] ["b" :keyword]]
                        [:fn vector?]]]
                 (m/unparse s (m/parse s [3 :x])))
```