### PR TITLE
schematize children once in -applying (instead of 3x)

### DIFF
--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -386,9 +386,10 @@
 
 (defn -applying [f]
   (fn [_ children options]
-    [(clojure.core/update children 0 #(m/schema % options))
-     (clojure.core/update children 0 #(m/form % options))
-     (delay (apply f (conj children options)))]))
+    (let [children (clojure.core/update children 0 #(m/schema % options))]
+      [children
+       (clojure.core/update children 0 m/-form)
+       (delay (apply f (conj children options)))])))
 
 (defn -util-schema [m] (m/-proxy-schema m))
 

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -386,7 +386,7 @@
 
 (defn -applying [f]
   (fn [_ children options]
-    (let [children (clojure.core/update children 0 #(m/schema % options))]
+    (let [children (clojure.core/update children 0 m/schema options)]
       [children
        (clojure.core/update children 0 m/-form)
        (delay (if (= 2 (count children))

--- a/src/malli/util.cljc
+++ b/src/malli/util.cljc
@@ -389,7 +389,9 @@
     (let [children (clojure.core/update children 0 #(m/schema % options))]
       [children
        (clojure.core/update children 0 m/-form)
-       (delay (apply f (conj children options)))])))
+       (delay (if (= 2 (count children))
+                (f (nth children 0) (nth children 1) options)
+                (apply f (conj children options))))])))
 
 (defn -util-schema [m] (m/-proxy-schema m))
 

--- a/test/malli/util_test.cljc
+++ b/test/malli/util_test.cljc
@@ -1133,3 +1133,14 @@
         #?(:clj Exception, :cljs js/Error)
         #":malli\.core/child-error"
         (m/schema :union {:registry (merge (mu/schemas) (m/default-schemas))}))))
+
+(deftest -applying-test
+  (let [times-initialized (atom 0)
+        map-proxy (m/-proxy-schema
+                    {:type ::map-proxy
+                     :max 0
+                     :fn (fn [_ _ _]
+                           (swap! times-initialized inc)
+                           [[] [] (m/schema :map)])})]
+    (m/deref-all (m/schema [:select-keys map-proxy []] {:registry (merge (mu/schemas) (m/default-schemas))}))
+    (is (= 1 @times-initialized))))


### PR DESCRIPTION
I also noticed we can skip the call to `apply` for the one schema we use `-applying` for.