### PR TITLE
Close #1194: add generator for empty? schema

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -373,6 +373,7 @@
 
 (defmethod -schema-generator ::default [schema options] (ga/gen-for-pred (m/validator schema options)))
 
+(defmethod -schema-generator 'empty? [_ _] (ga/gen-for-pred empty?))
 (defmethod -schema-generator :> [schema options] (gen-double {:min (inc (-child schema options))}))
 (defmethod -schema-generator :>= [schema options] (gen-double {:min (-child schema options)}))
 (defmethod -schema-generator :< [schema options] (gen-double {:max (dec (-child schema options))}))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1124,3 +1124,6 @@
   (doseq [_ (range 100)
           v (mg/sample [:seqable {:min 1} :any])]
     (is (seq v))))
+
+(deftest empty?-generator-test
+  (is (every? empty? (mg/sample empty?))))


### PR DESCRIPTION
The -safe-empty? predicate override for the empty? schema was interfering with the ga/gen-for-pred lookup.