### PR TITLE
Fix try/catch example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,7 +812,7 @@ Or if you already have a malli validation exception (e.g. in a catch form):
 (require '[malli.error :as me])
 
 (try
-  (m/validate Address {:not "an address"})
+  (m/assert Address {:not "an address"})
   (catch Exception e
     (-> e ex-data :data :explain me/humanize)))
 ```


### PR DESCRIPTION
README has the following example ([here](https://github.com/metosin/malli?tab=readme-ov-file#humanized-error-messages)):

```clojure
(require '[malli.error :as me])

(try
  (m/validate Address {:not "an address"})
  (catch Exception e
    (-> e ex-data :data :explain me/humanize)))
```

But, `m/validate` does not throw. I believe this was meant to be: `m/assert`. This PR swaps it.