### PR TITLE
Restore clojure 1.11 CI jobs, add JDK 23

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -12,9 +12,10 @@ jobs:
     strategy:
       matrix:
         # Supported Java versions: LTS releases and latest
-        jdk: [8, 11, 17, 21, 23]
+        jdk: [8, 11, 17, 21]
+        clojure: [11, 12]
 
-    name: Java ${{ matrix.jdk }}
+    name: Clojure ${{ matrix.clojure }} (Java ${{ matrix.jdk }})
 
     runs-on: ubuntu-latest
 
@@ -30,16 +31,16 @@ jobs:
           path: |
             ~/.m2/repository
             ~/.gitlibs
-          key: ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-${{ matrix.jdk }}
+          key: ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-${{ matrix.clojure }}-${{ matrix.jdk }}
           restore-keys: |
-            ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-
+            ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-${{ matrix.clojure }}-
             ${{ runner.os }}-test-deps-
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: latest
       - name: Run tests
-        run: bin/kaocha
+        run: CLOJURE_ALIAS=clojure-${{ matrix.clojure }} bin/kaocha
 
   build-cljs:
     name: ClojureScript

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -12,10 +12,9 @@ jobs:
     strategy:
       matrix:
         # Supported Java versions: LTS releases and latest
-        jdk: [8, 11, 17, 21]
-        clojure: [11, 12]
+        jdk: [8, 11, 17, 21, 23]
 
-    name: Clojure ${{ matrix.clojure }} (Java ${{ matrix.jdk }})
+    name: Java ${{ matrix.jdk }}
 
     runs-on: ubuntu-latest
 
@@ -31,16 +30,16 @@ jobs:
           path: |
             ~/.m2/repository
             ~/.gitlibs
-          key: ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-${{ matrix.clojure }}-${{ matrix.jdk }}
+          key: ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-${{ matrix.jdk }}
           restore-keys: |
-            ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-${{ matrix.clojure }}-
+            ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-
             ${{ runner.os }}-test-deps-
       - name: Setup Clojure
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: latest
       - name: Run tests
-        run: CLOJURE_ALIAS=clojure-${{ matrix.clojure }} bin/kaocha
+        run: bin/kaocha
 
   build-cljs:
     name: ClojureScript

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-clojure -M:test -m kaocha.runner "$@"
+# Should work if the env var is empty
+clojure -M:test:$CLOJURE_ALIAS -m kaocha.runner "$@"

--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-# Should work if the env var is empty
-clojure -A:$CLOJURE_ALIAS -M:test -m kaocha.runner "$@"
+clojure -M:test -m kaocha.runner "$@"

--- a/deps.edn
+++ b/deps.edn
@@ -26,6 +26,8 @@
                                com.bhauman/spell-spec {:mvn/version "0.1.2"}
                                org.clojure/spec-alpha2 {:git/url "https://github.com/clojure/spec-alpha2.git"
                                                         :sha "4cbfa677c4cd66339f18e1c122222c05c69e0d8e"}}}
+           :clojure-11 {:extra-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
+           :clojure-12 {}
            :sci {:extra-deps {org.babashka/sci {:mvn/version "0.9.44"}}}
            :cherry {:extra-deps {io.github.squint-cljs/cherry {:git/sha "bccd994556efca378984c5ac7fd973bda164923b"}}}
            :test-sci {:extra-paths ["test-sci"]


### PR DESCRIPTION
Closes #1174 

Clojure 1.11 jobs are redundant after removing the `:clojure-11` alias.