### PR TITLE
Cache validators recursively

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -14,7 +14,8 @@
 
 (declare schema schema? into-schema into-schema? type eval default-registry
          -simple-schema -val-schema -ref-schema -schema-schema -registry
-         parser unparser ast from-ast -instrument ^:private -safely-countable?)
+         parser unparser ast from-ast -instrument ^:private -safely-countable?
+         -cached-validator -cached-parser -cached-unparser)
 
 ;;
 ;; protocols and records
@@ -121,7 +122,7 @@
   (-regex-validator [this]
     (if (-ref-schema? this)
       (-regex-validator (-deref this))
-      (re/item-validator (-validator this))))
+      (re/item-validator (-cached-validator this))))
 
   (-regex-explainer [this path]
     (if (-ref-schema? this)
@@ -141,7 +142,7 @@
   (-regex-transformer [this transformer method options]
     (if (-ref-schema? this)
       (-regex-transformer (-deref this) transformer method options)
-      (re/item-transformer method (-validator this) (or (-transformer this transformer method options) identity))))
+      (re/item-transformer method (-cached-validator this) (or (-transformer this transformer method options) identity))))
 
   (-regex-min-max [_ _] {:min 1, :max 1}))
 
@@ -318,11 +319,26 @@
 
 (defn -create-cache [_options] (atom {}))
 
-(defn -cached [s k f]
-  (if (-cached? s)
-    (let [c (-cache s)]
-      (or (@c k) ((swap! c assoc k (f s)) k)))
-    (f s)))
+(defn -cached
+  ([s k f]
+   (if (-cached? s)
+     (-cached s k f (-cache s))
+     (f s)))
+  ([s k f c]
+   (or (@c k)
+       (let [r (f s)]
+         (swap! c assoc k r)
+         r))))
+
+(defn -cached-validator
+  ([s] (-cached s :validator -validator))
+  ([s c] (-cached s :validator -validator c)))
+(defn -cached-parser
+  ([s] (-cached s :parser -parser))
+  ([s c] (-cached s :parser -parser c)))
+(defn -cached-unparser
+  ([s] (-cached s :unparser -unparser))
+  ([s c] (-cached s :unparser -unparser c)))
 
 ;;
 ;; forms
