### PR TITLE
Skip instrumenting primitive fns

### DIFF
--- a/docs/function-schemas.md
+++ b/docs/function-schemas.md
@@ -509,6 +509,8 @@ Turning instrumentation on:
 ; =throws=> :malli.core/invalid-output {:output [:int {:max 6}], :value 11, :args [10], :schema [:=> [:cat :int] [:int {:max 6}]]}
 ```
 
+Note that functions with JVM primitive param or return type hints cannot be instrumented.
+
 #### Function Schema Metadata
 
 `defn` schemas can be defined with standard Var metadata. It allows `defn` schema documentation and instrumentation without dependencies to malli itself from the functions. It's just data.

--- a/docs/function-schemas.md
+++ b/docs/function-schemas.md
@@ -509,7 +509,7 @@ Turning instrumentation on:
 ; =throws=> :malli.core/invalid-output {:output [:int {:max 6}], :value 11, :args [10], :schema [:=> [:cat :int] [:int {:max 6}]]}
 ```
 
-Note that functions with JVM primitive param or return type hints will not be instrumented.
+Note that vars already containing a primitive JVM function will not be instrumented.
 
 #### Function Schema Metadata
 

--- a/docs/function-schemas.md
+++ b/docs/function-schemas.md
@@ -509,7 +509,7 @@ Turning instrumentation on:
 ; =throws=> :malli.core/invalid-output {:output [:int {:max 6}], :value 11, :args [10], :schema [:=> [:cat :int] [:int {:max 6}]]}
 ```
 
-Note that functions with JVM primitive param or return type hints cannot be instrumented.
+Note that functions with JVM primitive param or return type hints will not be instrumented.
 
 #### Function Schema Metadata
 

--- a/src/malli/instrument.clj
+++ b/src/malli/instrument.clj
@@ -8,17 +8,20 @@
 (defn -f->original [f] (-> f meta ::original (or f)))
 (defn -original [v] (let [f (deref v)] (-f->original f)))
 
-(defn -filter-ns [& ns] (fn [n _ _] ((set ns) n)))
+(defn -filter-ns [& ns] (let [ns (set ns)] (fn [n _ _] (contains? ns n))))
 (defn -filter-var [f] (fn [n s _] (f (-find-var n s))))
 (defn -filter-schema [f] (fn [_ _ {:keys [schema]}] (f schema)))
+
+(defn- -primitive-fn? [f]
+  (boolean (some (fn [^Class c] (.startsWith (.getName c) "clojure.lang.IFn$")) (supers (class f)))))
 
 (defn -strument!
   ([] (-strument! nil))
   ([{:keys [mode data filters gen report] :or {mode :instrument, data (m/function-schemas)} :as options}]
    (doall
     (for [[n d] data, [s d] d]
-      (when (or (not filters) (some #(% n s d) filters))
-        (when-let [v (-find-var n s)]
+      (when-let [v (-find-var n s)]
+        (when (or (not filters) (some #(% n s d) filters))
           (case mode
             :instrument (let [dgen (as-> (merge (select-keys options [:scope :report :gen]) d) $
                                      (cond-> $ report (update :report (fn [r] (fn [t data] (r t (assoc data :fn-name (symbol (name n) (name s))))))))
@@ -26,6 +29,8 @@
                                            (true? (:gen d)) (dissoc $ :gen)
                                            :else $))]
                           (alter-var-root v (fn [f]
+                                              (when (-primitive-fn? f)
+                                                (m/-fail! ::cannot-instrument-primitive-fn {:v v}))
                                               (let [f (-f->original f)]
                                                 (-> (m/-instrument dgen f) (with-meta {::original f}))))))
             :unstrument (alter-var-root v -f->original)

--- a/src/malli/instrument.clj
+++ b/src/malli/instrument.clj
@@ -13,7 +13,7 @@
 (defn -filter-schema [f] (fn [_ _ {:keys [schema]}] (f schema)))
 
 (defn- -primitive-fn? [f]
-  (boolean (some (fn [^Class c] (.startsWith (.getName c) "clojure.lang.IFn$")) (supers (class f)))))
+  (and (fn? f) (boolean (some (fn [^Class c] (.startsWith (.getName c) "clojure.lang.IFn$")) (supers (class f))))))
 
 (defn -strument!
   ([] (-strument! nil))

--- a/src/malli/instrument.clj
+++ b/src/malli/instrument.clj
@@ -15,11 +15,6 @@
 (defn- -primitive-fn? [f]
   (and (fn? f) (boolean (some (fn [^Class c] (.startsWith (.getName c) "clojure.lang.IFn$")) (supers (class f))))))
 
-(defmacro ^:private if-bb [then & [else]]
-  (if (System/getProperty "babashka.version")
-    then
-    else))
-
 (defn -strument!
   ([] (-strument! nil))
   ([{:keys [mode data filters gen report] :or {mode :instrument, data (m/function-schemas)} :as options}]

--- a/src/malli/instrument.cljs
+++ b/src/malli/instrument.cljs
@@ -97,8 +97,8 @@
   ([{:keys [mode data filters gen report skip-instrumented?] :or {skip-instrumented? false
                                                                   mode :instrument, data (m/function-schemas :cljs)} :as options}]
    (doseq [[n d] data, [s d] d]
-     (when (or (not filters) (some #(% n s d) filters))
-       (when-let [v (-find-var n s)]
+     (when-let [v (-find-var n s)]
+       (when (or (not filters) (some #(% n s d) filters))
          (case mode
            :instrument (let [original-fn (or (-original v) v)
                              dgen (as-> (select-keys options [:scope :report :gen]) $

--- a/test/malli/instrument_test.clj
+++ b/test/malli/instrument_test.clj
@@ -43,7 +43,17 @@
     else))
 
 (if-bb
-  nil
+  (deftest primitive-functions-can-be-instrumented
+    (is (= 42 (primitive-DO 42)))
+    (is (= "42" (primitive-DO "42")))
+    (is (mi/instrument! {:filters [(mi/-filter-var #(= #'primitive-DO %))]}))
+    (is (thrown-with-msg?
+          Exception
+          #":malli.core/invalid-input"
+          (primitive-DO "42")))
+    (is (mi/unstrument! {:filters [(mi/-filter-var #(= #'primitive-DO %))]}))
+    (is (= 42 (primitive-DO 42)))
+    (is (= "42" (primitive-DO "42"))))
   (deftest primitive-functions-cannot-be-instrumented
     (is (= 42.0 (primitive-DO 42)))
     (is (thrown-with-msg? Exception

--- a/test/malli/instrument_test.clj
+++ b/test/malli/instrument_test.clj
@@ -1,5 +1,6 @@
 (ns malli.instrument-test
-  (:require [clojure.test :refer [deftest is testing]]
+  (:require [clojure.string :as str]
+            [clojure.test :refer [deftest is testing]]
             [malli.core :as m]
             [malli.instrument :as mi]))
 
@@ -56,10 +57,12 @@
     (is (= "42" (primitive-DO "42"))))
   (deftest primitive-functions-cannot-be-instrumented
     (is (= 42.0 (primitive-DO 42)))
-    (is (thrown-with-msg? Exception
-                          #":malli\.instrument/cannot-instrument-primitive-fn"
-                          (mi/instrument! {:filters [(mi/-filter-var #(= #'primitive-DO %))]})))
-    (is (= 42.0 (primitive-DO 42)))))
+    (is (thrown? ClassCastException (primitive-DO "42")))
+    (is (str/includes?
+          (with-out-str (mi/instrument! {:filters [(mi/-filter-var #(= #'primitive-DO %))]}))
+          "WARNING: Not instrumenting primitive fn #'malli.instrument-test/primitive-DO"))
+    (is (= 42.0 (primitive-DO 42)))
+    (is (thrown? ClassCastException (primitive-DO "42")))))
 
 (defn minus
   "kukka"

--- a/test/malli/instrument_test.clj
+++ b/test/malli/instrument_test.clj
@@ -8,8 +8,13 @@
 
 (defn ->plus [] plus)
 
-(defn unstrument! [] (with-out-str (mi/unstrument! {:filters [(mi/-filter-ns 'malli.instrument-test)]})))
-(defn instrument! [] (with-out-str (mi/instrument! {:filters [(mi/-filter-ns 'malli.instrument-test)]})))
+(defn primitive-DO [^double val] val)
+(m/=> primitive-DO [:=> [:cat :double] :double])
+
+(defn opts [] {:filters [(mi/-filter-ns 'malli.instrument-test)
+                         (mi/-filter-var #(not= #'primitive-DO %))]})
+(defn unstrument! [] (with-out-str (mi/unstrument! (opts))))
+(defn instrument! [] (with-out-str (mi/instrument! (opts))))
 
 (deftest instrument!-test
 
@@ -30,6 +35,13 @@
          Exception
          #":malli.core/invalid-output"
          ((->plus) 6)))))
+
+(deftest primitive-functions-cannot-be-instrumented
+  (is (= 42.0 (primitive-DO 42)))
+  (is (thrown-with-msg? Exception
+                        #":malli\.instrument/cannot-instrument-primitive-fn"
+                        (mi/instrument! {:filters [(mi/-filter-var #(= #'primitive-DO %))]})))
+  (is (= 42.0 (primitive-DO 42))))
 
 (defn minus
   "kukka"


### PR DESCRIPTION
Closes #859 

Throwing seems too disruptive given that it's common to instrument everything.

Other changes:
- move `-find-var` test to the outside so `-filter-var` never fails to pass a var
- precompute `-find-ns` set for improved performance