@@ -598,7 +614,7 @@
   (let [this-transformer (-value-transformer transformer this method options)]
     (if (seq child-schemas)
       (let [transformers (-vmap #(or (-transformer % transformer method options) identity) child-schemas)
-            validators (-vmap -validator child-schemas)]
+            validators (-vmap -cached-validator child-schemas)]
         (-intercepting this-transformer
                        (if (= :decode method)
                          (fn [x]
@@ -735,13 +751,13 @@
                   (if-let [pvalidator (when property-pred (property-pred properties))]
                     (fn [x] (and (pred x) (pvalidator x))) pred))
                 (-explainer [this path]
-                  (let [validator (-validator this)]
+                  (let [validator (-cached-validator this cache)]
                     (fn explain [x in acc]
                       (if-not (validator x) (conj acc (miu/-error path in this x)) acc))))
                 (-parser [this]
-                  (let [validator (-validator this)]
+                  (let [validator (-cached-validator this cache)]
                     (fn [x] (if (validator x) x ::invalid))))
-                (-unparser [this] (-parser this))
+                (-unparser [this] (-cached-parser this cache))
                 (-transformer [this transformer method options]
                   (-intercepting (-value-transformer transformer this method options)))
                 (-walk [this walker path options] (-walk-leaf this walker path options))
@@ -789,12 +805,12 @@
         (reify
           Schema
           (-validator [_]
-            (let [validators (-vmap -validator children)] (miu/-every-pred validators)))
+            (let [validators (-vmap -cached-validator children)] (miu/-every-pred validators)))
           (-explainer [_ path]
             (let [explainers (-vmap (fn [[i c]] (-explainer c (conj path i))) (map-indexed vector children))]
               (fn explain [x in acc] (reduce (fn [acc' explainer] (explainer x in acc')) acc explainers))))
-          (-parser [_] (->parser -parser seq))
-          (-unparser [_] (->parser -unparser rseq))
+          (-parser [_] (->parser -cached-parser seq))
+          (-unparser [_] (->parser -cached-unparser rseq))
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options] (-walk-indexed this walker path options))
@@ -828,7 +844,7 @@
         (reify
           Schema
           (-validator [_]
-            (let [validators (-vmap -validator children)] (miu/-some-pred validators)))
+            (let [validators (-vmap -cached-validator children)] (miu/-some-pred validators)))
           (-explainer [_ path]
             (let [explainers (-vmap (fn [[i c]] (-explainer c (conj path i))) (map-indexed vector children))]
               (fn explain [x in acc]
@@ -837,8 +853,8 @@
                    (let [acc'' (explainer x in acc')]
                      (if (identical? acc' acc'') (reduced acc) acc'')))
                  acc explainers))))
-          (-parser [_] (->parser -parser))
-          (-unparser [_] (->parser -unparser))
+          (-parser [_] (->parser -cached-parser))
+          (-unparser [_] (->parser -cached-unparser))
           (-transformer [this transformer method options]
             (-or-transformer this transformer children method options))
           (-walk [this walker path options] (-walk-indexed this walker path options))
@@ -874,7 +890,7 @@
           AST
           (-to-ast [this _] (-entry-ast this (-entry-keyset entry-parser)))
           Schema
-          (-validator [this] (miu/-some-pred (-vmap (fn [[_ _ c]] (-validator c)) (-children this))))
+          (-validator [this] (miu/-some-pred (-vmap (fn [[_ _ c]] (-cached-validator c)) (-children this))))
           (-explainer [this path]
             (let [explainers (-vmap (fn [[k _ c]] (-explainer c (conj path k))) (-children this))]
               (fn explain [x in acc]
@@ -885,12 +901,12 @@
                  acc explainers))))
           (-parser [this]
             (let [parsers (-vmap (fn [[k _ c]]
-                                   (let [c (-parser c)]
+                                   (let [c (-cached-parser c)]
                                      (fn [x] (miu/-map-valid #(reduced (tag k %)) (c x)))))
                                  (-children this))]
               (fn [x] (reduce (fn [_ parser] (parser x)) x parsers))))
           (-unparser [this]
-            (let [unparsers (into {} (map (fn [[k _ c]] [k (-unparser c)])) (-children this))]
+            (let [unparsers (into {} (map (fn [[k _ c]] [k (-cached-unparser c)])) (-children this))]
               (fn [x]
                 (if (tag? x)
                   (if-some [unparse (get unparsers (:key x))]
@@ -935,15 +951,15 @@
           AST
           (-to-ast [this _] (-to-child-ast this))
           Schema
-          (-validator [_] (complement (-validator schema)))
+          (-validator [_] (complement (-cached-validator schema)))
           (-explainer [this path]
-            (let [validator (-validator this)]
+            (let [validator (-cached-validator this cache)]
               (fn explain [x in acc]
                 (if-not (validator x) (conj acc (miu/-error (conj path 0) in this x)) acc))))
           (-parser [this]
-            (let [validator (-validator this)]
+            (let [validator (-cached-validator this cache)]
               (fn [x] (if (validator x) x ::invalid))))
-          (-unparser [this] (-parser this))
+          (-unparser [this] (-cached-parser this cache))
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options] (-walk-indexed this walker path options))
@@ -983,10 +999,10 @@
            AST
            (-to-ast [this _] (-to-child-ast this))
            Schema
-           (-validator [_] (-validator schema))
+           (-validator [_] (-cached-validator schema))
            (-explainer [_ path] (-explainer schema path))
-           (-parser [_] (-parser schema))
-           (-unparser [_] (-unparser schema))
+           (-parser [_] (-cached-parser schema))
+           (-unparser [_] (-cached-unparser schema))
            (-transformer [this transformer method options]
              (-parent-children-transformer this (list schema) transformer method options))
            (-walk [this walker path options]
@@ -1066,10 +1082,10 @@
            Schema
            (-validator [this]
              (let [keyset (-entry-keyset (-entry-parser this))
-                   default-validator (some-> @default-schema (-validator))
+                   default-validator (some-> @default-schema (-cached-validator))
                    validators (cond-> (-vmap
                                        (fn [[key {:keys [optional]} value]]
-                                         (let [valid? (-validator value)
+                                         (let [valid? (-cached-validator value)
                                                default (boolean optional)]
                                            #?(:bb   (fn [m] (if-let [map-entry (find m key)] (valid? (val map-entry)) default))
                                               :clj  (let [not-found (Object.)]
@@ -1119,8 +1135,8 @@
                     (fn [acc explainer]
                       (explainer x in acc))
                     acc explainers)))))
-           (-parser [this] (->parser this -parser))
-           (-unparser [this] (->parser this -unparser))
+           (-parser [this] (->parser this -cached-parser))
+           (-unparser [this] (->parser this -cached-unparser))
            (-transformer [this transformer method options]
              (let [keyset (-entry-keyset (-entry-parser this))
                    this-transformer (-value-transformer transformer this method options)
@@ -1190,8 +1206,8 @@
              (-ast {:type :map-of, :key (ast key-schema), :value (ast value-schema)} properties options))
            Schema
            (-validator [_]
-             (let [key-valid? (-validator key-schema)
-                   value-valid? (-validator value-schema)]
+             (let [key-valid? (-cached-validator key-schema)
+                   value-valid? (-cached-validator value-schema)]
                (fn [m]
                  (and (map? m)
                       (validate-limits m)
@@ -1214,8 +1230,8 @@
                                (key-explainer key in)
                                (value-explainer value in))))
                       acc m))))))
-           (-parser [_] (->parser -parser))
-           (-unparser [_] (->parser -unparser))
+           (-parser [_] (->parser -cached-parser))
+           (-unparser [_] (->parser -cached-unparser))
            (-transformer [this transformer method options]
              (let [this-transformer (-value-transformer transformer this method options)
                    ->key (-transformer key-schema transformer method options)
@@ -1314,7 +1330,7 @@
                 (-to-ast [this _] (-to-child-ast this))
                 Schema
                 (-validator [_]
-                  (let [validator (-validator schema)]
+                  (let [validator (-cached-validator schema)]
                     (fn [x] (and (fpred x)
                                  (validate-limits x)
                                  (reduce (fn [acc v] (if (validator v) acc (reduced false))) true
@@ -1334,8 +1350,8 @@
                                                                      :default size))))
                                     (cond-> (or (explainer x (conj in (fin i x)) acc) acc) xs (recur (inc i) xs))
                                     acc)))))))
-                (-parser [_] (->parser (if bounded -validator -parser) (if bounded identity parse)))
-                (-unparser [_] (->parser (if bounded -validator -unparser) (if bounded identity unparse)))
+                (-parser [_] (->parser (if bounded -cached-validator -cached-parser) (if bounded identity parse)))
+                (-unparser [_] (->parser (if bounded -cached-validator -cached-unparser) (if bounded identity unparse)))
                 (-transformer [this transformer method options]
                   (let [collection? #(or (sequential? %) (set? %))
                         this-transformer (-value-transformer transformer this method options)
@@ -1393,7 +1409,7 @@
          (reify
            Schema
            (-validator [_]
-             (let [validators (into (array-map) (map-indexed vector (mapv -validator children)))]
+             (let [validators (into (array-map) (map-indexed vector (mapv -cached-validator children)))]
                (fn [x] (and (vector? x)
                             (= (count x) size)
                             (reduce-kv
@@ -1409,8 +1425,8 @@
                            acc
                            (loop [acc acc, i 0, [x & xs] x, [e & es] explainers]
                              (cond-> (e x (conj in i) acc) xs (recur (inc i) xs es))))))))
-           (-parser [_] (->parser -parser))
-           (-unparser [_] (->parser -unparser))
+           (-parser [_] (->parser -cached-parser))
+           (-unparser [_] (->parser -cached-unparser))
            (-transformer [this transformer method options]
              (let [this-transformer (-value-transformer transformer this method options)
                    ->children (into {} (comp (map-indexed vector)
@@ -1455,11 +1471,11 @@
           (-validator [_]
             (fn [x] (contains? schema x)))
           (-explainer [this path]
-            (let [validator (-validator this)]
+            (let [validator (-cached-validator this cache)]
               (fn explain [x in acc]
                 (if-not (validator x) (conj acc (miu/-error path in this x)) acc))))
           (-parser [_] (fn [x] (if (contains? schema x) x ::invalid)))
-          (-unparser [this] (-parser this))
+          (-unparser [this] (-cached-parser this cache))
           ;; TODO: should we try to derive the type from values? e.g. [:enum 1 2] ~> int?
           (-transformer [this transformer method options]
             (-intercepting (-value-transformer transformer this method options)))
@@ -1512,9 +1528,9 @@
           (-transformer [this transformer method options]
             (-intercepting (-value-transformer transformer this method options)))
           (-parser [this]
-            (let [valid? (-validator this)]
+            (let [valid? (-cached-validator this cache)]
               (fn [x] (if (valid? x) x ::invalid))))
-          (-unparser [this] (-parser this))
+          (-unparser [this] (-cached-parser this cache))
           (-walk [this walker path options] (-walk-leaf this walker path options))
           (-properties [_] properties)
           (-options [_] options)
@@ -1557,9 +1573,9 @@
                 (catch #?(:clj Exception, :cljs js/Error) e
                   (conj acc (miu/-error path in this x (:type (ex-data e))))))))
           (-parser [this]
-            (let [validator (-validator this)]
+            (let [validator (-cached-validator this cache)]
               (fn [x] (if (validator x) x ::invalid))))
-          (-unparser [this] (-parser this))
+          (-unparser [this] (-cached-parser this cache))
           (-transformer [this transformer method options]
             (-intercepting (-value-transformer transformer this method options)))
           (-walk [this walker path options] (-walk-leaf this walker path options))
@@ -1597,14 +1613,14 @@
           (-to-ast [this _] (-to-child-ast this))
           Schema
           (-validator [_]
-            (let [validator (-validator schema)]
+            (let [validator (-cached-validator schema)]
               (fn [x] (or (nil? x) (validator x)))))
           (-explainer [_ path]
             (let [explainer (-explainer schema (conj path 0))]
               (fn explain [x in acc]
                 (if (nil? x) acc (explainer x in acc)))))
-          (-parser [_] (->parser -parser))
-          (-unparser [_] (->parser -unparser))
+          (-parser [_] (->parser -cached-parser))
+          (-unparser [_] (->parser -cached-unparser))
           (-transformer [this transformer method options]
             (-parent-children-transformer this children transformer method options))
           (-walk [this walker path options] (-walk-indexed this walker path options))
@@ -1658,7 +1674,7 @@
                            options))
            Schema
            (-validator [_]
-             (let [find (finder (reduce-kv (fn [acc k s] (assoc acc k (-validator s))) {} @dispatch-map))]
+             (let [find (finder (reduce-kv (fn [acc k s] (assoc acc k (-cached-validator s))) {} @dispatch-map))]
                (fn [x] (if-let [validator (find (dispatch x))] (validator x) false))))
            (-explainer [this path]
              (let [find (finder (reduce (fn [acc [k s]] (assoc acc k (-explainer s (conj path k)))) {} (-entries this)))]
@@ -1668,11 +1684,11 @@
                    (let [->path (if (and (map? x) (keyword? dispatch)) #(conj % dispatch) identity)]
                      (conj acc (miu/-error (->path path) (->path in) this x ::invalid-dispatch-value)))))))
            (-parser [_]
-             (let [parse (fn [k s] (let [p (-parser s)] (fn [x] (miu/-map-valid #(tag k %) (p x)))))
+             (let [parse (fn [k s] (let [p (-cached-parser s)] (fn [x] (miu/-map-valid #(tag k %) (p x)))))
                    find (finder (reduce-kv (fn [acc k s] (assoc acc k (parse k s))) {} @dispatch-map))]
                (fn [x] (if-some [parser (find (dispatch x))] (parser x) ::invalid))))
            (-unparser [_]
-             (let [unparsers (reduce-kv (fn [acc k s] (assoc acc k (-unparser s))) {} @dispatch-map)]
+             (let [unparsers (reduce-kv (fn [acc k s] (assoc acc k (-cached-unparser s))) {} @dispatch-map)]
                (fn [x] (if (tag? x) (if-some [f (unparsers (:key x))] (f (:value x)) ::invalid) ::invalid))))
            (-transformer [this transformer method options]
             ;; FIXME: Probably should not use `dispatch`
@@ -1729,13 +1745,13 @@
            (-to-ast [this _] (-to-value-ast this))
            Schema
            (-validator [_]
-             (let [validator (-memoize (fn [] (-validator (rf))))]
+             (let [validator (-memoize (fn [] (-cached-validator (rf))))]
                (fn [x] ((validator) x))))
            (-explainer [_ path]
              (let [explainer (-memoize (fn [] (-explainer (rf) (into path [0 0]))))]
                (fn [x in acc] ((explainer) x in acc))))
-           (-parser [_] (->parser -parser))
-           (-unparser [_] (->parser -unparser))
+           (-parser [_] (->parser -cached-parser))
+           (-unparser [_] (->parser -cached-unparser))
            (-transformer [this transformer method options]
              (let [this-transformer (-value-transformer transformer this method options)
                    deref-transformer (-memoize (fn [] (-transformer (rf) transformer method options)))]
@@ -1801,10 +1817,10 @@
                 raw (-to-value-ast this)
                 :else (-to-child-ast this)))
             Schema
-            (-validator [_] (-validator child))
+            (-validator [_] (-cached-validator child))
             (-explainer [_ path] (-explainer child (conj path 0)))
-            (-parser [_] (-parser child))
-            (-unparser [_] (-unparser child))
+            (-parser [_] (-cached-parser child))
+            (-unparser [_] (-cached-unparser child))
             (-transformer [this transformer method options]
               (-parent-children-transformer this children transformer method options))
             (-walk [this walker path options]
@@ -1835,7 +1851,7 @@
             (-regex-validator [_]
               (if internal
                 (-regex-validator child)
-                (re/item-validator (-validator child))))
+                (re/item-validator (-cached-validator child))))
             (-regex-explainer [_ path]
               (if internal
                 (-regex-explainer child path)
@@ -1851,7 +1867,7 @@
             (-regex-transformer [_ transformer method options]
               (if internal
                 (-regex-transformer child transformer method options)
-                (re/item-transformer method (-validator child)
+                (re/item-transformer method (-cached-validator child)
                                      (or (-transformer child transformer method options) identity))))
             (-regex-min-max [_ nested?]
               (if (and nested? (not internal))
@@ -1885,8 +1901,8 @@
           Schema
           (-validator [this]
             (if-let [checker (->checker this)]
-              (let [validator (fn [x] (nil? (checker x)))]
-                (fn [x] (and (ifn? x) (validator x)))) ifn?))
+              (fn [x] (and (ifn? x) (nil? (checker x))))
+              ifn?))
           (-explainer [this path]
             (if-let [checker (->checker this)]
               (fn explain [x in acc]
@@ -1900,13 +1916,13 @@
                                   (cond-> acc e (into (map #(assoc % :path (conj path i), :in in) (:errors e)))))]
                       (-> (conj acc error) (-push 0 explain-input) (-push 1 explain-output) (-push 2 explain-guard)))
                     acc)))
-              (let [validator (-validator this)]
+              (let [validator (-cached-validator this cache)]
                 (fn explain [x in acc]
                   (if-not (validator x) (conj acc (miu/-error path in this x)) acc)))))
           (-parser [this]
-            (let [validator (-validator this)]
+            (let [validator (-cached-validator this cache)]
               (fn [x] (if (validator x) x ::invalid))))
-          (-unparser [this] (-parser this))
+          (-unparser [this] (-cached-parser this cache))
           (-transformer [_ _ _ _])
           (-walk [this walker path options] (-walk-indexed this walker path options))
           (-properties [_] properties)
@@ -1927,8 +1943,8 @@
                 max (assoc :max max))))
           (-instrument-f [schema {:keys [scope report gen] :as props} f _options]
             (let [{:keys [min max input output guard]} (-function-info schema)
-                  [validate-input validate-output] (-vmap -validator [input output])
-                  validate-guard (or (some-> guard -validator) any?)
+                  [validate-input validate-output] (-vmap -cached-validator [input output])
+                  validate-guard (or (some-> guard -cached-validator) any?)
                   [wrap-input wrap-output wrap-guard] (-vmap #(contains? scope %) [:input :output :guard])
                   f (or (if gen (gen schema) f) (-fail! ::missing-function {:props props}))]
               (fn [& args]
@@ -1982,13 +1998,13 @@
                   (if-let [res (checker x)]
                     (conj acc (assoc (miu/-error path in this x) :check res))
                     acc)))
-              (let [validator (-validator this)]
+              (let [validator (-cached-validator this cache)]
                 (fn explain [x in acc]
                   (if-not (validator x) (conj acc (miu/-error path in this x)) acc)))))
           (-parser [this]
-            (let [validator (-validator this)]
+            (let [validator (-cached-validator this cache)]
               (fn [x] (if (validator x) x ::invalid))))
-          (-unparser [this] (-parser this))
+          (-unparser [this] (-cached-parser this cache))
           (-transformer [_ _ _ _])
           (-walk [this walker path options] (-walk-indexed this walker path options))
           (-properties [_] properties)
@@ -2039,10 +2055,10 @@
         ^{:type ::schema}
         (reify
           Schema
-          (-validator [_] (-validator @schema))
+          (-validator [_] (-cached-validator @schema))
           (-explainer [_ path] (-explainer @schema (conj path ::in)))
-          (-parser [_] (-parser @schema))
-          (-unparser [_] (-unparser @schema))
+          (-parser [_] (-cached-parser @schema))
+          (-unparser [_] (-cached-unparser @schema))
           (-transformer [this transformer method options]
             (-parent-children-transformer this [@schema] transformer method options))
           (-walk [this walker path options]
@@ -2343,7 +2359,7 @@
   ([?schema]
    (validator ?schema nil))
   ([?schema options]
-   (-cached (schema ?schema options) :validator -validator)))
+   (-cached-validator (schema ?schema options))))
 
 (defn validate
   "Returns true if value is valid according to given schema. Creates the `validator`
@@ -2359,16 +2375,17 @@
   ([?schema]
    (explainer ?schema nil))
   ([?schema options]
-   (let [schema' (schema ?schema options)
-         explainer' (-cached schema' :explainer #(-explainer % []))]
-     (fn explainer
-       ([value]
-        (explainer value [] []))
-       ([value in acc]
-        (when-let [errors (seq (explainer' value in acc))]
-          {:schema schema'
-           :value value
-           :errors errors}))))))
+   (-cached (schema ?schema options) :explainer
+            (fn [schema']
+              (let [explainer' (-explainer schema' [])]
+                (fn explainer
+                  ([value]
+                   (explainer value [] []))
+                  ([value in acc]
+                   (when-let [errors (seq (explainer' value in acc))]
+                     {:schema schema'
+                      :value value
+                      :errors errors}))))))))
 
 (defn explain
   "Explains a value against a given schema. Creates the `explainer` for every call.
@@ -2384,7 +2401,7 @@
   ([?schema]
    (parser ?schema nil))
   ([?schema options]
-   (-cached (schema ?schema options) :parser -parser)))
+   (-cached-parser (schema ?schema options))))
 
 (defn parse
   "parses a value against a given schema. Creates the `parser` for every call.
@@ -2400,7 +2417,7 @@
   ([?schema]
    (unparser ?schema nil))
   ([?schema options]
-   (-cached (schema ?schema options) :unparser -unparser)))
+   (-cached-unparser (schema ?schema options))))
 
 (defn unparse
   "Unparses a value against a given schema. Creates the `unparser` for every call.

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -199,7 +199,7 @@
    #(cond->> % (map? %) (into {} (map (fn [[k v]] [(cond-> k (contains? ks k) f) v]))))))
 
 (defn -transform-if-valid [f schema]
-  (let [validator (m/-validator schema)]
+  (let [validator (m/-cached-validator schema)]
     (fn [x] (let [out (f x)] (if (validator out) out x)))))
 
 ;;


### PR DESCRIPTION
In some cases, we can save a lot of work and memory by pushing in the `-cached` logic further into the schemas. The tests demonstrate a key use-case: a schema that is only ever used as a child.

This is the output of the final line of the test on master:
```clojure
{:-validator 10, :-parser 10, :-unparser 10, :-explainer [[0] [0]]}
```

i.e., this PR saves 27 calls to protocol methods, each returning fresh fns.

Moving the `explainer` cache to the entire fn also saves recreating the fn every call.