### PR TITLE
Automated testing for examples in README.md

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -105,3 +105,33 @@ jobs:
           bb: latest
       - name: Run tests
         run: bb test-bb
+
+  doc-tests:
+    # Builds tests from Documentation with test-doc-blocks and tests that
+    # the examples are still valid.
+    name: Doc Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Java 11
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: 11
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.deps.clj
+            ~/.gitlibs
+          key: ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-${{ hashFiles('**/bb.edn') }}
+          restore-keys: |
+            ${{ runner.os }}-test-deps-${{ hashFiles('**/deps.edn') }}-
+            ${{ runner.os }}-test-deps-
+      - name: Setup Clojure
+        uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: latest
+          bb: latest
+      - name: Run doc tests
+        run: bb test-docs

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Usage:
 
 (m/ast non-empty-string)
 ;; => {:type :string
-;      :properties {:min 1}}
+;;     :properties {:min 1}}
 ```
 
 Map-syntax is also called the [Schema AST](#schema-ast).
@@ -287,8 +287,8 @@ Schemas can have properties:
 
 (m/properties Age)
 ;; => {:title "Age"
-;      :description "It's an age"
-;      :json-schema/example 20}
+;;     :description "It's an age"
+;;     :json-schema/example 20}
 ```
 
 Maps are open by default:
@@ -537,9 +537,9 @@ and `:?`, `:*`, `:+` & `:repeat` for repetition:
   [:* [:catn [:prop :string] [:val [:altn [:s :string] [:b :boolean]]]]]
   ["-server" "foo" "-verbose" 11 "-user" "joe"])
 ;; => {:schema [:* [:catn [:prop :string] [:val [:altn [:s :string] [:b :boolean]]]]],
-;      :value ["-server" "foo" "-verbose" 11 "-user" "joe"],
-;      :errors ({:path [0 :val :s], :in [3], :schema :string, :value 11}
-;               {:path [0 :val :b], :in [3], :schema :boolean, :value 11})}
+;;     :value ["-server" "foo" "-verbose" 11 "-user" "joe"],
+;;     :errors ({:path [0 :val :s], :in [3], :schema :string, :value 11}
+;;              {:path [0 :val :b], :in [3], :schema :boolean, :value 11})}
 ```
 
 while `:cat` and `:alt` just use numeric indices for paths:
@@ -744,34 +744,34 @@ Detailed errors with `m/explain`:
              :zip 33100
              :lonlat [61.4858322, nil]}})
 ;; => {:schema [:map
-          [:id string?]
-          [:tags [:set keyword?]]
-          [:address [:map
-                     [:street string?]
-                     [:city string?]
-                     [:zip int?]
-                     [:lonlat [:tuple double? double?]]]]],
- :value {:id "Lillan",
-         :tags #{:artesan :garden "coffee"},
-         :address {:street "Ahlmanintie 29"
-                   :zip 33100
-                   :lonlat [61.4858322 nil]}},
- :errors ({:path [:tags 0]
-           :in [:tags 0]
-           :schema keyword?
-           :value "coffee"}
-          {:path [:address :city],
-           :in [:address :city],
-           :schema [:map
-                    [:street string?]
-                    [:city string?]
-                    [:zip int?]
-                    [:lonlat [:tuple double? double?]]],
-           :type :malli.core/missing-key}
-          {:path [:address :lonlat 1]
-           :in [:address :lonlat 1]
-           :schema double?
-           :value nil})}
+;;              [:id string?]
+;;              [:tags [:set keyword?]]
+;;              [:address [:map
+;;                         [:street string?]
+;;                         [:city string?]
+;;                         [:zip int?]
+;;                         [:lonlat [:tuple double? double?]]]]],
+;;     :value {:id "Lillan",
+;;             :tags #{:artesan :garden "coffee"},
+;;             :address {:street "Ahlmanintie 29"
+;;                       :zip 33100
+;;                       :lonlat [61.4858322 nil]}},
+;;     :errors ({:path [:tags 0]
+;;               :in [:tags 0]
+;;               :schema keyword?
+;;               :value "coffee"}
+;;              {:path [:address :city],
+;;               :in [:address :city],
+;;               :schema [:map
+;;                        [:street string?]
+;;                        [:city string?]
+;;                        [:zip int?]
+;;                        [:lonlat [:tuple double? double?]]],
+;;               :type :malli.core/missing-key}
+;;              {:path [:address :lonlat 1]
+;;               :in [:address :lonlat 1]
+;;               :schema double?
+;;               :value nil})}
 ```
 
 Under `:errors`, you get a list of errors with the following keys:
@@ -823,8 +823,8 @@ Explain results can be humanized with `malli.error/humanize`:
                  :lonlat [61.4858322, nil]}})
     (me/humanize))
 ;; => {:tags #{["should be a keyword"]}
-;      :address {:city ["missing required key"]
-;                :lonlat [nil ["should be a double"]]}}
+;;     :address {:city ["missing required key"]
+;;               :lonlat [nil ["should be a double"]]}}
 ```
 
 Or if you already have a malli validation exception (e.g. in a catch form):
@@ -899,8 +899,8 @@ Here are some basic examples of `:error/message` and `:error/fn`:
       {:errors (-> me/default-errors
                    (assoc ::m/missing-key {:error/fn (fn [{:keys [in]} _] (str "missing key " (last in)))}))}))
 ;; => {:id ["missing key :id"]
-;      :size ["should be: S|M|L"]
-;      :age ["10, should be > 18"]}
+;;     :size ["should be: S|M|L"]
+;;     :age ["10, should be > 18"]}
 ```
 
 Messages can be localized:
@@ -922,8 +922,8 @@ Messages can be localized:
                    (assoc ::m/missing-key {:error/fn {:en (fn [{:keys [in]} _] (str "missing key " (last in)))
                                                       :fi (fn [{:keys [in]} _] (str "puuttuu avain " (last in)))}}))}))
 ;; => {:id ["puuttuu avain :id"]
-;      :size ["pitäisi olla: S|M|L"]
-;      :age ["10, pitäisi olla > 18"]}
+;;     :size ["pitäisi olla: S|M|L"]
+;;     :age ["10, pitäisi olla > 18"]}
 ```
 
 Top-level humanized map-errors are under `:malli/error`:
@@ -991,7 +991,7 @@ For closed schemas, key spelling can be checked with:
     (me/with-spell-checking)
     (me/humanize))
 ;; => {:address {:streetz ["should be spelled :street"]}
-;      :name ["disallowed key"]}
+;;     :name ["disallowed key"]}
 ```
 
 ## Values in error
@@ -1008,7 +1008,7 @@ Just to get parts of the value that are in error:
                 :lonlat [61.4858322, "23.7832851,17"]}})
     (me/error-value))
 ;; => {:tags #{"coffee" "ground"}
-;      :address {:lonlat [nil "23.7832851,17"]}}
+;;     :address {:lonlat [nil "23.7832851,17"]}}
 ```
 
 Masking irrelevant parts:
@@ -1023,10 +1023,10 @@ Masking irrelevant parts:
                 :lonlat [61.4858322, "23.7832851,17"]}})
     (me/error-value {::me/mask-valid-values '...}))
 ;; => {:id ...
-;      :tags #{"coffee" "ground" ...}
-;      :address {:street ...
-;                :zip ...
-;                :lonlat [... "23.7832851,17"]}}
+;;     :tags #{"coffee" "ground" ...}
+;;     :address {:street ...
+;;               :zip ...
+;;               :lonlat [... "23.7832851,17"]}}
 ```
 
 ## Pretty errors
@@ -1166,11 +1166,11 @@ Transformations are recursive:
              :lonlat [61.4858322 23.7854658]}}
   mt/json-transformer)
 ;; => {:id "Lillan",
-;      :tags #{:coffee :artesan :garden},
-;      :address {:street "Ahlmanintie 29"
-;                :city "Tampere"
-;                :zip 33100
-;                :lonlat [61.4858322 23.7854658]}}
+;;     :tags #{:coffee :artesan :garden},
+;;     :address {:street "Ahlmanintie 29"
+;;               :city "Tampere"
+;;               :zip 33100
+;;               :lonlat [61.4858322 23.7854658]}}
 ```
 
 Transform map keys:
@@ -1186,11 +1186,11 @@ Transform map keys:
              :lonlat [61.4858322 23.7854658]}}
   (mt/key-transformer {:encode name}))
 ;; => {"id" "Lillan",
-;      "tags" ["coffee" "artesan" "garden"],
-;      "address" {"street" "Ahlmanintie 29"
-;                 "city" "Tampere"
-;                 "zip" 33100
-;                 "lonlat" [61.4858322 23.7854658]}}
+;;     "tags" ["coffee" "artesan" "garden"],
+;;     "address" {"street" "Ahlmanintie 29"
+;;                "city" "Tampere"
+;;                "zip" 33100
+;;                "lonlat" [61.4858322 23.7854658]}}
 ```
 
 Transforming homogenous `:enum` or `:=`s (supports automatic type detection of `:keyword`, `:symbol`, `:int` and `:double`):
@@ -1220,11 +1220,11 @@ Transformers can be composed with `mt/transformer`:
              :lonlat [61.4858322 23.7854658]}}
   strict-json-transformer)
 ;; => {:id "Lillan",
-;      :tags #{:coffee :artesan :garden},
-;      :address {:street "Ahlmanintie 29"
-;                :city "Tampere"
-;                :zip 33100
-;                :lonlat [61.4858322 23.7854658]}}
+;;     :tags #{:coffee :artesan :garden},
+;;     :address {:street "Ahlmanintie 29"
+;;               :city "Tampere"
+;;               :zip 33100
+;;               :lonlat [61.4858322 23.7854658]}}
 ```
 
 Schema properties can be used to override default transformations:
@@ -1377,8 +1377,8 @@ From JSON with validation:
                                                jsonista.core/keyword-keys-object-mapper)
                      mt/json-transformer))
 ;; => {:schema [:map {:closed true} [:tags [:set :keyword]]],
-;      :value {:tags #{:bar ["quux"]}},
-;      :errors ({:path [:tags 0], :in [:tags ["quux"]], :schema :keyword, :value ["quux"]})}
+;;     :value {:tags #{:bar ["quux"]}},
+;;     :errors ({:path [:tags 0], :in [:tags ["quux"]], :schema :keyword, :value ["quux"]})}
 ```
 
 ```clojure
@@ -1485,8 +1485,8 @@ Single sweep of defaults & string encoding:
     mt/default-value-transformer
     mt/string-transformer))
 ;; => {:a "1"
-;      :b ["1" "2" "3"]
-;      :c {:x "42"}}
+;;     :b ["1" "2" "3"]
+;;     :c {:x "42"}}
 ```
 
 ## Programming with schemas
@@ -2016,8 +2016,8 @@ Any function can be used for `:dispatch`:
              :street "this is an extra key"}}
   (mt/transformer mt/strip-extra-keys-transformer mt/string-transformer))
 ;; => {:type :human
-;      :name "Tiina"
-;      :address {:country :finland}}
+;;     :name "Tiina"
+;;     :address {:country :finland}}
 ```
 
 ## Recursive schemas
@@ -2304,9 +2304,9 @@ By default, `:map-of` is not inferred:
   {"2" [1 2]}
   {"3" [1 2 3]}])
 ;; => [:map
-;      ["1" {:optional true} [:vector :int]]
-;      ["2" {:optional true} [:vector :int]]
-;      ["3" {:optional true} [:vector :int]]]
+;;     ["1" {:optional true} [:vector :int]]
+;;     ["2" {:optional true} [:vector :int]]
+;;     ["3" {:optional true} [:vector :int]]]
 ```
 
 With `::mp/map-of-threshold` option:
@@ -2330,10 +2330,10 @@ Sample-data can be type-hinted with `::mp/hint`:
     :c {:b 3}
     :d nil}])
 ;; => [:map-of
-;      :keyword
-;      [:maybe [:map
-;               [:b :int]
-;               [:c {:optional true} :int]]]]
+;;     :keyword
+;;     [:maybe [:map
+;;              [:b :int]
+;;              [:c {:optional true} :int]]]]
 ```
 
 ### :tuple inferring
@@ -2421,8 +2421,8 @@ Pulling out function argument schemas from Vars:
 
 (md/infer #'kikka)
 ;; => [:function
-;      [:=> [:cat :any] :any]
-;      [:=> [:cat :any :any [:* :any]] :any]]
+;;     [:=> [:cat :any] :any]
+;;     [:=> [:cat :any :any [:* :any]] :any]]
 ```
 
 `md/parse` uses the following options:
@@ -2446,32 +2446,32 @@ A more complete example:
             :or {d 0}
             :as opts}])
 ;; => [:cat
-;      :any
-;      [:maybe [:cat
-;               [:? :any]
-;               [:? :any]
-;               [:* :any]]]
-;      [:orn
-;       [:map
-;        [:map
-;         [:d {:optional true} :any]
-;         [:e {:optional true} :any]
-;         [:demo/f {:optional true}]
-;         [:demo/g {:optional true}]
-;         [:h {:optional true} [:maybe [:cat
-;                                       [:? :any]
-;                                       [:* :any]]]]]]
-;       [:args
-;        [:*
-;         [:alt
-;          [:cat [:= :d] :any]
-;          [:cat [:= :e] :any]
-;          [:cat [:= :demo/f] :demo/f]
-;          [:cat [:= :demo/g] :demo/g]
-;          [:cat [:= :h] [:maybe [:cat
-;                                 [:? :any]
-;                                 [:* :any]]]]
-;          [:cat [:not [:enum :d :e :demo/f :demo/g :h]] :any]]]]]]
+;;     :any
+;;     [:maybe [:cat
+;;              [:? :any]
+;;              [:? :any]
+;;              [:* :any]]]
+;;     [:orn
+;;      [:map
+;;       [:map
+;;        [:d {:optional true} :any]
+;;        [:e {:optional true} :any]
+;;        [:demo/f {:optional true}]
+;;        [:demo/g {:optional true}]
+;;        [:h {:optional true} [:maybe [:cat
+;;                                      [:? :any]
+;;                                      [:* :any]]]]]]
+;;      [:args
+;;       [:*
+;;        [:alt
+;;         [:cat [:= :d] :any]
+;;         [:cat [:= :e] :any]
+;;         [:cat [:= :demo/f] :demo/f]
+;;         [:cat [:= :demo/g] :demo/g]
+;;         [:cat [:= :h] [:maybe [:cat
+;;                                [:? :any]
+;;                                [:* :any]]]]
+;;         [:cat [:not [:enum :d :e :demo/f :demo/g :h]] :any]]]]]]
 ```
 
 ## Parsing values
@@ -2489,8 +2489,8 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
               [:b boolean?]]]]]
   ["-server" "foo" "-verbose" true "-user" "joe"])
 ;; => [#malli.core.Tags{:values {:prop "-server", :val #malli.core.Tag{:key :s, :value "foo"}}}
-;      #malli.core.Tags{:values {:prop "-verbose", :val #malli.core.Tag{:key :b, :value true}}}
-;      #malli.core.Tags{:values {:prop "-user", :val #malli.core.Tag{:key :s, :value "joe"}}}]
+;;     #malli.core.Tags{:values {:prop "-verbose", :val #malli.core.Tag{:key :b, :value true}}}
+;;     #malli.core.Tags{:values {:prop "-user", :val #malli.core.Tag{:key :s, :value "joe"}}}]
 
 ```
 
@@ -2517,23 +2517,23 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
    [:p "Hello, world of data"]])
 
 ;; => #malli.core.Tag
-;     {:key :node,
-;      :value
-;      #malli.core.Tags
-;      {:values {:name :div,
-;                :props {:class [:foo :bar]},
-;                :children [#malli.core.Tag
-;                           {:key :node,
-;                            :value
-;                            #malli.core.Tags
-;                            {:values {:name :p,
-;                                      :props nil,
-;                                      :children [#malli.core.Tag
-;                                                 {:key :primitive,
-;                                                  :value
-;                                                  #malli.core.Tag
-;                                                  {:key :text,
-;                                                   :value "Hello, world of data"}}]}}}]}}}
+;;    {:key :node,
+;;     :value
+;;     #malli.core.Tags
+;;     {:values {:name :div,
+;;               :props {:class [:foo :bar]},
+;;               :children [#malli.core.Tag
+;;                          {:key :node,
+;;                           :value
+;;                           #malli.core.Tags
+;;                           {:values {:name :p,
+;;                                     :props nil,
+;;                                     :children [#malli.core.Tag
+;;                                                {:key :primitive,
+;;                                                 :value
+;;                                                 #malli.core.Tag
+;;                                                 {:key :text,
+;;                                                  :value "Hello, world of data"}}]}}}]}}}
 ```
 
 Parsing returns tagged values for `:orn`, `:catn`, `:altn` and `:multi`.
@@ -2561,7 +2561,7 @@ The inverse of parsing, using `m/unparse` and `m/unparser`:
      (m/parse Hiccup)
      (m/unparse Hiccup))
 ;; => [:div {:class [:foo :bar]}
-;      [:p "Hello, world of data"]]
+;;     [:p "Hello, world of data"]]
 ```
 
 ```clojure
@@ -2626,25 +2626,25 @@ Implemented with protocol `malli.core/AST`. Allows lossless round-robin with fas
 
 (m/form ?schema)
 ;; => [:map
-;      [:x boolean?]
-;      [:y {:optional true} int?]
-;      [:z [:map
-;           [:x boolean?]
-;           [:y {:optional true} int?]]]]
+;;     [:x boolean?]
+;;     [:y {:optional true} int?]
+;;     [:z [:map
+;;          [:x boolean?]
+;;          [:y {:optional true} int?]]]]
 
 (m/ast ?schema)
 ;; => {:type :map,
-;      :keys {:x {:order 0
-;                 :value {:type boolean?}},
-;             :y {:order 1, :value {:type int?}
-;                 :properties {:optional true}},
-;             :z {:order 2,
-;                 :value {:type :map,
-;                         :keys {:x {:order 0
-;                                    :value {:type boolean?}},
-;                                :y {:order 1
-;                                    :value {:type int?}
-;                                    :properties {:optional true}}}}}}}
+;;     :keys {:x {:order 0
+;;                :value {:type boolean?}},
+;;            :y {:order 1, :value {:type int?}
+;;                :properties {:optional true}},
+;;            :z {:order 2,
+;;                :value {:type :map,
+;;                        :keys {:x {:order 0
+;;                                   :value {:type boolean?}},
+;;                               :y {:order 1
+;;                                   :value {:type int?}
+;;                                   :properties {:optional true}}}}}}}
 
 (-> ?schema
     (m/schema) ;; 3.4µs
@@ -2703,16 +2703,16 @@ Transforming schemas into maps:
         (assoc :malli/type (m/type schema))
         (cond-> (seq children) (assoc :malli/children children)))))
 ;; => {:malli/type :map,
-;      :malli/children [[:id nil {:malli/type string?}]
-;                       [:tags nil {:malli/type :set
-;                                   :malli/children [{:malli/type keyword?}]}]
-;                       [:address nil {:malli/type :map,
-;                                      :malli/children [[:street nil {:malli/type string?}]
-;                                                       [:city nil {:malli/type string?}]
-;                                                       [:zip nil {:malli/type int?}]
-;                                                       [:lonlat nil {:malli/type :tuple
-;                                                                     :malli/children [{:malli/type double?}
-;                                                                                      {:malli/type double?}]}]]}]]}
+;;     :malli/children [[:id nil {:malli/type string?}]
+;;                      [:tags nil {:malli/type :set
+;;                                  :malli/children [{:malli/type keyword?}]}]
+;;                      [:address nil {:malli/type :map,
+;;                                     :malli/children [[:street nil {:malli/type string?}]
+;;                                                      [:city nil {:malli/type string?}]
+;;                                                      [:zip nil {:malli/type int?}]
+;;                                                      [:lonlat nil {:malli/type :tuple
+;;                                                                    :malli/children [{:malli/type double?}
+;;                                                                                     {:malli/type double?}]}]]}]]}
 ```
 
 ### JSON Schema
@@ -2724,19 +2724,19 @@ Transforming Schemas into [JSON Schema](https://json-schema.org/):
 
 (json-schema/transform Address)
 ;; => {:type "object",
-;      :properties {:id {:type "string"},
-;                   :tags {:type "array"
-;                          :items {:type "string"}
-;                          :uniqueItems true},
-;                   :address {:type "object",
-;                             :properties {:street {:type "string"},
-;                                          :city {:type "string"},
-;                                          :zip {:type "integer"},
-;                                          :lonlat {:type "array",
-;                                                   :prefixItems [{:type "number"} {:type "number"}],
-;                                                   :items false}},
-;                             :required [:street :city :zip :lonlat]}},
-;      :required [:id :tags :address]}
+;;     :properties {:id {:type "string"},
+;;                  :tags {:type "array"
+;;                         :items {:type "string"}
+;;                         :uniqueItems true},
+;;                  :address {:type "object",
+;;                            :properties {:street {:type "string"},
+;;                                         :city {:type "string"},
+;;                                         :zip {:type "integer"},
+;;                                         :lonlat {:type "array",
+;;                                                  :prefixItems [{:type "number"} {:type "number"}],
+;;                                                  :items false}},
+;;                            :required [:street :city :zip :lonlat]}},
+;;     :required [:id :tags :address]}
 ```
 
 Custom transformation via `:json-schema` namespaced properties:
@@ -2750,10 +2750,10 @@ Custom transformation via `:json-schema` namespaced properties:
     :json-schema/default "perch"}
    "perch" "pike"])
 ;; => {:title "Fish"
-;      :description "It's a fish"
-;      :type "string"
-;      :default "perch"
-;      :enum ["perch" "pike"]}
+;;     :description "It's a fish"
+;;     :type "string"
+;;     :default "perch"
+;;     :enum ["perch" "pike"]}
 ```
 
 Full override with `:json-schema` property:
@@ -2774,20 +2774,20 @@ Transforming Schemas into [Swagger2 Schema](https://github.com/OAI/OpenAPI-Speci
 
 (swagger/transform Address)
 ;; => {:type "object",
-;      :properties {:id {:type "string"},
-;                   :tags {:type "array"
-;                          :items {:type "string"}
-;                          :uniqueItems true},
-;                   :address {:type "object",
-;                             :properties {:street {:type "string"},
-;                                          :city {:type "string"},
-;                                          :zip {:type "integer", :format "int64"},
-;                                          :lonlat {:type "array",
-;                                                   :items {},
-;                                                   :x-items [{:type "number", :format "double"}
-;                                                             {:type "number", :format "double"}]}},
-;                             :required [:street :city :zip :lonlat]}},
-;      :required [:id :tags :address]}
+;;     :properties {:id {:type "string"},
+;;                  :tags {:type "array"
+;;                         :items {:type "string"}
+;;                         :uniqueItems true},
+;;                  :address {:type "object",
+;;                            :properties {:street {:type "string"},
+;;                                         :city {:type "string"},
+;;                                         :zip {:type "integer", :format "int64"},
+;;                                         :lonlat {:type "array",
+;;                                                  :items {},
+;;                                                  :x-items [{:type "number", :format "double"}
+;;                                                            {:type "number", :format "double"}]}},
+;;                            :required [:street :city :zip :lonlat]}},
+;;     :required [:id :tags :address]}
 ```
 
 Custom transformation via `:swagger` and `:json-schema` namespaced properties:
@@ -2801,10 +2801,10 @@ Custom transformation via `:swagger` and `:json-schema` namespaced properties:
     :json-schema/default "perch"}
    "perch" "pike"])
 ;; => {:title "Fish"
-;      :description "It's a fish"
-;      :type "string"
-;      :default "perch"
-;      :enum ["perch" "pike"]}
+;;     :description "It's a fish"
+;;     :type "string"
+;;     :default "perch"
+;;     :enum ["perch" "pike"]}
 ```
 
 Full override with `:swagger` property:

--- a/README.md
+++ b/README.md
@@ -3211,6 +3211,13 @@ Registries can be composed, a full example:
 ;; => true
 ```
 
+Revert the registry back to defaults:
+```clojure
+(mr/set-default-registry!
+  (m/default-schemas))
+```
+
+
 ## Function schemas
 
 See [Working with functions](docs/function-schemas.md).
@@ -3225,7 +3232,6 @@ See [Instrumentation](docs/function-schemas.md#instrumentation).
 
 Given functions and function Schemas:
 
-<!-- :test-doc-blocks/skip -->
 ```clojure
 (defn square [x] (* x x))
 (m/=> square [:=> [:cat int?] nat-int?])
@@ -3241,7 +3247,6 @@ Given functions and function Schemas:
 
 Generating `clj-kondo` configuration from current namespace:
 
-<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.clj-kondo :as mc])
 
@@ -3358,20 +3363,19 @@ Simple syntax sugar, like [data-specs](https://cljdoc.org/d/metosin/spec-tools/C
 
 As the namespace suggests, it's experimental, built for [reitit](https://github.com/metosin/reitit).
 
-<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.experimental.lite :as l])
 
 (l/schema
- {:map1 {:x int?
-         :y [:maybe string?]
-         :z (l/maybe keyword?)}
+ {:map1 {:x :int
+         :y [:maybe :string]
+         :z (l/maybe :keyword)}
   :map2 {:min-max [:int {:min 0 :max 10}]
-         :tuples (l/vector (l/tuple int? string?))
+         :tuples (l/vector (l/tuple :int :string))
          :optional (l/optional (l/maybe :boolean))
-         :set-of-maps (l/set {:e int?
-                              :f string?})
-         :map-of-int (l/map-of int? {:s string?})}})
+         :set-of-maps (l/set {:e :int
+                              :f :string})
+         :map-of-int (l/map-of :int {:s :string})}})
 ;[:map
 ; [:map1
 ;  [:map
@@ -3389,7 +3393,6 @@ As the namespace suggests, it's experimental, built for [reitit](https://github.
 
 Options can be used by binding a dynamic `l/*options*` Var:
 
-<!-- :test-doc-blocks/skip -->
 ```clojure
 (binding [l/*options* {:registry (merge
                                   (m/default-schemas)

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Malli supports [Vector](#vector-syntax), [Map](#map-syntax) and [Lite](#lite) sy
 
 The default syntax uses vectors, inspired by [hiccup](https://github.com/weavejester/hiccup):
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 type
 [type & children]
@@ -146,16 +147,16 @@ Usage:
   (m/schema [:string {:min 1}]))
 
 (m/schema? non-empty-string)
-; => true
+;; => true
 
 (m/validate non-empty-string "")
-; => false
+;; => false
 
 (m/validate non-empty-string "kikka")
-; => true
+;; => true
 
 (m/form non-empty-string)
-; => [:string {:min 1}]
+;; => [:string {:min 1}]
 ```
 
 ### Map syntax
@@ -170,7 +171,7 @@ Alternative map-syntax, similar to [cljfx](https://github.com/cljfx/cljfx):
 
 ;; type with properties
 {:type :string
- :properties {:min 1, :max 10}
+ :properties {:min 1, :max 10}}
 
 ;; type with properties and children
 {:type :tuple
@@ -194,17 +195,17 @@ Usage:
                :properties {:min 1}}))
 
 (m/schema? non-empty-string)
-; => true
+;; => true
 
 (m/validate non-empty-string "")
-; => false
+;; => false
 
 (m/validate non-empty-string "kikka")
-; => true
+;; => true
 
 (m/ast non-empty-string)
-; => {:type :string,
-;     :properties {:min 1}}
+;; => {:type :string
+;      :properties {:min 1}}
 ```
 
 Map-syntax is also called the [Schema AST](#schema-ast).
@@ -241,26 +242,26 @@ Validating values against a schema:
 ```clojure
 ;; with schema instances
 (m/validate (m/schema :int) 1)
-; => true
+;; => true
 
 ;; with vector syntax
 (m/validate :int 1)
-; => true
+;; => true
 
 (m/validate :int "1")
-; => false
+;; => false
 
 (m/validate [:= 1] 1)
-; => true
+;; => true
 
 (m/validate [:enum 1 2] 1)
-; => true
+;; => true
 
 (m/validate [:and :int [:> 6]] 7)
-; => true
+;; => true
 
 (m/validate [:qualified-keyword {:namespace :aaa}] :aaa/bbb)
-; => true
+;; => true
 
 ;; optimized (pure) validation function for best performance
 (def valid?
@@ -271,7 +272,7 @@ Validating values against a schema:
      [:z :string]]))
 
 (valid? {:x true, :z "kikka"})
-; => true
+;; => true
 ```
 
 Schemas can have properties:
@@ -285,9 +286,9 @@ Schemas can have properties:
    :int [:> 18]])
 
 (m/properties Age)
-; => {:title "Age"
-;     :description "It's an age"
-;     :json-schema/example 20}
+;; => {:title "Age"
+;      :description "It's an age"
+;      :json-schema/example 20}
 ```
 
 Maps are open by default:
@@ -296,7 +297,7 @@ Maps are open by default:
 (m/validate
   [:map [:x :int]]
   {:x 1, :extra "key"})
-; => true
+;; => true
 ```
 
 Maps can be closed with `:closed` property:
@@ -305,7 +306,7 @@ Maps can be closed with `:closed` property:
 (m/validate
   [:map {:closed true} [:x :int]]
   {:x 1, :extra "key"})
-; => false
+;; => false
 ```
 
 Maps keys are not limited to keywords:
@@ -321,14 +322,14 @@ Maps keys are not limited to keywords:
    1 'number
    nil :yay
    ::a "properly awesome"})
-; => true
+;; => true
 ```
 
 Most core-predicates are mapped to Schemas:
 
 ```clojure
 (m/validate string? "kikka")
-; => true
+;; => true
 ```
 
 *NOTE*: Predicate Schemas do not cover any schema properties, e.g. `string?` can't be modified with properties like `:min` and `:max`. If you want to use the schema properties, use real schema types instead, e.g. `:string` over `string?`.
@@ -374,7 +375,7 @@ You can also use [decomplected maps keys and values](https://clojure.org/about/s
    [::country {:optional true}]]
   {::id 1
    :name "kikka"})
-; => true
+;; => true
 ```
 
 ## Homogeneous maps
@@ -400,7 +401,7 @@ Map schemas can define a special `:malli.core/default` key to handle extra keys:
   [:y :int]
   [::m/default [:map-of :int :int]]]
  {:x 1, :y 2, 1 1, 2 2})
-; => true
+;; => true
 ```
 default branching can be arbitrarily nested:
 
@@ -412,7 +413,7 @@ default branching can be arbitrarily nested:
                 [:y :int]
                 [::m/default [:map-of :int :int]]]]]
  {:x 1, :y 2, 1 1, 2 2})
-; => true
+;; => true
 ```
 
 ## Seqable schemas
@@ -431,32 +432,32 @@ the entire collection if the input is `counted?` or `indexed?`.
 ```clojure
 ;; :seqable and :every validate identically with small, counted, or indexed collections.
 (m/validate [:seqable :int] #{1 2 3})
-;=> true
+;; => true
 (m/validate [:seqable :int] [1 2 3])
-;=> true
+;; => true
 (m/validate [:seqable :int] (sorted-set 1 2 3))
-;=> true
+;; => true
 (m/validate [:seqable :int] (range 1000))
-;=> true
+;; => true
 (m/validate [:seqable :int] (conj (vec (range 1000)) nil))
-;=> false
+;; => false
 
 (m/validate [:every :int] #{1 2 3})
-;=> true
+;; => true
 (m/validate [:every :int] [1 2 3])
-;=> true
+;; => true
 (m/validate [:every :int] (sorted-set 1 2 3))
-;=> true
+;; => true
 (m/validate [:every :int] (vec (range 1000)))
-;=> true
+;; => true
 (m/validate [:every :int] (conj (vec (range 1000)) nil))
-;=> false
+;; => false
 
 ;; for large uncounted and unindexed collections, :every only checks a certain length
 (m/validate [:seqable :int] (concat (range 1000) [nil]))
-;=> false
+;; => false
 (m/validate [:every :int] (concat (range 1000) [nil]))
-;=> true
+;; => true
 ```
 
 
@@ -479,53 +480,71 @@ Malli also supports sequence regexes (also called sequence expressions) like [Se
 The supported operators are `:cat` & `:catn` for concatenation / sequencing
 
 ```clojure
-(m/validate [:cat string? int?] ["foo" 0]) ; => true
+(m/validate [:cat string? int?] ["foo" 0])
+;; => true
 
-(m/validate [:catn [:s string?] [:n int?]] ["foo" 0]) ; => true
+(m/validate [:catn [:s string?] [:n int?]] ["foo" 0])
+;; => true
 ```
 
 `:alt` & `:altn` for alternatives
 
 ```clojure
-(m/validate [:alt keyword? string?] ["foo"]) ; => true
+(m/validate [:alt keyword? string?] ["foo"])
+;; => true
 
-(m/validate [:altn [:kw keyword?] [:s string?]] ["foo"]) ; => true
+(m/validate [:altn [:kw keyword?] [:s string?]] ["foo"])
+;; => true
 ```
 
 and `:?`, `:*`, `:+` & `:repeat` for repetition:
 
 ```clojure
-(m/validate [:? int?] []) ; => true
-(m/validate [:? int?] [1]) ; => true
-(m/validate [:? int?] [1 2]) ; => false
+(m/validate [:? int?] [])
+;; => true
+(m/validate [:? int?] [1])
+;; => true
+(m/validate [:? int?] [1 2])
+;; => false
 
-(m/validate [:* int?] []) ; => true
-(m/validate [:* int?] [1 2 3]) ; => true
+(m/validate [:* int?] [])
+;; => true
+(m/validate [:* int?] [1 2 3])
+;; => true
 
-(m/validate [:+ int?] []) ; => false
-(m/validate [:+ int?] [1]) ; => true
-(m/validate [:+ int?] [1 2 3]) ; => true
+(m/validate [:+ int?] [])
+;; => false
+(m/validate [:+ int?] [1])
+;; => true
+(m/validate [:+ int?] [1 2 3])
+;; => true
 
-(m/validate [:repeat {:min 2, :max 4} int?] [1]) ; => false
-(m/validate [:repeat {:min 2, :max 4} int?] [1 2]) ; => true
-(m/validate [:repeat {:min 2, :max 4} int?] [1 2 3 4]) ; => true (:max is inclusive, as elsewhere in Malli)
-(m/validate [:repeat {:min 2, :max 4} int?] [1 2 3 4 5]) ; => false
+(m/validate [:repeat {:min 2, :max 4} int?] [1])
+;; => false
+(m/validate [:repeat {:min 2, :max 4} int?] [1 2])
+;; => true
+(m/validate [:repeat {:min 2, :max 4} int?] [1 2 3 4])
+;; => true ; (:max is inclusive, as elsewhere in Malli)
+(m/validate [:repeat {:min 2, :max 4} int?] [1 2 3 4 5])
+;; => false
 ```
 
 `:catn` and `:altn` allow naming the subsequences / alternatives
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/explain
-  [:* [:catn [:prop string?] [:val [:altn [:s string?] [:b boolean?]]]]]
+  [:* [:catn [:prop :string] [:val [:altn [:s :string] [:b :boolean]]]]]
   ["-server" "foo" "-verbose" 11 "-user" "joe"])
-;; => {:schema [:* [:catn [:prop string?] [:val [:altn [:s string?] [:b boolean?]]]]],
-;;     :value ["-server" "foo" "-verbose" 11 "-user" "joe"],
-;;     :errors ({:path [0 :val :s], :in [3], :schema string?, :value 11}
-;;              {:path [0 :val :b], :in [3], :schema boolean?, :value 11})}
+;; => {:schema [:* [:catn [:prop :string] [:val [:altn [:s :string] [:b :boolean]]]]],
+;      :value ["-server" "foo" "-verbose" 11 "-user" "joe"],
+;      :errors ({:path [0 :val :s], :in [3], :schema :string, :value 11}
+;               {:path [0 :val :b], :in [3], :schema :boolean, :value 11})}
 ```
 
 while `:cat` and `:alt` just use numeric indices for paths:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/explain
   [:* [:cat string? [:alt string? boolean?]]]
@@ -544,17 +563,18 @@ a seqex child `:schema` can be used:
 (m/validate
   [:cat [:= :names] [:schema [:* string?]] [:= :nums] [:schema [:* number?]]]
   [:names ["a" "b"] :nums [1 2 3]])
-; => true
+;; => true
 
 ;; whereas
 (m/validate
   [:cat [:= :names] [:* string?] [:= :nums] [:* number?]]
   [:names "a" "b" :nums 1 2 3])
-; => true
+;; => true
 ```
 
 Although a lot of effort has gone into making the seqex implementation fast
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[clojure.spec.alpha :as s])
 (require '[criterium.core :as cc])
@@ -568,6 +588,7 @@ Although a lot of effort has gone into making the seqex implementation fast
 
 it is always better to use less general tools whenever possible:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (let [valid? (partial s/valid? (s/coll-of int?))]
   (cc/quick-bench (valid? (range 10)))) ; Execution time mean : 1.8µs
@@ -602,12 +623,12 @@ To create a vector schema based on a seqex, use `:and`.
 (m/validate [:and [:cat :keyword [:* :any]]
                   vector?]
             [:a 1])
-; => true
+;; => true
 
 (m/validate [:and [:cat :keyword [:* :any]]
                   vector?]
             (:a 1))
-; => false
+;; => false
 ```
 
 Note: To generate values from a vector seqex, see [:and generation](#and-generation).
@@ -645,7 +666,6 @@ Using `:string` Schema:
 Using regular expressions:
 
 ```clojure
-
 (m/validate #"a+b+c+" "abbccc")
 ;; => true
 
@@ -664,7 +684,6 @@ Using regular expressions:
 ;; anchor with ^...$ if you want to strictly match the whole string
 (m/validate [:re #"^\d{4}$"] "1234567")
 ;; => false
-
 ```
 
 ## Maybe schemas
@@ -695,16 +714,17 @@ Use `:maybe` to express that an element should match some schema OR be `nil`:
    [:fn (fn [{:keys [x y]}] (> x y))]])
 
 (m/validate my-schema {:x 1, :y 0})
-; => true
+;; => true
 
 (m/validate my-schema {:x 1, :y 2})
-; => false
+;; => false
 ```
 
 ## Error messages
 
 Detailed errors with `m/explain`:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/explain
   Address
@@ -714,7 +734,7 @@ Detailed errors with `m/explain`:
              :city "Tampere"
              :zip 33100
              :lonlat [61.4858322, 23.7854658]}})
-; => nil
+;; => nil
 
 (m/explain
   Address
@@ -723,35 +743,35 @@ Detailed errors with `m/explain`:
    :address {:street "Ahlmanintie 29"
              :zip 33100
              :lonlat [61.4858322, nil]}})
-;{:schema [:map
-;          [:id string?]
-;          [:tags [:set keyword?]]
-;          [:address [:map
-;                     [:street string?]
-;                     [:city string?]
-;                     [:zip int?]
-;                     [:lonlat [:tuple double? double?]]]]],
-; :value {:id "Lillan",
-;         :tags #{:artesan :garden "coffee"},
-;         :address {:street "Ahlmanintie 29"
-;                   :zip 33100
-;                   :lonlat [61.4858322 nil]}},
-; :errors ({:path [:tags 0]
-;           :in [:tags 0]
-;           :schema keyword?
-;           :value "coffee"}
-;          {:path [:address :city],
-;           :in [:address :city],
-;           :schema [:map
-;                    [:street string?]
-;                    [:city string?]
-;                    [:zip int?]
-;                    [:lonlat [:tuple double? double?]]],
-;           :type :malli.core/missing-key}
-;          {:path [:address :lonlat 1]
-;           :in [:address :lonlat 1]
-;           :schema double?
-;           :value nil})}
+;; => {:schema [:map
+          [:id string?]
+          [:tags [:set keyword?]]
+          [:address [:map
+                     [:street string?]
+                     [:city string?]
+                     [:zip int?]
+                     [:lonlat [:tuple double? double?]]]]],
+ :value {:id "Lillan",
+         :tags #{:artesan :garden "coffee"},
+         :address {:street "Ahlmanintie 29"
+                   :zip 33100
+                   :lonlat [61.4858322 nil]}},
+ :errors ({:path [:tags 0]
+           :in [:tags 0]
+           :schema keyword?
+           :value "coffee"}
+          {:path [:address :city],
+           :in [:address :city],
+           :schema [:map
+                    [:street string?]
+                    [:city string?]
+                    [:zip int?]
+                    [:lonlat [:tuple double? double?]]],
+           :type :malli.core/missing-key}
+          {:path [:address :lonlat 1]
+           :in [:address :lonlat 1]
+           :schema double?
+           :value nil})}
 ```
 
 Under `:errors`, you get a list of errors with the following keys:
@@ -761,6 +781,7 @@ Under `:errors`, you get a list of errors with the following keys:
 * `:schema`, schema in error
 * `:value`, value in error
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def Schema [:map [:x [:maybe [:tuple :string]]]])
 
@@ -778,10 +799,10 @@ error
 ; :value 1}
 
 (get-in value (:in error))
-; => 1
+;; => 1
 
 (mu/get-in Schema (:path error))
-; => :string
+;; => :string
 ```
 
 Note! If you need error messages that serialize neatly to EDN/JSON, use `malli.util/explain-data` instead.
@@ -801,9 +822,9 @@ Explain results can be humanized with `malli.error/humanize`:
                  :zip 33100
                  :lonlat [61.4858322, nil]}})
     (me/humanize))
-;{:tags #{["should be a keyword"]}
-; :address {:city ["missing required key"]
-;           :lonlat [nil ["should be a double"]]}}
+;; => {:tags #{["should be a keyword"]}
+;      :address {:city ["missing required key"]
+;                :lonlat [nil ["should be a double"]]}}
 ```
 
 Or if you already have a malli validation exception (e.g. in a catch form):
@@ -823,6 +844,7 @@ Error messages can be customized with `:error/message` and `:error/fn` propertie
 
 If `:error/message` is of a predictable structure, it will automatically support custom `[:not schema]` failures for the following locales:
 - `:en` if message starts with `should` or `should not` then they will be swapped automatically. Otherwise, message is ignored.
+
 ```clojure
 ;; e.g.,
 (me/humanize
@@ -831,7 +853,7 @@ If `:error/message` is of a predictable structure, it will automatically support
      [:fn {:error/message {:en "should be a multiple of 3"}}
       #(= 0 (mod % 3))]]
     3))
-; => ["should not be a multiple of 3"]
+;; => ["should not be a multiple of 3"]
 ```
 
 The first argument to `:error/fn` is a map with keys:
@@ -843,6 +865,7 @@ The first argument to `:error/fn` is a map with keys:
   If returning a string,
   the resulting error message will be negated by the `:error/fn` caller in the same way as `:error/message`.
   Returning `(negated string)` disables this behavior and `string` is used as the negated error message.
+
 ```clojure
 ;; automatic negation
 (me/humanize
@@ -850,7 +873,7 @@ The first argument to `:error/fn` is a map with keys:
     [:not [:fn {:error/fn {:en (fn [_ _] "should not be a multiple of 3")}}
            #(not= 0 (mod % 3))]]
     1))
-; => ["should be a multiple of 3"]
+;; => ["should be a multiple of 3"]
 
 ;; manual negation
 (me/humanize
@@ -859,7 +882,7 @@ The first argument to `:error/fn` is a map with keys:
                                             (negated "should not avoid being a multiple of 3")
                                             "should not be a multiple of 3"))}}
                     #(not= 0 (mod % 3))]] 1))
-; => ["should not avoid being a multiple of 3"]
+;; => ["should not avoid being a multiple of 3"]
 ```
 
 Here are some basic examples of `:error/message` and `:error/fn`:
@@ -875,9 +898,9 @@ Here are some basic examples of `:error/message` and `:error/fn`:
     (me/humanize
       {:errors (-> me/default-errors
                    (assoc ::m/missing-key {:error/fn (fn [{:keys [in]} _] (str "missing key " (last in)))}))}))
-;{:id ["missing key :id"]
-; :size ["should be: S|M|L"]
-; :age ["10, should be > 18"]}
+;; => {:id ["missing key :id"]
+;      :size ["should be: S|M|L"]
+;      :age ["10, should be > 18"]}
 ```
 
 Messages can be localized:
@@ -898,9 +921,9 @@ Messages can be localized:
                    (assoc-in ['int? :error-message :fi] "pitäisi olla numero")
                    (assoc ::m/missing-key {:error/fn {:en (fn [{:keys [in]} _] (str "missing key " (last in)))
                                                       :fi (fn [{:keys [in]} _] (str "puuttuu avain " (last in)))}}))}))
-;{:id ["puuttuu avain :id"]
-; :size ["pitäisi olla: S|M|L"]
-; :age ["10, pitäisi olla > 18"]}
+;; => {:id ["puuttuu avain :id"]
+;      :size ["pitäisi olla: S|M|L"]
+;      :age ["10, pitäisi olla > 18"]}
 ```
 
 Top-level humanized map-errors are under `:malli/error`:
@@ -915,7 +938,7 @@ Top-level humanized map-errors are under `:malli/error`:
     (m/explain {:password "secret"
                 :password2 "faarao"})
     (me/humanize))
-; => ["passwords don't match"]
+;; => ["passwords don't match"]
 ```
 
 Errors can be targeted using `:error/path` property:
@@ -931,7 +954,7 @@ Errors can be targeted using `:error/path` property:
     (m/explain {:password "secret"
                 :password2 "faarao"})
     (me/humanize))
-; {:password2 ["passwords don't match"]}
+;; => {:password2 ["passwords don't match"]}
 ```
 
 By default, only direct erroneous schema properties are used:
@@ -941,7 +964,7 @@ By default, only direct erroneous schema properties are used:
      [:foo {:error/message "entry-failure"} :int]] ;; here, :int fails, no error props
     (m/explain {:foo "1"})
     (me/humanize))
-; => {:foo ["should be an integer"]}
+;; => {:foo ["should be an integer"]}
 ```
 
 Looking up humanized errors from parent schemas with custom `:resolve` (BETA, subject to change):
@@ -951,7 +974,7 @@ Looking up humanized errors from parent schemas with custom `:resolve` (BETA, su
      [:foo {:error/message "entry-failure"} :int]]
     (m/explain {:foo "1"})
     (me/humanize {:resolve me/-resolve-root-error}))
-; => {:foo ["entry-failure"]}
+;; => {:foo ["entry-failure"]}
 ```
 
 ## Spell checking
@@ -959,6 +982,7 @@ Looking up humanized errors from parent schemas with custom `:resolve` (BETA, su
 For closed schemas, key spelling can be checked with:
 
 ```clojure
+(require '[malli.util :as mu])
 (-> [:map [:address [:map [:street string?]]]]
     (mu/closed-schema)
     (m/explain
@@ -966,8 +990,8 @@ For closed schemas, key spelling can be checked with:
        :address {:streetz "Hämeenkatu 14"}})
     (me/with-spell-checking)
     (me/humanize))
-;{:address {:streetz ["should be spelled :street"]}
-; :name ["disallowed key"]}
+;; => {:address {:streetz ["should be spelled :street"]}
+;      :name ["disallowed key"]}
 ```
 
 ## Values in error
@@ -983,8 +1007,8 @@ Just to get parts of the value that are in error:
                 :zip 33100
                 :lonlat [61.4858322, "23.7832851,17"]}})
     (me/error-value))
-;{:tags #{"coffee" "ground"}
-; :address {:lonlat [nil "23.7832851,17"]}}
+;; => {:tags #{"coffee" "ground"}
+;      :address {:lonlat [nil "23.7832851,17"]}}
 ```
 
 Masking irrelevant parts:
@@ -998,11 +1022,11 @@ Masking irrelevant parts:
                 :zip 33100
                 :lonlat [61.4858322, "23.7832851,17"]}})
     (me/error-value {::me/mask-valid-values '...}))
-;{:id ...
-; :tags #{"coffee" "ground" ...}
-; :address {:street ...
-;           :zip ...
-;           :lonlat [... "23.7832851,17"]}}
+;; => {:id ...
+;      :tags #{"coffee" "ground" ...}
+;      :address {:street ...
+;                :zip ...
+;                :lonlat [... "23.7832851,17"]}}
 ```
 
 ## Pretty errors
@@ -1013,6 +1037,7 @@ There are two ways to get pretty errors:
 
 Start development mode:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ((requiring-resolve 'malli.dev/start!))
 ```
@@ -1029,6 +1054,7 @@ Custom exception (with default layout):
 
 Pretty printing in being backed by `malli.dev.virhe/-format` multimethod using `(-> exception (ex-data) :data)` as the default dispatch key. As fallback, exception class - or exception subclass can be used, e.g. the following will handle all `java.sql.SQLException` and it's parent exceptions:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.dev.virhe :as v])
 
@@ -1070,10 +1096,10 @@ Simple usage:
 
 ```clojure
 (m/decode int? "42" mt/string-transformer)
-; 42
+;; =>  42
 
 (m/encode int? 42 mt/string-transformer)
-; "42"
+;; => "42"
 ```
 
 For performance, precompute the transformations with `m/decoder` and `m/encoder`:
@@ -1082,24 +1108,25 @@ For performance, precompute the transformations with `m/decoder` and `m/encoder`
 (def decode (m/decoder int? mt/string-transformer))
 
 (decode "42")
-; 42
+;; => 42
 
 (def encode (m/encoder int? mt/string-transformer))
 
 (encode 42)
-; "42"
+;; => "42"
 ```
 
 ### Coercion
 
 For both decoding + validating the results (throwing exception on error), there is `m/coerce` and `m/coercer`:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/coerce :int "42" mt/string-transformer)
-; 42
+;; => 42
 
 ((m/coercer :int mt/string-transformer) "42")
-; 42
+;; => 42
 
 (m/coerce :int "invalid" mt/string-transformer)
 ; =throws=> :malli.core/invalid-input {:value "invalid", :schema :int, :explain {:schema :int, :value "invalid", :errors ({:path [], :in [], :schema :int, :value "invalid"})}}
@@ -1107,6 +1134,7 @@ For both decoding + validating the results (throwing exception on error), there 
 
 Coercion can be applied without transformer, doing just validation:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/coerce :int 42)
 ; 42
@@ -1117,9 +1145,10 @@ Coercion can be applied without transformer, doing just validation:
 
 Exception-free coercion with continuation-passing style:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/coerce :int "fail" nil (partial prn "success:") (partial prn "error:"))
-; =prints=> "error:" {:value "fail", :schema :int, :explain ...}
+;; =stdout=> "error:" {:value "fail", :schema :int, :explain ...}
 ```
 
 ### Advanced Transformations
@@ -1136,12 +1165,12 @@ Transformations are recursive:
              :zip 33100
              :lonlat [61.4858322 23.7854658]}}
   mt/json-transformer)
-;{:id "Lillan",
-; :tags #{:coffee :artesan :garden},
-; :address {:street "Ahlmanintie 29"
-;           :city "Tampere"
-;           :zip 33100
-;           :lonlat [61.4858322 23.7854658]}}
+;; => {:id "Lillan",
+;      :tags #{:coffee :artesan :garden},
+;      :address {:street "Ahlmanintie 29"
+;                :city "Tampere"
+;                :zip 33100
+;                :lonlat [61.4858322 23.7854658]}}
 ```
 
 Transform map keys:
@@ -1156,19 +1185,19 @@ Transform map keys:
              :zip 33100
              :lonlat [61.4858322 23.7854658]}}
   (mt/key-transformer {:encode name}))
-;{"id" "Lillan",
-; "tags" ["coffee" "artesan" "garden"],
-; "address" {"street" "Ahlmanintie 29"
-;            "city" "Tampere"
-;            "zip" 33100
-;            "lonlat" [61.4858322 23.7854658]}}
+;; => {"id" "Lillan",
+;      "tags" ["coffee" "artesan" "garden"],
+;      "address" {"street" "Ahlmanintie 29"
+;                 "city" "Tampere"
+;                 "zip" 33100
+;                 "lonlat" [61.4858322 23.7854658]}}
 ```
 
 Transforming homogenous `:enum` or `:=`s (supports automatic type detection of `:keyword`, `:symbol`, `:int` and `:double`):
 
 ```clojure
 (m/decode [:enum :kikka :kukka] "kukka" mt/string-transformer)
-; => :kukka
+;; => :kukka
 ```
 
 Transformers can be composed with `mt/transformer`:
@@ -1190,12 +1219,12 @@ Transformers can be composed with `mt/transformer`:
              :zip 33100
              :lonlat [61.4858322 23.7854658]}}
   strict-json-transformer)
-;{:id "Lillan",
-; :tags #{:coffee :artesan :garden},
-; :address {:street "Ahlmanintie 29"
-;           :city "Tampere"
-;           :zip 33100
-;           :lonlat [61.4858322 23.7854658]}}
+;; => {:id "Lillan",
+;      :tags #{:coffee :artesan :garden},
+;      :address {:street "Ahlmanintie 29"
+;                :city "Tampere"
+;                :zip 33100
+;                :lonlat [61.4858322 23.7854658]}}
 ```
 
 Schema properties can be used to override default transformations:
@@ -1204,7 +1233,7 @@ Schema properties can be used to override default transformations:
 (m/decode
   [string? {:decode/string clojure.string/upper-case}]
   "kerran" mt/string-transformer)
-; => "KERRAN"
+;; => "KERRAN"
 ```
 
 This works too:
@@ -1213,7 +1242,7 @@ This works too:
 (m/decode
   [string? {:decode {:string clojure.string/upper-case}}]
   "kerran" mt/string-transformer)
-; => "KERRAN"
+;; => "KERRAN"
 ```
 
 Decoders and encoders as interceptors (with `:enter` and `:leave` stages):
@@ -1222,7 +1251,7 @@ Decoders and encoders as interceptors (with `:enter` and `:leave` stages):
 (m/decode
   [string? {:decode/string {:enter clojure.string/upper-case}}]
   "kerran" mt/string-transformer)
-; => "KERRAN"
+;; => "KERRAN"
 ```
 
 ```clojure
@@ -1230,7 +1259,7 @@ Decoders and encoders as interceptors (with `:enter` and `:leave` stages):
   [string? {:decode/string {:enter #(str "olipa_" %)
                             :leave #(str % "_avaruus")}}]
   "kerran" mt/string-transformer)
-; => "olipa_kerran_avaruus"
+;; => "olipa_kerran_avaruus"
 ```
 
 To access Schema (and options) use `:compile`:
@@ -1243,7 +1272,7 @@ To access Schema (and options) use `:compile`:
                                     (fn [x] (* x multiplier))))}}]
   12
   (mt/transformer {:name :math}))
-; => 120
+;; => 120
 ```
 
 Going crazy:
@@ -1257,7 +1286,7 @@ Going crazy:
                             :leave (partial * 3)}}]]]
   {:x 1}
   (mt/transformer {:name :math}))
-; => {:x 24}
+;; => {:x 24}
 ```
 
 `:and` accumulates the transformed value left-to-right.
@@ -1300,7 +1329,7 @@ Proxy schemas like `:merge` and `:union` transform as if `m/deref`ed.
   {:registry (merge (mu/schemas) (m/default-schemas))}
   (mt/default-value-transformer {::mt/add-optional-keys true}))
 ;; => {:name "kikka"
-;;     :description "kikka"}
+;      :description "kikka"}
 ```
 
 ## To and from JSON
@@ -1315,6 +1344,8 @@ schema.
 To JSON:
 
 ```clojure
+(require 'jsonista.core)
+
 (def Tags
   (m/schema [:map
              {:closed true}
@@ -1323,7 +1354,7 @@ To JSON:
  (m/encode Tags
            {:tags #{:bar :quux}}
            mt/json-transformer))
-; => "{\"tags\":[\"bar\",\"quux\"]}"
+;; => "{\"tags\":[\"bar\",\"quux\"]}"
 ```
 
 From JSON without validation:
@@ -1333,20 +1364,21 @@ From JSON without validation:
           (jsonista.core/read-value "{\"tags\":[\"bar\",[\"quux\"]]}"
                                     jsonista.core/keyword-keys-object-mapper)
           mt/json-transformer)
-; => {:tags #{:bar ["quux"]}}
+;; => {:tags #{:bar ["quux"]}}
 ```
 
 From JSON with validation:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/explain Tags
            (m/decode Tags
                      (jsonista.core/read-value "{\"tags\":[\"bar\",[\"quux\"]]}"
                                                jsonista.core/keyword-keys-object-mapper)
                      mt/json-transformer))
-; => {:schema [:map {:closed true} [:tags [:set :keyword]]],
-;     :value {:tags #{:bar ["quux"]}},
-;     :errors ({:path [:tags 0], :in [:tags ["quux"]], :schema :keyword, :value ["quux"]})}
+;; => {:schema [:map {:closed true} [:tags [:set :keyword]]],
+;      :value {:tags #{:bar ["quux"]}},
+;      :errors ({:path [:tags 0], :in [:tags ["quux"]], :schema :keyword, :value ["quux"]})}
 ```
 
 ```clojure
@@ -1367,7 +1399,7 @@ For performance, it's best to prebuild the validator, decoder and explainer:
                               jsonista.core/keyword-keys-object-mapper)
     decode-Tags
     validate-Tags)
-; => true
+;; => true
 ```
 
 ## Default values
@@ -1376,7 +1408,7 @@ Applying default values:
 
 ```clojure
 (m/decode [:and {:default 42} int?] nil mt/default-value-transformer)
-; => 42
+;; => 42
 ```
 
 With custom key and type defaults:
@@ -1392,11 +1424,12 @@ With custom key and type defaults:
     {:key :ui/default
      :defaults {:map (constantly {})
                 :string (constantly "")}}))
-; => {:user {:name "", :description "-"}}
+;; => {:user {:name "", :description "-"}}
 ```
 
 With custom function:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/decode
  [:map
@@ -1418,7 +1451,7 @@ Optional Keys are not added by default:
   [:description {:optional true} [:string {:default "kikka"}]]]
  {}
  (mt/default-value-transformer))
-; => {:name "kikka"}
+;; => {:name "kikka"}
 ```
 
 Adding optional keys too via `::mt/add-optional-keys` option:
@@ -1430,7 +1463,7 @@ Adding optional keys too via `::mt/add-optional-keys` option:
   [:description {:optional true} [:string {:default "kikka"}]]]
  {}
  (mt/default-value-transformer {::mt/add-optional-keys true}))
-; => {:name "kikka", :description "kikka"}
+;; => {:name "kikka", :description "kikka"}
 ```
 
 Single sweep of defaults & string encoding:
@@ -1451,9 +1484,9 @@ Single sweep of defaults & string encoding:
   (mt/transformer
     mt/default-value-transformer
     mt/string-transformer))
-;{:a "1"
-; :b ["1" "2" "3"]
-; :c {:x "42"}}
+;; => {:a "1"
+;      :b ["1" "2" "3"]
+;      :c {:x "42"}}
 ```
 
 ## Programming with schemas
@@ -1464,9 +1497,10 @@ Single sweep of defaults & string encoding:
 
 Updating Schema properties:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (mu/update-properties [:vector int?] assoc :min 1)
-; => [:vector {:min 1} int?]
+;; => [:vector {:min 1} int?]
 ```
 
 Lifted `clojure.core` function to work with schemas: `select-keys`, `dissoc`, `get`, `assoc`, `update`, `get-in`, `assoc-in`, `update-in`
@@ -1649,7 +1683,7 @@ Finding first value (prewalk):
    [:z [:string {:salaisuus "piilossa"}]]]
   (fn [schema _ _]
     (-> schema m/properties :salaisuus)))
-; => "turvassa"
+;; => "turvassa"
 ```
 
 Finding all subschemas with paths, retaining order:
@@ -1731,17 +1765,17 @@ Schema paths can be converted into value paths:
 
 ```clojure
 (mu/get-in Schema [0 :address 0 :lonlat])
-; => [:tuple double? double?]
+; [:tuple double? double?]
 
 (mu/path->in Schema [0 :address 0 :lonlat])
-; => [:address :lonlat]
+; [:address :lonlat]
 ```
 
 and back, returning all paths:
 
 ```clojure
 (mu/in->paths Schema [:address :lonlat])
-; => [[0 :address 0 :lonlat]]
+; [[0 :address 0 :lonlat]]
 ```
 
 ## Declarative schema transformation
@@ -1769,7 +1803,7 @@ Merged
 ; [:y :int]]
 
 (m/validate Merged {:x "kikka", :y 6})
-; => true
+;; => true
 ```
 
 `:union` is similar to `:or`, except `:union` combines map schemas in different disjuncts with `:or`.
@@ -1791,10 +1825,10 @@ For example, `UnionMaps` is equivalent to `[:map [:x [:or :int :string]] [:y [:o
     {:registry registry}))
 
 (m/validate OrMaps {:x "kikka" :y "kikka"})
-; => false
+;; => false
 
 (m/validate UnionMaps {:x "kikka" :y "kikka"})
-; => true
+;; => true
 ```
 
 `:merge` and `:union` differ on schemas with common keys. `:merge` chooses the right-most
@@ -1818,13 +1852,13 @@ is equivalent to `[:map [:x [:or :string :int]]]`.
     {:registry registry}))
 
 (m/validate MergedCommon {:x "kikka"})
-; => false
+;; => false
 (m/validate MergedCommon {:x 1})
-; => true
+;; => true
 (m/validate UnionCommon {:x "kikka"})
-; => true
+;; => true
 (m/validate UnionCommon {:x 1})
-; => true
+;; => true
 ```
 
 ### Distributive schemas
@@ -1832,6 +1866,7 @@ is equivalent to `[:map [:x [:or :string :int]]]`.
 `:merge` also distributes over `:multi` in a [similar way](https://en.wikipedia.org/wiki/Distributive_property) to how multiplication
 distributes over addition in arithmetic. There are two transformation rules, applied in the following order:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; right-distributive
 [:merge [:multi M1 M2 ...] M3]
@@ -1847,6 +1882,7 @@ distributes over addition in arithmetic. There are two transformation rules, app
 For `:merge` with more than two arguments, the rules are applied iteratively left-to-right
 as if the following transformation was applied:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 [:merge M1 M2 M3 M4 ...]
 =>
@@ -1872,7 +1908,7 @@ Here are concrete examples of applying the rules:
    [1 [:map [:y [:= 1]]]]
    [2 [:map [:y [:= 2]]]]]]
  {:registry registry})
-; => [:multi {:dispatch :y}
+;    [:multi {:dispatch :y}
 ;     [1 [:map [:x :int] [:y [:= 1]]]]
 ;     [2 [:map [:x :int] [:y [:= 2]]]]]
 
@@ -1884,7 +1920,7 @@ Here are concrete examples of applying the rules:
    [2 [:map [:y [:= 2]]]]]
   [:map [:x :int]]]
  {:registry registry})
-; => [:multi {:dispatch :y}
+;    [:multi {:dispatch :y}
 ;     [1 [:map [:y [:= 1]] [:x :int]]]
 ;     [2 [:map [:y [:= 2]] [:x :int]]]]
 ```
@@ -1932,7 +1968,7 @@ Closed dispatch with `:multi` schema and `:dispatch` property:
    [:sized [:map [:type keyword?] [:size int?]]]
    [:human [:map [:type keyword?] [:name string?] [:address [:map [:country keyword?]]]]]]
   {:type :sized, :size 10})
-; true
+;; => true
 ```
 
 Default branch with `::m/default`:
@@ -1945,13 +1981,13 @@ Default branch with `::m/default`:
      [::m/default :string]]))
 
 (valid? {:type "object", :key "1", :value "100"})
-; => true
+;; => true
 
 (valid? "SUCCESS!")
-; => true
+;; => true
 
 (valid? :failure)
-; => false
+;; => false
 ```
 
 Any function can be used for `:dispatch`:
@@ -1962,7 +1998,7 @@ Any function can be used for `:dispatch`:
    [:sized [:tuple keyword? [:map [:size int?]]]]
    [:human [:tuple keyword? [:map [:name string?] [:address [:map [:country keyword?]]]]]]]
   [:human {:name "seppo", :address {:country :sweden}}])
-; true
+;; => true
 ```
 
 `:dispatch` values should be decoded before actual values:
@@ -1979,9 +2015,9 @@ Any function can be used for `:dispatch`:
    :address {:country "finland"
              :street "this is an extra key"}}
   (mt/transformer mt/strip-extra-keys-transformer mt/string-transformer))
-;{:type :human
-; :name "Tiina"
-; :address {:country :finland}}
+;; => {:type :human
+;      :name "Tiina"
+;      :address {:country :finland}}
 ```
 
 ## Recursive schemas
@@ -1995,11 +2031,12 @@ For example, here is a recursive schema using `:schema` for singly-linked lists 
   [:schema {:registry {::cons [:maybe [:tuple pos-int? [:ref ::cons]]]}}
    [:ref ::cons]]
   [16 [64 [26 [1 [13 nil]]]]])
-; => true
+;; => true
 ```
 
 Without the `:ref` keyword, malli eagerly expands the schema until a stack overflow error is thrown:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/validate
   [:schema {:registry {::cons [:maybe [:tuple pos-int? ::cons]]}}
@@ -2011,6 +2048,7 @@ Without the `:ref` keyword, malli eagerly expands the schema until a stack overf
 Technically, you only need the `:ref` in recursive positions. However, it is best practice to `:ref` all references
 to recursive variables for better-behaving generators:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; Note:
 [:schema {:registry {::cons [:maybe [:tuple pos-int? [:ref ::cons]]]}}
@@ -2035,7 +2073,7 @@ Mutual recursion works too. Thanks to the `:schema` construct, many schemas coul
                        ::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
    ::ping]
   ["ping" ["pong" ["ping" ["pong" ["ping" nil]]]]])
-; => true
+;; => true
 ```
 
 Nested registries, the last definition wins:
@@ -2047,13 +2085,14 @@ Nested registries, the last definition wins:
    [:schema {:registry {::pong [:maybe [:tuple [:= "pong"] [:ref ::ping]]]}}
     ::ping]]
   ["ping" ["pong" ["ping" ["pong" ["ping" nil]]]]])
-; => true
+;; => true
 ```
 
 ## Value generation
 
 Schemas can be used to generate values:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.generator :as mg])
 
@@ -2140,11 +2179,12 @@ Generated values are valid:
 ;           :lonlat [-2.75 -0.625]}}
 
 (m/validate Address (mg/generate Address))
-; => true
+;; => true
 ```
 
 Sampling values:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; sampling
 (mg/sample [:and int? [:> 10] [:< 100]] {:seed 123})
@@ -2153,6 +2193,7 @@ Sampling values:
 
 Integration with test.check:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[clojure.test.check.generators :as gen])
 (gen/sample (mg/generator pos-int?))
@@ -2167,6 +2208,7 @@ out any values that do not pass the overall `:and` schema.
 For the most reliable results, place the schema that is most likely to generate valid
 values for the entire schema as the first child of an `:and` schema.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; BAD: :string is unlikely to generate values satisfying the schema
 (mg/generate [:and :string [:enum "a" "b" "c"]] {:seed 42})
@@ -2185,6 +2227,7 @@ For example, a schema for non-empty heterogeneous vectors can validate values
 by combining `:cat` and `vector?`, but since `:cat` generates sequences
 we need to use `:gen/fmap` to make it generate vectors:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; generate a non-empty vector starting with a keyword
 (mg/generate [:and [:cat {:gen/fmap vec}
@@ -2234,11 +2277,12 @@ All samples are valid against the inferred schema:
 
 ```clojure
 (every? (partial m/validate (mp/provide samples)) samples)
-; => true
+;; => true
 ```
 
 For better performance, use `mp/provider`:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[criterium.core :as p])
 
@@ -2259,10 +2303,10 @@ By default, `:map-of` is not inferred:
  [{"1" [1]}
   {"2" [1 2]}
   {"3" [1 2 3]}])
-;[:map
-; ["1" {:optional true} [:vector :int]]
-; ["2" {:optional true} [:vector :int]]
-; ["3" {:optional true} [:vector :int]]]
+;; => [:map
+;      ["1" {:optional true} [:vector :int]]
+;      ["2" {:optional true} [:vector :int]]
+;      ["3" {:optional true} [:vector :int]]]
 ```
 
 With `::mp/map-of-threshold` option:
@@ -2273,7 +2317,7 @@ With `::mp/map-of-threshold` option:
   {"2" [1 2]}
   {"3" [1 2 3]}]
  {::mp/map-of-threshold 3})
-; [:map-of :string [:vector :int]]
+;; => [:map-of :string [:vector :int]]
 ```
 
 Sample-data can be type-hinted with `::mp/hint`:
@@ -2285,11 +2329,11 @@ Sample-data can be type-hinted with `::mp/hint`:
     :b {:b 2, :c 1}
     :c {:b 3}
     :d nil}])
-;[:map-of
-; :keyword
-; [:maybe [:map
-;          [:b :int]
-;          [:c {:optional true} :int]]]]
+;; => [:map-of
+;      :keyword
+;      [:maybe [:map
+;               [:b :int]
+;               [:c {:optional true} :int]]]]
 ```
 
 ### :tuple inferring
@@ -2301,7 +2345,7 @@ By default, tuples are not inferred:
   [[1 "kikka" true]
    [2 "kukka" true]
    [3 "kakka" true]])
-; [:vector :some]
+;; => [:vector :some]
 ```
 
 With `::mp/tuple-threshold` option:
@@ -2312,7 +2356,7 @@ With `::mp/tuple-threshold` option:
    [2 "kukka" true]
    [3 "kakka" false]]
   {::mp/tuple-threshold 3})
-; [:tuple :int :string :boolean]
+;; => [:tuple :int :string :boolean]
 ```
 
 Sample-data can be type-hinted with `::mp/hint`:
@@ -2322,7 +2366,7 @@ Sample-data can be type-hinted with `::mp/hint`:
   [^{::mp/hint :tuple}
    [1 "kikka" true]
    ["2" "kukka" true]])
-; [:tuple :some :string :boolean]
+;; => [:tuple :some :string :boolean]
 ```
 
 ### value decoding in inferring
@@ -2333,7 +2377,7 @@ By default, no decoding is applied for (leaf) values:
 (mp/provide
  [{:id "caa71a26-5fe1-11ec-bf63-0242ac130002"}
   {:id "8aadbf5e-5fe3-11ec-bf63-0242ac130002"}])
-; => [:map [:id :string]]
+;; => [:map [:id :string]]
 ```
 
 Adding custom decoding via `::mp/value-decoders` option:
@@ -2346,7 +2390,7 @@ Adding custom decoding via `::mp/value-decoders` option:
    :time "2022-01-01T00:00:00Z"}]
  {::mp/value-decoders {:string {:uuid mt/-string->uuid
                                 'inst? mt/-string->date}}})
-; => [:map [:id :uuid] [:time inst?]]
+;; => [:map [:id :uuid] [:time inst?]]
 ```
 
 ## Destructuring
@@ -2359,13 +2403,13 @@ Schemas can also be inferred from [Clojure Destructuring Syntax](https://clojure
 (def infer (comp :schema md/parse))
 
 (infer '[a b & cs])
-; => [:cat :any :any [:* :any]]
+;; => [:cat :any :any [:* :any]]
 ```
 Malli also supports adding type hints as an extension to the normal Clojure syntax (enabled by default), inspired by [Plumatic Schema](https://github.com/plumatic/schema#beyond-type-hints).
 
 ```clojure
 (infer '[a :- :int, b :- :string & cs :- [:* :boolean]])
-; => [:cat :int :string [:* :boolean]]
+;; => [:cat :int :string [:* :boolean]]
 ```
 
 Pulling out function argument schemas from Vars:
@@ -2376,9 +2420,9 @@ Pulling out function argument schemas from Vars:
   ([a b & cs] [a b cs]))
 
 (md/infer #'kikka)
-;[:function
-; [:=> [:cat :any] :any]
-; [:=> [:cat :any :any [:* :any]] :any]]
+;; => [:function
+;      [:=> [:cat :any] :any]
+;      [:=> [:cat :any :any [:* :any]] :any]]
 ```
 
 `md/parse` uses the following options:
@@ -2401,33 +2445,33 @@ A more complete example:
             [h] :h
             :or {d 0}
             :as opts}])
-;[:cat
-; :any
-; [:maybe [:cat
-;          [:? :any]
-;          [:? :any]
-;          [:* :any]]]
-; [:altn
-;  [:map
-;   [:map
-;    [:d {:optional true} :any]
-;    [:e {:optional true} :any]
-;    [:demo/f {:optional true}]
-;    [:demo/g {:optional true}]
-;    [:h {:optional true} [:maybe [:cat
-;                                  [:? :any]
-;                                  [:* :any]]]]]]
-;  [:args
-;   [:*
-;    [:alt
-;     [:cat [:= :d] :any]
-;     [:cat [:= :e] :any]
-;     [:cat [:= :demo/f] :demo/f]
-;     [:cat [:= :demo/g] :demo/g]
-;     [:cat [:= :h] [:maybe [:cat
-;                            [:? :any]
-;                            [:* :any]]]]
-;     [:cat [:not [:enum :d :e :demo/f :demo/g :h]] :any]]]]]]
+;; => [:cat
+;      :any
+;      [:maybe [:cat
+;               [:? :any]
+;               [:? :any]
+;               [:* :any]]]
+;      [:orn
+;       [:map
+;        [:map
+;         [:d {:optional true} :any]
+;         [:e {:optional true} :any]
+;         [:demo/f {:optional true}]
+;         [:demo/g {:optional true}]
+;         [:h {:optional true} [:maybe [:cat
+;                                       [:? :any]
+;                                       [:* :any]]]]]]
+;       [:args
+;        [:*
+;         [:alt
+;          [:cat [:= :d] :any]
+;          [:cat [:= :e] :any]
+;          [:cat [:= :demo/f] :demo/f]
+;          [:cat [:= :demo/g] :demo/g]
+;          [:cat [:= :h] [:maybe [:cat
+;                                 [:? :any]
+;                                 [:* :any]]]]
+;          [:cat [:not [:enum :d :e :demo/f :demo/g :h]] :any]]]]]]
 ```
 
 ## Parsing values
@@ -2444,9 +2488,9 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
               [:s string?]
               [:b boolean?]]]]]
   ["-server" "foo" "-verbose" true "-user" "joe"])
-;[#malli.core.Tags{:values {:prop "-server", :val #malli.core.Tag{:key :s, :value "foo"}}}
-; #malli.core.Tags{:values {:prop "-verbose", :val #malli.core.Tag{:key :b, :value true}}}
-; #malli.core.Tags{:values {:prop "-user", :val #malli.core.Tag{:key :s, :value "joe"}}}]
+;; => [#malli.core.Tags{:values {:prop "-server", :val #malli.core.Tag{:key :s, :value "foo"}}}
+;      #malli.core.Tags{:values {:prop "-verbose", :val #malli.core.Tag{:key :b, :value true}}}
+;      #malli.core.Tags{:values {:prop "-user", :val #malli.core.Tag{:key :s, :value "joe"}}}]
 
 ```
 
@@ -2472,24 +2516,24 @@ Schemas can be used to parse values using `m/parse` and `m/parser`:
   [:div {:class [:foo :bar]}
    [:p "Hello, world of data"]])
 
-;#malli.core.Tag
-;{:key :node,
-; :value
-; #malli.core.Tags
-; {:values {:name :div,
-;           :props {:class [:foo :bar]},
-;           :children [#malli.core.Tag
-;                      {:key :node,
-;                       :value
-;                       #malli.core.Tags
-;                       {:values {:name :p,
-;                                 :props nil,
-;                                 :children [#malli.core.Tag
-;                                            {:key :primitive,
-;                                             :value
-;                                             #malli.core.Tag
-;                                             {:key :text,
-;                                              :value "Hello, world of data"}}]}}}]}}}
+;; => #malli.core.Tag
+;     {:key :node,
+;      :value
+;      #malli.core.Tags
+;      {:values {:name :div,
+;                :props {:class [:foo :bar]},
+;                :children [#malli.core.Tag
+;                           {:key :node,
+;                            :value
+;                            #malli.core.Tags
+;                            {:values {:name :p,
+;                                      :props nil,
+;                                      :children [#malli.core.Tag
+;                                                 {:key :primitive,
+;                                                  :value
+;                                                  #malli.core.Tag
+;                                                  {:key :text,
+;                                                   :value "Hello, world of data"}}]}}}]}}}
 ```
 
 Parsing returns tagged values for `:orn`, `:catn`, `:altn` and `:multi`.
@@ -2501,10 +2545,10 @@ Parsing returns tagged values for `:orn`, `:catn`, `:altn` and `:multi`.
    [::m/default :any]])
 
 (m/parse Multi {:type :user, :size 1})
-; => #malli.core.Tag{:key :user, :value {:type :user, :size 1}}
+;; => #malli.core.Tag{:key :user, :value {:type :user, :size 1}}
 
 (m/parse Multi {:type "sized", :size 1})
-; => #malli.core.Tag{:key :malli.core/default, :value {:type "sized", :size 1}}
+;; => #malli.core.Tag{:key :malli.core/default, :value {:type "sized", :size 1}}
 ```
 
 ## Unparsing values
@@ -2516,19 +2560,19 @@ The inverse of parsing, using `m/unparse` and `m/unparser`:
       [:p "Hello, world of data"]]
      (m/parse Hiccup)
      (m/unparse Hiccup))
-;[:div {:class [:foo :bar]}
-; [:p "Hello, world of data"]]
+;; => [:div {:class [:foo :bar]}
+;      [:p "Hello, world of data"]]
 ```
 
 ```clojure
 (m/unparse [:orn [:name :string] [:id :int]]
            (m/tag :name "x"))
-; => "x"
+;; => "x"
 
 (m/unparse [:* [:catn [:name :string] [:id :int]]]
            [(m/tags {:name "x" :id 1})
             (m/tags {:name "y" :id 2})])
-; => ["x" 1 "y" 2]
+;; => ["x" 1 "y" 2]
 ```
 
 ## Serializable functions
@@ -2540,6 +2584,7 @@ For ClojureScript, you need to require `sci.core` or `malli.cherry` manually.
 
 For GraalVM, you need to require `sci.core` manually, before requiring any malli namespaces.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def my-schema
   [:and
@@ -2557,6 +2602,7 @@ For GraalVM, you need to require `sci.core` manually, before requiring any malli
 
 **NOTE**: [sci is not termination safe](https://github.com/borkdude/sci/issues/348) so be wary of `sci` functions from untrusted sources. You can explicitly disable sci with option `::m/disable-sci` and set the default options with `::m/sci-options`.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/validate [:fn 'int?] 1 {::m/disable-sci true})
 ; Execution error
@@ -2579,26 +2625,26 @@ Implemented with protocol `malli.core/AST`. Allows lossless round-robin with fas
         [:y {:optional true} int?]]]])
 
 (m/form ?schema)
-;[:map
-; [:x boolean?]
-; [:y {:optional true} int?]
-; [:z [:map
+;; => [:map
 ;      [:x boolean?]
-;      [:y {:optional true} int?]]]]
+;      [:y {:optional true} int?]
+;      [:z [:map
+;           [:x boolean?]
+;           [:y {:optional true} int?]]]]
 
 (m/ast ?schema)
-;{:type :map,
-; :keys {:x {:order 0
-;            :value {:type boolean?}},
-;        :y {:order 1, :value {:type int?}
-;            :properties {:optional true}},
-;        :z {:order 2,
-;            :value {:type :map,
-;                    :keys {:x {:order 0
-;                               :value {:type boolean?}},
-;                           :y {:order 1
-;                               :value {:type int?}
-;                               :properties {:optional true}}}}}}}
+;; => {:type :map,
+;      :keys {:x {:order 0
+;                 :value {:type boolean?}},
+;             :y {:order 1, :value {:type int?}
+;                 :properties {:optional true}},
+;             :z {:order 2,
+;                 :value {:type :map,
+;                         :keys {:x {:order 0
+;                                    :value {:type boolean?}},
+;                                :y {:order 1
+;                                    :value {:type int?}
+;                                    :properties {:optional true}}}}}}}
 
 (-> ?schema
     (m/schema) ;; 3.4µs
@@ -2606,7 +2652,7 @@ Implemented with protocol `malli.core/AST`. Allows lossless round-robin with fas
     (m/from-ast) ;; 180ns (18x, lazy)
     (m/form)
     (= (m/form ?schema)))
-; => true
+;; => true
 ```
 
 ## Schema transformation
@@ -2656,17 +2702,17 @@ Transforming schemas into maps:
     (-> (m/properties schema)
         (assoc :malli/type (m/type schema))
         (cond-> (seq children) (assoc :malli/children children)))))
-;{:malli/type :map,
-; :malli/children [[:id nil {:malli/type string?}]
-;                  [:tags nil {:malli/type :set
-;                              :malli/children [{:malli/type keyword?}]}]
-;                  [:address nil {:malli/type :map,
-;                                 :malli/children [[:street nil {:malli/type string?}]
-;                                                  [:city nil {:malli/type string?}]
-;                                                  [:zip nil {:malli/type int?}]
-;                                                  [:lonlat nil {:malli/type :tuple
-;                                                                :malli/children [{:malli/type double?}
-;                                                                                 {:malli/type double?}]}]]}]]}
+;; => {:malli/type :map,
+;      :malli/children [[:id nil {:malli/type string?}]
+;                       [:tags nil {:malli/type :set
+;                                   :malli/children [{:malli/type keyword?}]}]
+;                       [:address nil {:malli/type :map,
+;                                      :malli/children [[:street nil {:malli/type string?}]
+;                                                       [:city nil {:malli/type string?}]
+;                                                       [:zip nil {:malli/type int?}]
+;                                                       [:lonlat nil {:malli/type :tuple
+;                                                                     :malli/children [{:malli/type double?}
+;                                                                                      {:malli/type double?}]}]]}]]}
 ```
 
 ### JSON Schema
@@ -2677,20 +2723,20 @@ Transforming Schemas into [JSON Schema](https://json-schema.org/):
 (require '[malli.json-schema :as json-schema])
 
 (json-schema/transform Address)
-;{:type "object",
-; :properties {:id {:type "string"},
-;              :tags {:type "array"
-;                     :items {:type "string"}
-;                     :uniqueItems true},
-;              :address {:type "object",
-;                        :properties {:street {:type "string"},
-;                                     :city {:type "string"},
-;                                     :zip {:type "integer", :format "int64"},
-;                                     :lonlat {:type "array",
-;                                              :items [{:type "number"} {:type "number"}],
-;                                              :additionalItems false}},
-;                        :required [:street :city :zip :lonlat]}},
-; :required [:id :tags :address]}
+;; => {:type "object",
+;      :properties {:id {:type "string"},
+;                   :tags {:type "array"
+;                          :items {:type "string"}
+;                          :uniqueItems true},
+;                   :address {:type "object",
+;                             :properties {:street {:type "string"},
+;                                          :city {:type "string"},
+;                                          :zip {:type "integer"},
+;                                          :lonlat {:type "array",
+;                                                   :prefixItems [{:type "number"} {:type "number"}],
+;                                                   :items false}},
+;                             :required [:street :city :zip :lonlat]}},
+;      :required [:id :tags :address]}
 ```
 
 Custom transformation via `:json-schema` namespaced properties:
@@ -2703,11 +2749,11 @@ Custom transformation via `:json-schema` namespaced properties:
     :json-schema/type "string"
     :json-schema/default "perch"}
    "perch" "pike"])
-;{:title "Fish"
-; :description "It's a fish"
-; :type "string"
-; :default "perch"
-; :enum ["perch" "pike"]}
+;; => {:title "Fish"
+;      :description "It's a fish"
+;      :type "string"
+;      :default "perch"
+;      :enum ["perch" "pike"]}
 ```
 
 Full override with `:json-schema` property:
@@ -2716,7 +2762,7 @@ Full override with `:json-schema` property:
 (json-schema/transform
   [:map {:json-schema {:type "file"}}
    [:file any?]])
-; {:type "file"}
+;; =>  {:type "file"}
 ```
 
 ### Swagger2
@@ -2727,21 +2773,21 @@ Transforming Schemas into [Swagger2 Schema](https://github.com/OAI/OpenAPI-Speci
 (require '[malli.swagger :as swagger])
 
 (swagger/transform Address)
-;{:type "object",
-; :properties {:id {:type "string"},
-;              :tags {:type "array"
-;                     :items {:type "string"}
-;                     :uniqueItems true},
-;              :address {:type "object",
-;                        :properties {:street {:type "string"},
-;                                     :city {:type "string"},
-;                                     :zip {:type "integer", :format "int64"},
-;                                     :lonlat {:type "array",
-;                                              :items {},
-;                                              :x-items [{:type "number", :format "double"}
-;                                                        {:type "number", :format "double"}]}},
-;                        :required [:street :city :zip :lonlat]}},
-; :required [:id :tags :address]}
+;; => {:type "object",
+;      :properties {:id {:type "string"},
+;                   :tags {:type "array"
+;                          :items {:type "string"}
+;                          :uniqueItems true},
+;                   :address {:type "object",
+;                             :properties {:street {:type "string"},
+;                                          :city {:type "string"},
+;                                          :zip {:type "integer", :format "int64"},
+;                                          :lonlat {:type "array",
+;                                                   :items {},
+;                                                   :x-items [{:type "number", :format "double"}
+;                                                             {:type "number", :format "double"}]}},
+;                             :required [:street :city :zip :lonlat]}},
+;      :required [:id :tags :address]}
 ```
 
 Custom transformation via `:swagger` and `:json-schema` namespaced properties:
@@ -2754,11 +2800,11 @@ Custom transformation via `:swagger` and `:json-schema` namespaced properties:
     :swagger/type "string"
     :json-schema/default "perch"}
    "perch" "pike"])
-;{:title "Fish"
-; :description "It's a fish"
-; :type "string"
-; :default "perch"
-; :enum ["perch" "pike"]}
+;; => {:title "Fish"
+;      :description "It's a fish"
+;      :type "string"
+;      :default "perch"
+;      :enum ["perch" "pike"]}
 ```
 
 Full override with `:swagger` property:
@@ -2767,7 +2813,7 @@ Full override with `:swagger` property:
 (swagger/transform
   [:map {:swagger {:type "file"}}
    [:file any?]])
-; {:type "file"}
+;; => {:type "file"}
 ```
 
 ## Custom schema types
@@ -2795,7 +2841,7 @@ For simple cases, there is `m/-simple-schema`:
                        :gen/gen (gen/large-integer* {:min 7})}}))
 
 (m/into-schema? Over6)
-; => true
+;; => true
 ```
 
 `m/IntoSchema` can be both used as Schema (creating a Schema instance with `nil` properties
@@ -2804,20 +2850,20 @@ register the types:
 
 ```clojure
 (m/schema? (m/schema Over6))
-; => true
+;; => true
 
 (m/schema? (m/schema [Over6 {:title "over 6"}]))
-; => true
+;; => true
 ```
 
 `:pred` is used for validation:
 
 ```clojure
 (m/validate Over6 2)
-; => false
+;; => false
 
 (m/validate Over6 7)
-; => true
+;; => true
 ```
 
 `:type-properties` are shared for all schema instances and are used just like Schema
@@ -2826,10 +2872,10 @@ register the types:
 
 ```clojure
 (json-schema/transform Over6)
-; => {:type "integer", :format "int64", :minimum 6}
+;; => {:type "integer", :format "int64", :minimum 6}
 
 (json-schema/transform [Over6 {:json-schema/example 42}])
-; => {:type "integer", :format "int64", :minimum 6, :example 42}
+;; => {:type "integer", :format "int64", :minimum 6, :example 42}
 ```
 
 ### Content dependent simple schema
@@ -2855,15 +2901,15 @@ You can also build content-dependent schemas by using a callback function `:comp
                                   :gen/gen (gen/large-integer* {:min (inc min), :max max})}})}))
 
 (m/form [Between 10 20])
-; => [user/Between 10 20]
+; [user/Between 10 20]
 
 (-> [Between 10 20]
     (m/explain 8)
     (me/humanize))
-; => ["should be between 10 and 20, was 8"]
+;; => ["should be between 10 and 20, was 8"]
 
 (mg/sample [Between -10 10])
-; => (-1 0 -2 -4 -4 0 -2 7 1 0)
+; (-1 0 -2 -4 -4 0 -2 7 1 0)
 ```
 
 ## Schema registry
@@ -2875,11 +2921,11 @@ Custom `Registry` can be passed into all/most malli public APIs via the optional
 ```clojure
 ;; the default registry
 (m/validate [:maybe string?] "kikka")
-; => true
+;; => true
 
 ;; registry as explicit options
 (m/validate [:maybe string?] "kikka" {:registry m/default-registry})
-; => true
+;; => true
 ```
 
 The default immutable registry is merged from multiple parts, enabling easy re-composition of custom schema sets. See [built-in schemas](#built-in-schemas) for list of all Schemas.
@@ -2898,14 +2944,15 @@ Here's an example to create a custom registry without the default core predicate
      :pos-int (m/-simple-schema {:type :pos-int, :pred pos-int?})}))
 
 (m/validate [:or :pos-int :neg-int] 'kikka {:registry registry})
-; => false
+;; => false
 
 (m/validate [:or :pos-int :neg-int] 123 {:registry registry})
-; => true
+;; => true
 ```
 
 We did not register normal predicate schemas:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/validate pos-int? 123 {:registry registry})
 ; Syntax error (ExceptionInfo) compiling
@@ -2922,7 +2969,7 @@ Any schema can define a local registry using `:registry` schema property:
    [:age ::age]])
 
 (mg/generate Adult {:size 10, :seed 1})
-; => {:age 92}
+; {:age 92}
 ```
 
 Local registries can be persisted:
@@ -2932,7 +2979,7 @@ Local registries can be persisted:
     (malli.edn/write-string)
     (malli.edn/read-string)
     (m/validate {:age 46}))
-; => true
+;; => true
 ```
 
 See also [Recursive Schemas](#recursive-schemas).
@@ -2946,7 +2993,7 @@ Passing in custom options to all public methods is a lot of boilerplate. For the
 
 ;; the default registry
 (-> m/default-registry (mr/schemas) (count))
-;=> 140
+; 147
 
 ;; global side-effects! free since 0.7.0!
 (mr/set-default-registry!
@@ -2955,13 +3002,17 @@ Passing in custom options to all public methods is a lot of boilerplate. For the
    :map (m/-map-schema)})
 
 (-> m/default-registry (mr/schemas) (count))
-; => 3
+;; => 3
 
 (m/validate
   [:map [:maybe [:maybe :string]]]
   {:maybe "sheep"})
-; => true
+;; => true
+```
+Invalid values throw:
 
+<!-- :test-doc-blocks/skip -->
+```clojure
 (m/validate :int 42)
 ; =throws=> :malli.core/invalid-schema {:schema :int}
 ```
@@ -2978,6 +3029,7 @@ Malli allows the default registry to initialized with empty schemas, using the f
    * cljs: `:closure-defines {malli.registry/type "custom"}`
    * clj: `:jvm-opts ["-Dmalli.registry/type=custom"]`
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; with the flag set on
 (-> m/default-registry (mr/schemas) (count))
@@ -3005,12 +3057,13 @@ Just a `Map`.
 (m/validate
   [:map [:maybe [:maybe :string]]]
   {:maybe "sheep"})
-; => true
+;; => true
 ```
 ### Var registry
 
 Var is a valid reference type in Malli. To support auto-resolving Var references to Vars, `mr/var-registry` is needed. It is enabled by default.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def UserId :string)
 
@@ -3053,7 +3106,7 @@ Using a custom registry atom:
 (register! :non-empty-string [:string {:min 1}])
 
 (m/validate :non-empty-string "malli")
-; => true
+;; => true
 ```
 
 The mutable registry can also be passed in as an explicit option:
@@ -3062,7 +3115,7 @@ The mutable registry can also be passed in as an explicit option:
 (def registry (mr/mutable-registry registry*))
 
 (m/validate :non-empty-string "malli" {:registry registry})
-; => true
+;; => true
 ```
 
 ### Dynamic registry
@@ -3078,7 +3131,7 @@ If you know what you are doing, you can also use [dynamic scope](https://stuarts
                          :map (m/-map-schema)
                          :non-empty-string [:string {:min 1}]}]
   (m/validate :non-empty-string "malli"))
-; => true
+;; => true
 ```
 
 ### Lazy registries
@@ -3115,13 +3168,13 @@ You can provide schemas at runtime using `mr/lazy-registry` - it takes a local r
   {:Type "AWS::ApiGateway::UsagePlan"
    :Description "laiskanlinna"})
 ; ... loaded AWS::ApiGateway::UsagePlan
-; => true
+;; => true
 
 (m/validate
   CloudFormation
   {:Type "AWS::ApiGateway::UsagePlan"
    :Description "laiskanlinna"})
-; => true
+;; => true
 ```
 
 ### Composite registry
@@ -3155,7 +3208,7 @@ Registries can be composed, a full example:
   (m/validate
     [:map [:maybe [:maybe :string]]]
     {:maybe "sheep"}))
-; => true
+;; => true
 ```
 
 ## Function schemas
@@ -3172,6 +3225,7 @@ See [Instrumentation](docs/function-schemas.md#instrumentation).
 
 Given functions and function Schemas:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (defn square [x] (* x x))
 (m/=> square [:=> [:cat int?] nat-int?])
@@ -3187,6 +3241,7 @@ Given functions and function Schemas:
 
 Generating `clj-kondo` configuration from current namespace:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.clj-kondo :as mc])
 
@@ -3205,6 +3260,7 @@ Generating `clj-kondo` configuration from current namespace:
 
 Emitting confing into `./.clj-kondo/configs/malli/config.edn`:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (mc/emit!)
 ```
@@ -3223,6 +3279,7 @@ schema syntax to statically type check and infer Clojure code.
 See this in action in the [malli-type-providers](https://github.com/typedclojure/typedclojure/tree/main/example-projects/malli-type-providers)
 example project.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (ns typed-example.malli-type-providers
   (:require [typed.clojure :as t]
@@ -3244,6 +3301,7 @@ example project.
 
 Transforming Schemas into [DOT Language](https://en.wikipedia.org/wiki/DOT_(graph_description_language) ):
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.dot :as md])
 
@@ -3282,6 +3340,7 @@ Visualized with [Graphviz](https://graphviz.org/):
 
 Transforming Schemas into [PlantUML](https://plantuml.com/):
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.plantuml :as plantuml])
 
@@ -3299,6 +3358,7 @@ Simple syntax sugar, like [data-specs](https://cljdoc.org/d/metosin/spec-tools/C
 
 As the namespace suggests, it's experimental, built for [reitit](https://github.com/metosin/reitit).
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.experimental.lite :as l])
 
@@ -3329,6 +3389,7 @@ As the namespace suggests, it's experimental, built for [reitit](https://github.
 
 Options can be used by binding a dynamic `l/*options*` Var:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (binding [l/*options* {:registry (merge
                                   (m/default-schemas)
@@ -3348,6 +3409,7 @@ Malli tries to be really, really fast.
 
 Usually as fast (or faster) as idiomatic Clojure.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[criterium.core :as cc])
 
@@ -3375,6 +3437,7 @@ Usually as fast (or faster) as idiomatic Clojure.
 
 Same with Clojure Spec and Plumatic Schema:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[clojure.spec.alpha :as spec])
 (require '[schema.core :as schema])
@@ -3401,6 +3464,7 @@ Same with Clojure Spec and Plumatic Schema:
 
 Usually faster than idiomatic Clojure.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def data {:x "true", :y "1", :z "kikka"})
 (def expected {:x true, :y 1, :z "kikka"})
@@ -3425,6 +3489,7 @@ Usually faster than idiomatic Clojure.
 
 Same with Clojure Spec and Plumatic Schema:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[spec-tools.core :as st])
 (require '[schema.coerce :as sc])
@@ -3450,6 +3515,7 @@ Same with Clojure Spec and Plumatic Schema:
 
 The transformation engine is smart enough to just transform parts of the schema that need to be transformed. If there is nothing to transform, `identity` function is returned.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def json->user
   (m/decoder
@@ -3477,6 +3543,7 @@ The transformation engine is smart enough to just transform parts of the schema 
 
 ### Parsing performance
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; 37µs
 (let [spec (s/* (s/cat :prop string?,
@@ -3557,7 +3624,6 @@ The following schemas and their respective types are provided:
 To use these schemas, add the schemas provided by `(malli.experimental.time/schemas)` to your registry.
 
 Using time-schemas to default registry:
-
 ```clj
 (require '[malli.experimental.time :as met])
 
@@ -3579,6 +3645,7 @@ to make use of zone related time objects.
 
 For example, to include only timezone data for +/- 5 years from the time the library was released, use:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (ns com.my-co.my-app
   (:require ["@js-joda/timezone/dist/js-joda-timezone-10-year-range"]))
@@ -3592,6 +3659,7 @@ https://github.com/js-joda/js-joda/tree/main/packages/timezone
 
 Time schemas respect min/max predicates for their respective types:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (import (java.time LocalTime))
 
@@ -3623,7 +3691,7 @@ Formats can be configured by providing a `formatter` or a `pattern` property
   (m/decode [:time/local-date {:pattern "yyyyMMdd"}] $ (mett/time-transformer))
   (m/encode [:time/local-date {:pattern "yyyy_MM_dd"}] $ (mett/time-transformer))
   (= "2020_01_01" $))
-; => true
+;; => true
 ```
 
 #### Generators - `malli.experimental.time.generator`
@@ -3635,6 +3703,7 @@ Generated data also respects min/max properties.
 When generating `Period`s there is no way distinguish between `nil` values and zero for each unit, so zero units will
 not constrain the generator, if you need some of the units to be zero in generated `Period`s you can always `gen/fmap` the data:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 [:time/period {:gen/fmap #(. % withMonths 0) :min (. Period of -10 0 1)}]
 ```
@@ -3792,12 +3861,14 @@ a native, fast starting Clojure interpreter for scripting.
 
 You can add malli to `bb.edn`:
 
+<!-- :test-doc-blocks/skip -->
 ``` clojure
 {:deps {metosin/malli {:mvn/version "0.9.0"}}}
 ```
 
 or directly in a babashka script:
 
+<!-- :test-doc-blocks/skip -->
 ``` clojure
 (ns bb-malli
   (:require [babashka.deps :as deps]))

--- a/README.md
+++ b/README.md
@@ -1768,14 +1768,14 @@ Schema paths can be converted into value paths:
 ; [:tuple double? double?]
 
 (mu/path->in Schema [0 :address 0 :lonlat])
-; [:address :lonlat]
+;; => [:address :lonlat]
 ```
 
 and back, returning all paths:
 
 ```clojure
 (mu/in->paths Schema [:address :lonlat])
-; [[0 :address 0 :lonlat]]
+;; => [[0 :address 0 :lonlat]]
 ```
 
 ## Declarative schema transformation

--- a/bb.edn
+++ b/bb.edn
@@ -41,4 +41,4 @@
                      (println "Generating tests from README.md")
                      (clojure "-X:test-doc-blocks")
                      (println "Running tests")
-                     (clojure "-M:test:test-doc-test" "-m" "kaocha.runner" "--config-file" "gen-tests.edn" "generated"))}}}
+                     (clojure "-M:test:test-doc-test" "-m" "kaocha.runner" "--config-file" "test-doc-tests.edn" "generated"))}}}

--- a/bb.edn
+++ b/bb.edn
@@ -34,4 +34,11 @@
            :extra-deps {org.babashka/spec.alpha {:git/url "https://github.com/babashka/spec.alpha"
                                                  :git/sha "b6eb0f2208ab036c0a5d0e7235cb0b09d2feabb7"}}
            :extra-paths ["src" "test"]
-           :task bb-test-runner/run-tests}}}
+           :task bb-test-runner/run-tests}
+
+  test-docs {:doc "Run README.md based tests"
+             :task (do
+                     (println "Generating tests from README.md")
+                     (clojure "-X:test-doc-blocks")
+                     (println "Running tests")
+                     (clojure "-M:test:test-doc-test" "-m" "kaocha.runner" "--config-file" "gen-tests.edn" "generated"))}}}

--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
                          :main-opts ["-m" "cljs-test-runner.main" "-d" "test-cherry" "-d" "test"]}
            :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}
                                             mattiuusitalo/test-doc-blocks {:git/url "https://github.com/mattiuusitalo/test-doc-blocks"
-                                                                           :git/sha "62bdc9caecd9c44b71c23f1718370fda05b18eb2"}
+                                                                           :git/sha "2edd731c1dfeb83a8f72d3b0ebdb011f79593e6f"}
 
                                             #_#_com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
                              ;; for -X syntax support specify exec-fn

--- a/deps.edn
+++ b/deps.edn
@@ -40,7 +40,7 @@
                              :exec-fn lread.test-doc-blocks/gen-tests
                              ;; for -M syntax support specify main-opts
                              :main-opts ["-m" "lread.test-doc-blocks" "gen-tests"]}
-           :test-doc-test {:replace-paths ["target/test-doc-blocks/test"]}
+           :test-doc-test {:replace-paths ["src" "resources" "target/test-doc-blocks/test"]}
            :cljs-test-runner {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.1"}
                                         ; used only to pull in its externs file needed to compile js-joda types under advanced compilation
                                            com.widdindustries/cljs.java-time {:mvn/version "0.1.20"}}

--- a/deps.edn
+++ b/deps.edn
@@ -43,6 +43,7 @@
                              :exec-fn lread.test-doc-blocks/gen-tests
                              :exec-args {:docs ["README.md"
                                                 "docs/function-schemas.md"
+                                                "docs/reusable-schemas.md"
                                                 "docs/tips.md"]}
                              ;; for -M syntax support specify main-opts
                              :main-opts ["-m" "lread.test-doc-blocks" "gen-tests"]}

--- a/deps.edn
+++ b/deps.edn
@@ -35,10 +35,7 @@
            :test-cherry {:extra-paths ["test-cherry"]
                          :main-opts ["-m" "cljs-test-runner.main" "-d" "test-cherry" "-d" "test"]}
            :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}
-                                            mattiuusitalo/test-doc-blocks {:git/url "https://github.com/mattiuusitalo/test-doc-blocks"
-                                                                           :git/sha "2edd731c1dfeb83a8f72d3b0ebdb011f79593e6f"}
-
-                                            #_#_com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
+                                            com.github.lread/test-doc-blocks {:mvn/version "1.2.21"}}
                              ;; for -X syntax support specify exec-fn
                              :exec-fn lread.test-doc-blocks/gen-tests
                              :exec-args {:docs ["README.md"

--- a/deps.edn
+++ b/deps.edn
@@ -41,7 +41,9 @@
                                             #_#_com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
                              ;; for -X syntax support specify exec-fn
                              :exec-fn lread.test-doc-blocks/gen-tests
-                             :exec-args {:docs ["README.md" "docs/tips.md"]}
+                             :exec-args {:docs ["README.md"
+                                                "docs/function-schemas.md"
+                                                "docs/tips.md"]}
                              ;; for -M syntax support specify main-opts
                              :main-opts ["-m" "lread.test-doc-blocks" "gen-tests"]}
            :test-doc-test {:replace-paths ["src" "resources" "target/test-doc-blocks/test"]}

--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
                          :main-opts ["-m" "cljs-test-runner.main" "-d" "test-cherry" "-d" "test"]}
            :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}
                                             mattiuusitalo/test-doc-blocks {:git/url "https://github.com/mattiuusitalo/test-doc-blocks"
-                                                                           :git/sha "3cdb0058a8633aee32b461ebf5da2bcadf2050e3"}
+                                                                           :git/sha "62bdc9caecd9c44b71c23f1718370fda05b18eb2"}
 
                                             #_#_com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
                              ;; for -X syntax support specify exec-fn

--- a/deps.edn
+++ b/deps.edn
@@ -34,8 +34,15 @@
                       :main-opts ["-m" "cljs-test-runner.main" "-d" "test-sci" "-d" "test"]}
            :test-cherry {:extra-paths ["test-cherry"]
                          :main-opts ["-m" "cljs-test-runner.main" "-d" "test-cherry" "-d" "test"]}
+           :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}
+                                            com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
+                             ;; for -X syntax support specify exec-fn
+                             :exec-fn lread.test-doc-blocks/gen-tests
+                             ;; for -M syntax support specify main-opts
+                             :main-opts ["-m" "lread.test-doc-blocks" "gen-tests"]}
+           :test-doc-test {:replace-paths ["target/test-doc-blocks/test"]}
            :cljs-test-runner {:extra-deps {olical/cljs-test-runner {:mvn/version "3.8.1"}
-                                           ; used only to pull in its externs file needed to compile js-joda types under advanced compilation
+                                        ; used only to pull in its externs file needed to compile js-joda types under advanced compilation
                                            com.widdindustries/cljs.java-time {:mvn/version "0.1.20"}}
                               :extra-paths ["test" "cljs-test-runner-out/gen"]
                               :main-opts ["-m" "cljs-test-runner.main" "-d" "test"]}

--- a/deps.edn
+++ b/deps.edn
@@ -35,7 +35,10 @@
            :test-cherry {:extra-paths ["test-cherry"]
                          :main-opts ["-m" "cljs-test-runner.main" "-d" "test-cherry" "-d" "test"]}
            :test-doc-blocks {:replace-deps {org.clojure/clojure {:mvn/version "1.12.0"}
-                                            com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
+                                            mattiuusitalo/test-doc-blocks {:git/url "https://github.com/mattiuusitalo/test-doc-blocks"
+                                                                           :git/sha "3cdb0058a8633aee32b461ebf5da2bcadf2050e3"}
+
+                                            #_#_com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
                              ;; for -X syntax support specify exec-fn
                              :exec-fn lread.test-doc-blocks/gen-tests
                              ;; for -M syntax support specify main-opts

--- a/deps.edn
+++ b/deps.edn
@@ -41,6 +41,7 @@
                                             #_#_com.github.lread/test-doc-blocks {:mvn/version "1.1.20"}}
                              ;; for -X syntax support specify exec-fn
                              :exec-fn lread.test-doc-blocks/gen-tests
+                             :exec-args {:docs ["README.md" "docs/tips.md"]}
                              ;; for -M syntax support specify main-opts
                              :main-opts ["-m" "lread.test-doc-blocks" "gen-tests"]}
            :test-doc-test {:replace-paths ["src" "resources" "target/test-doc-blocks/test"]}

--- a/docs/function-schemas.md
+++ b/docs/function-schemas.md
@@ -30,9 +30,9 @@ In Clojure, functions are first-class. Here's a simple function:
 ```clojure
 (defn plus [x y]
   (+ x y))
-  
+
 (plus 1 2)
-; => 3
+;; => 3
 ```
 
 ## Predicate Schemas
@@ -43,20 +43,20 @@ Simplest way to describe function values with malli is to use predefined predica
 (require '[malli.core :as m])
 
 (m/validate fn? plus)
-; => true
+;; => true
 
 (m/validate ifn? plus)
-; => true
+;; => true
 ```
 
 Note that `ifn?` also accepts many data-structures that can be used as functions:
 
 ```clojure
 (m/validate ifn? :kikka)
-; => true
+;; => true
 
 (m/validate ifn? {})
-; => true
+;; => true
 ```
 
 But, neither of the predefined function predicate schemas can validate function arity, function arguments or return values. As it stands, [there is no robust way to programmatically check function arity at runtime](https://stackoverflow.com/questions/1696693/clojure-how-to-find-out-the-arity-of-function-at-runtime).
@@ -77,8 +77,8 @@ Examples of function definitions:
 [:=> [:cat :int] :int]
 
 ;; x:int, xs:int* -> int
-[:=> [:catn 
-      [:x :int] 
+[:=> [:catn
+      [:x :int]
       [:xs [:+ :int]]] :int]
 
 ;; arg:int -> ret:int, arg > ret
@@ -90,7 +90,7 @@ Examples of function definitions:
 ;; multi-arity function
 [:function
  [:=> [:cat :int] :int]
- [:=> [:cat :int :int [:* :int]] :int]]      
+ [:=> [:cat :int :int [:* :int]] :int]]
 ```
 
 What is that `:cat` all about in the input schemas? Wouldn't it be simpler without it? Sure, check out [Flat Arrow Function Schema](#flat-arrow-function-schemas).
@@ -105,14 +105,14 @@ Let's try:
 
 ```clojure
 (m/validate =>plus plus)
-; => true
+;; => true
 ```
 
 But, wait, as there was no way to know the function arity & other information at runtime, so how did the validation work? Actually, it didn't. By default. `:=>` validation just checks that it's a `fn?`, so this holds too:
 
 ```clojure
 (m/validate =>plus str)
-; => true
+;; => true
 ```
 Bummer.
 
@@ -125,16 +125,16 @@ Like [clojure.spec](https://clojure.org/about/spec) demonstrated, we can use [te
 ```clojure
 (require '[malli.generator :as mg])
 
-(def =>plus 
-  (m/schema 
-    [:=> [:cat :int :int] :int] 
+(def =>plus
+  (m/schema
+    [:=> [:cat :int :int] :int]
     {::m/function-checker mg/function-checker}))
 
 (m/validate =>plus plus)
-; => true
+;; => true
 
 (m/validate =>plus str)
-; => false
+;; => false
 ```
 
 Explanation why it is not valid:
@@ -183,7 +183,7 @@ But, why `mg/function-checker` is not enabled by default? The reason is that it 
    {::m/function-checker mg/function-checker}))
 
 (m/explain arg<ret (fn [x] (inc x)))
-; nil
+;; => nil
 
 (m/explain arg<ret (fn [x] x))
 ;{:schema ...
@@ -207,6 +207,7 @@ But, why `mg/function-checker` is not enabled by default? The reason is that it 
 ;                    (fn [[[arg] ret]] (< arg ret))],
 ;           :value [(0) 0]})}
 
+(require '[malli.error :as me])
 (me/humanize *1)
 ; ["invalid function" "argument should be less than return"]
 ```
@@ -229,6 +230,7 @@ Identical schema using the Schema AST syntax:
 
 We can also generate function implementations based on the function schemas. The generated functions check the function arity and arguments at runtime and return generated values.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def plus-gen (mg/generate =>plus))
 
@@ -246,6 +248,7 @@ We can also generate function implementations based on the function schemas. The
 
 Multi-arity functions can be composed with `:function`:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; multi-arity fn with function checking always on
 (def =>my-fn
@@ -303,6 +306,7 @@ Multi-arity functions can be composed with `:function`:
 
 Generating multi-arity functions:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def my-fn-gen (mg/generate =>my-fn))
 
@@ -334,6 +338,7 @@ Simplest way to do this is to use `m/-instrument` which takes an options map and
 
 Instrumenting a function with input & return constraints:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def pow
   (m/-instrument
@@ -368,17 +373,18 @@ Example of a multi-arity function with instrumentation scopes and custom reporti
       ([x y] (* x y)))))
 
 (multi-arity-pow 4)
-; =prints=> :malli.core/invalid-output {:output [:int {:max 6}], :value 16, :args [4], :schema [:=> [:cat :int] [:int {:max 6}]]}
-; => 16
+;; =stdout=> :malli.core/invalid-output {:output [:int {:max 6}], :value 16, :args [4], :schema [:=> [:cat :int] [:int {:max 6}]]}
+;; => 16
 
 (multi-arity-pow 5 0.1)
-; =prints=> :malli.core/invalid-input {:input [:cat :int :int], :args [5 0.1], :schema [:=> [:cat :int :int] [:int {:max 6}]]}
-; =prints=> :malli.core/invalid-output {:output [:int {:max 6}], :value 0.5, :args [5 0.1], :schema [:=> [:cat :int :int] [:int {:max 6}]]}
-; => 0.5
+;; =stdout=> :malli.core/invalid-input {:input [:cat :int :int], :args [5 0.1], :schema [:=> [:cat :int :int] [:int {:max 6}]]}
+;; :malli.core/invalid-output {:output [:int {:max 6}], :value 0.5, :args [5 0.1], :schema [:=> [:cat :int :int] [:int {:max 6}]]}
+;; => 0.5
 ```
 
 With `:gen` we can omit the function body. Here's an example to generate random values based on the return schema:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (def pow-gen
   (m/-instrument
@@ -409,7 +415,7 @@ Function schema `:=>` requires input arguments to be wrapped in `:cat` or `:catn
 [:-> :int :int]
 
 ;; arg:int -> ret:int, arg > ret
-(defn guard [[arg] ret] 
+(defn guard [[arg] ret]
   (> arg ret))
 
 [:-> {:guard guard} :int :int]
@@ -472,7 +478,7 @@ There are three ways to add function schemas to function Vars (e.g. `defn`s):
 
 (defn plus1 [x] (inc x))
 (m/=> plus1 [:=> [:cat :int] small-int])
-``` 
+```
 
 The order doesn't matter, so this also works:
 
@@ -494,16 +500,17 @@ Without instrumentation turned on, there is no schema enforcement:
 
 ```clojure
 (plus1 10)
-; => 11
+;; => 11
 ```
 
 Turning instrumentation on:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (require '[malli.instrument :as mi])
 
 (mi/instrument!)
-; =prints=> ..instrumented #'user/plus1
+; =stdout=> ..instrumented #'user/plus1
 
 (plus1 10)
 ; =throws=> :malli.core/invalid-output {:output [:int {:max 6}], :value 11, :args [10], :schema [:=> [:cat :int] [:int {:max 6}]]}
@@ -540,10 +547,11 @@ To collect instrumentation for the `defn`, we need to call `mi/collect!`. It rea
 
 We'll also have to reinstrument the new var:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (mi/instrument!)
-; =prints=> ..instrumented #'user/plus1
-; =prints=> ..instrumented #'user/minus
+; =stdout=> ..instrumented #'user/plus1
+; =stdout=> ..instrumented #'user/minus
 
 (minus 6)
 ; =throws=> :malli.core/invalid-output {:output [:int {:min 6}], :value 5, :args [6], :schema [:=> [:cat :int] [:int {:min 6}]]}
@@ -591,16 +599,17 @@ Function schema is registered automatically:
 
 ```clojure
 (times 10 10)
-; => 100
+;; => 100
 ```
 
 You can enable instrumentation with `mi/instrument!`:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (mi/instrument!)
-; =prints=> ..instrumented #'user/plus1
-; =prints=> ..instrumented #'user/minus
-; =prints=> ..instrumented #'user/times
+; =stdout=> ..instrumented #'user/plus1
+; =stdout=> ..instrumented #'user/minus
+; =stdout=> ..instrumented #'user/times
 
 (times 10 10)
 ; =throws=> :malli.core/invalid-input {:input [:cat :int [:int {:max 6}]], :args [10 10], :schema [:=> [:cat :int [:int {:max 6}]] :int]}
@@ -614,7 +623,7 @@ You can enable instrumentation with `mi/instrument!`:
   [x :- :int, y :- small-int]
   (* x y))
 ```
-
+<!-- :test-doc-blocks/skip -->
 ```clojure
 user=> (times 10 5)
 50
@@ -633,6 +642,7 @@ The function (Var) registry is passive and doesn't do anything by itself. To ins
 
 Vars can be instrumented with `mi/instrument!` and the instrumentation can be removed with `mi/unstrument!`.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/=> power [:=> [:cat :int] [:int {:max 6}]])
 (defn power [x] (* x x))
@@ -653,7 +663,7 @@ Vars can be instrumented with `mi/instrument!` and the instrumentation can be re
 ```
 
 Instrumentation can be configured with the same options as `m/-instrument` and with a set of `:filters` to select which Vars should be instrumented.
-
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (mi/instrument!
  {:filters [;; everything from user ns
@@ -668,13 +678,13 @@ Instrumentation can be configured with the same options as `m/-instrument` and w
   :report println})
 
 (power 6)
-; =prints=> :malli.core/invalid-output {:output [:int {:max 6}], :value 36, :args [6], :schema [:=> [:cat :int] [:int {:max 6}]]}
+; =stdout=> :malli.core/invalid-output {:output [:int {:max 6}], :value 36, :args [6], :schema [:=> [:cat :int] [:int {:max 6}]]}
 ; => 36
 ```
 
 ### Defn Checking
 
-We can also check the defn schemas against their function implementations using `mi/check`. It takes same options as `mi/instrument!`. 
+We can also check the defn schemas against their function implementations using `mi/check`. It takes same options as `mi/instrument!`.
 
 Checking all registered schemas:
 
@@ -702,7 +712,7 @@ Checking all registered schemas:
 ```
 
 It reports that the `plus1` is not correct. It accepts `:int` but promises to return `[:int {:max 6}]`. Let's fix the contract by constraining the input values.
-
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/=> plus1 [:=> [:cat [:int {:max 5}]] [:int {:max 6}]])
 
@@ -714,8 +724,9 @@ All good! But, it's still wrong as the actual implementation allows invalid inpu
 
 A pragmatically correct schema for `plus1` would be `[:=> [:cat :int] [:int]]`. It also checks, but would fail on `Long/MAX_VALUE` as input. Fully correct schema would be `[:=> [:cat [:int {:max (dec Long/MAX_VALUE)}] [:int]]]`. Generative testing is best effort, not a silver bullet.
 
-We redefined `plus1` function schema and the instrumentation is now out of sync. We have to call `mi/instrument!` to re-instrument it correctly. 
+We redefined `plus1` function schema and the instrumentation is now out of sync. We have to call `mi/instrument!` to re-instrument it correctly.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 ;; the old schema & old error
 (plus1 6)
@@ -728,13 +739,13 @@ We redefined `plus1` function schema and the instrumentation is now out of sync.
 ; =throws=> :malli.core/invalid-input {:input [:cat [:int {:max 5}]], :args [6], :schema [:=> [:cat [:int {:max 5}]] [:int {:max 6}]]}
 ```
 
-This is not good developer experience. 
+This is not good developer experience.
 
 We can do much better.
 
 ## Development Instrumentation
 
-For better DX, there is `malli.dev` namespace. 
+For better DX, there is `malli.dev` namespace.
 
 ```clojure
 (require '[malli.dev :as dev])
@@ -742,6 +753,7 @@ For better DX, there is `malli.dev` namespace.
 
 It's main entry points is `dev/start!`, taking same options as `mi/instrument!`. It runs `mi/instrument!` and `mi/collect!` (for all loaded namespaces) once and starts watching the function registry for changes. Any change that matches the filters will cause automatic re-instrumentation for the functions. `dev/stop!` removes all instrumentation and stops watching the registry.
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (defn plus1 [x] (inc x))
 (m/=> plus1 [:=> [:cat :int] [:int {:max 6}]])
@@ -757,7 +769,7 @@ It's main entry points is `dev/start!`, taking same options as `mi/instrument!`.
 ; =throws=> :malli.core/invalid-output {:output [:int {:max 6}], :value 9, :args [8], :schema [:=> [:cat :int] [:int {:max 6}]]}
 
 (m/=> plus1 [:=> [:cat :int] :int])
-; =prints=> ..instrumented #'user/plus1
+; =stdout=> ..instrumented #'user/plus1
 
 (plus 6)
 ; => 7
@@ -787,6 +799,7 @@ For prettier runtime error messages, we can swap the default error printer / thr
 (require '[malli.dev.pretty :as pretty])
 ```
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (defn plus1 [x] (inc x))
 (m/=> plus1 [:=> [:cat :int] [:int {:max 6}]])
@@ -794,30 +807,30 @@ For prettier runtime error messages, we can swap the default error printer / thr
 (dev/start! {:report (pretty/reporter)})
 
 (plus1 "2")
-; =prints=>
+; =stdout=>
 ; -- Schema Error ----------------------------------- malli.demo:13 --
-; 
+;
 ; Invalid function arguments:
-; 
+;
 ;   ["2"]
-; 
+;
 ; Input Schema:
-; 
+;
 ;   [:cat :int]
-; 
+;
 ; Errors:
-; 
+;
 ;   {:in [0],
 ;    :message "should be an integer",
 ;    :path [0],
 ;    :schema :int,
 ;    :type nil,
 ;    :value "2"}
-; 
+;
 ; More information:
-; 
+;
 ;   https://cljdoc.org/d/metosin/malli/LATEST/doc/function-schemas
-; 
+;
 ; --------------------------------------------------------------------
 ; =throws=> Execution error (ClassCastException) at malli.demo/plus1 (demo.cljc:13).
 ;           java.lang.String cannot be cast to java.lang.Number
@@ -842,6 +855,7 @@ Pretty printer uses [fipp](https://github.com/brandonbloom/fipp) under the hood 
 
 Example of annotating function with var meta-data and using `malli.dev` for dev-time function instrumentation, pretty runtime exceptions and clj-kondo for static checking:
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (ns malli.demo)
 

--- a/docs/reusable-schemas.md
+++ b/docs/reusable-schemas.md
@@ -33,7 +33,7 @@ We can define Schemas using `def`:
              :lonlat [61.5014816, 23.7678986]}})
 
 (m/validate User user)
-; => true
+;; => true
 ```
 
 All subschemas as inlined as values:
@@ -81,7 +81,7 @@ Registering Schemas:
                    [:address ::address]])
 
 (m/validate ::user user)
-; => true
+;; => true
 ```
 
 By default, reference keys are used instead of values:
@@ -98,8 +98,8 @@ We can recursively deref the Schema to get the values:
 ;[:map
 ; [:id :uuid]
 ; [:name :string]
-; [:address [:map 
-;            [:street :string] 
+; [:address [:map
+;            [:street :string]
 ;            [:lonlat [:tuple :double :double]]]]]
 ```
 
@@ -123,8 +123,8 @@ Clojure Spec declared [map specs should be of keysets only](https://clojure.org/
 ;[:map
 ; [:user/id :uuid]
 ; [:user/name :string]
-; [:user/address [:map 
-;                 [:user/street :string] 
+; [:user/address [:map
+;                 [:user/street :string]
 ;                 [:user/latlon [:tuple :double :double]]]]]
 
 ;; data has a different shape now
@@ -132,7 +132,7 @@ Clojure Spec declared [map specs should be of keysets only](https://clojure.org/
                     ::name "Maija"
                     ::address {::street "Kuninkaankatu 13"
                                ::latlon [61.5014816, 23.7678986]}})
-; => true
+;; => true
 ```
 
 ## Schemas via Local Registries
@@ -165,13 +165,13 @@ Using registry via options:
 ```
 
 Works with both:
-
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (m/deref-recursive *1)
 ;[:map
 ; [:id :uuid]
 ; [:name :string]
-; [:address [:map 
+; [:address [:map
 ;            [:street :string]
 ;            [:lonlat [:tuple :double :double]]]]]
 ```
@@ -187,7 +187,7 @@ Here's a comparison matrix of the two different ways:
 | Support Recursive Schemas        |  ✅   |        ✅        |       ✅        |
 | Decomplect Maps, Keys and Values |  ❌   |        ✅        |       ✅        |
 
-You should pick the way what works best for your project. 
+You should pick the way what works best for your project.
 
 [My](https://gist.github.com/ikitommi) personal preference is the Var-style - it's simple and Plumatic proved it works well even with large codebases.
 
@@ -196,6 +196,7 @@ You should pick the way what works best for your project.
 1. Could we also decomplect the Maps, Keys and Values with the Var Style?
 2. Utilities for transforming between inlined and referenced models (why? why not!)
 
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (-flatten-refs
  [:schema {:registry {::user-id :uuid
@@ -225,4 +226,3 @@ You should pick the way what works best for your project.
 ;                             [:address ::address]]}}
 ; ::user]
 ```
-

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -43,7 +43,7 @@
 ;["Ahlmanintie 29" :string]
 ;["Tampere" [:malli.core/val :string]]
 ;["Tampere" :string]
-; => {:id "Lillan", :tags #{:coffee :artesan :hotel}, :address {:street "Ahlmanintie 29", :city "Tampere"}}
+;; => {:id "Lillan", :tags #{:coffee :artesan :hotel}, :address {:street "Ahlmanintie 29", :city "Tampere"}}
 ```
 
 ## Removing Schemas based on a property
@@ -64,7 +64,7 @@ Schemas can be walked over recursively using `m/walk`:
 (m/walk
   Schema
   (fn [schema _ children options]
-    ;; return nil if Schema has the property 
+    ;; return nil if Schema has the property
     (when-not (:deleteMe (m/properties schema))
       ;; there are two syntaxes: normal and the entry, handle separately
       (let [children (if (m/entries schema) (filterv last children) children)]
@@ -72,8 +72,8 @@ Schemas can be walked over recursively using `m/walk`:
         (try (m/into-schema (m/type schema) (m/properties schema) children options)
              (catch #?(:clj Exception, :cljs js/Error) _))))))
 ;[:map
-; [:user map?] 
-; [:profile map?] 
+; [:user map?]
+; [:profile map?]
 ; [:nested :map]]
 ```
 
@@ -99,11 +99,11 @@ Example how to trim all `:string` values using a custom transformer:
 
 ;; trim me please
 (m/decode [:string {:string/trim true, :min 1}] " kikka  " string-trimmer)
-; => "kikka"
+;; => "kikka"
 
 ;; no trimming
 (m/decode [:string {:min 1}] "    " string-trimmer)
-; => "    "
+;; => "    "
 
 ;; without :string/trim, decoding is a no-op
 (m/decoder :string string-trimmer)
@@ -119,11 +119,11 @@ Transforming a comma-separated string into a vector of ints:
 (require '[malli.transform :as mt])
 (require '[clojure.string :as str])
 
-(m/decode 
-  [:vector {:decode/string #(str/split % #",")} int?] 
-  "1,2,3,4" 
+(m/decode
+  [:vector {:decode/string #(str/split % #",")} int?]
+  "1,2,3,4"
   (mt/string-transformer))
-; => [1 2 3 4]
+;; => [1 2 3 4]
 ```
 
 Using a custom transformer:
@@ -153,10 +153,10 @@ Using a custom transformer:
      [:b [:vector :int]]]))
 
 (decode {:a "1", :b "1"})
-; => {:a [1], :b [1]}
+;; => {:a [1], :b [1]}
 
 (decode {:a "1;2", :b "1,2"})
-; => {:a [1 2], :b [1 2]}
+;; => {:a [1 2], :b [1 2]}
 ```
 
 ## Normalizing properties
@@ -179,12 +179,12 @@ Returning a Schema form with `nil` in place of empty properties:
    [:x int?]
    [:y [:tuple int? int?]]
    [:z [:set [:map [:x [:enum 1 2 3]]]]]])
-;[:map nil
-; [:x nil int?]
-; [:y nil [:tuple nil int? int?]]
-; [:z nil [:set nil
-;          [:map nil
-;           [:x nil [:enum nil 1 2 3]]]]]]
+;; => [:map nil
+;;     [:x nil int?]
+;;     [:y nil [:tuple nil int? int?]]
+;;     [:z nil [:set nil
+;;              [:map nil
+;;               [:x nil [:enum nil 1 2 3]]]]]]
 ```
 
 ## Default value from a function
@@ -245,9 +245,12 @@ Example 2: if `:cost` is missing, try to calculate it from `:price` and `:qty`:
 (def decode-interconnected-vals
   (m/decoder Purchase (default-fn-value-transformer)))
 
-(-> {:qty "100" :price "1.2"} decode-autonomous-vals decode-interconnected-vals) ;; => {:price 1.2, :qty 1, :cost 1.2}
-(-> {:price "1.2"} decode-autonomous-vals decode-interconnected-vals)            ;; => {:qty 100.0, :price 1.2, :cost 120.0}
-(-> {:prie "1.2"} decode-autonomous-vals decode-interconnected-vals)             ;; => {:prie "1.2", :qty 1}
+(-> {:qty "100" :price "1.2"} decode-autonomous-vals decode-interconnected-vals)
+;; => {:price 1.2, :qty 100.0, :cost 120.0}
+(-> {:price "1.2"} decode-autonomous-vals decode-interconnected-vals)
+;; => {:qty 1, :price 1.2, :cost 1.2}
+(-> {:prie "1.2"} decode-autonomous-vals decode-interconnected-vals)
+;; => {:prie "1.2", :qty 1}
 ```
 
 ## Walking Schema and Entry Properties
@@ -297,6 +300,8 @@ e.g. don't fail if the optional keys hava invalid values.
 2. done.
 
 ```clojure
+(require '[malli.util :as mu])
+
 (defn allow-invalid-optional-values [schema]
   (m/walk
     schema
@@ -327,7 +332,7 @@ e.g. don't fail if the optional keys hava invalid values.
    [:a string?]
    [:b {:optional true} int?]]
   {:a "Hey" :b "Nope"})
-; => false
+;; => false
 
 (m/validate
   (allow-invalid-optional-values
@@ -335,7 +340,7 @@ e.g. don't fail if the optional keys hava invalid values.
      [:a string?]
      [:b {:optional true} int?]])
   {:a "Hey" :b "Nope"})
-; => true
+;; => true
 ```
 ## Collecting inlined reference definitions from schemas
 
@@ -366,6 +371,8 @@ Use cases:
 Naive implementation (doesn't look up the local registries):
 
 ```clojure
+(require '[malli.registry :as mr])
+
 (defn collect-references [schema]
   (let [acc* (atom {})
         ->registry (fn [registry]
@@ -409,7 +416,7 @@ In action:
 ;          [:name :string]
 ;          [:user/country {:optional true}]]}
 ```
-
+<!-- :test-doc-blocks/skip -->
 ```clojure
 (collect-references
   [:map
@@ -422,6 +429,7 @@ In action:
 ## Getting error-values into humanized result
 
 ```clojure
+(require '[malli.error :as me])
 (-> [:map
      [:x :int]
      [:y [:set :keyword]]
@@ -431,7 +439,7 @@ In action:
                 :y #{:a "b" :c}
                 :z {:a [1 "2"]}})
     (me/humanize {:wrap #(select-keys % [:value :message])}))
-;{:x [{:value "1"
+;; => {:x [{:value "1"
 ;      :message "should be an integer"}],
 ; :y #{[{:value "b"
 ;        :message "should be a keyword"}]},
@@ -441,7 +449,7 @@ In action:
 
 ## Dependent String Schemas
 
-A schema for a string made of two components `a` and `b` separated by a `/` where the schema of `b` 
+A schema for a string made of two components `a` and `b` separated by a `/` where the schema of `b`
 depends on the value of `a`. The valid values of a are known in advance.
 
 For instance:
@@ -474,10 +482,10 @@ Here are a few examples of valid and invalid data:
 (def encode (m/encoder schema mt/string-transformer))
 
 (decode "ip/127.0.0.1")
-; => ["ip" "127.0.0.1"]
+;; => ["ip" "127.0.0.1"]
 
 (-> "ip/127.0.0.1" (decode) (encode))
-; => "ip/127.0.0.1"
+;; => "ip/127.0.0.1"
 
 (map (comp validate decode)
      ["ip/127.0.0.1"
@@ -485,7 +493,7 @@ Here are a few examples of valid and invalid data:
       "domain/cnn.com"
       "domain/aa"
       "kika/aaa"])
-; => (true false true false false)
+;; => (true false true false false)
 ```
 
 It is also possible to use a custom transformer instead of `string-transformer` (for example, in order to avoid `string-transformer` to perform additional encoding and decoding):
@@ -497,13 +505,13 @@ It is also possible to use a custom transformer instead of `string-transformer` 
              ["domain" [:tuple [:= "domain"] domain]]
              ["ip" [:tuple [:= "ip"] ipv4]]])
 
-(def decode (m/decoder schema (mt/transformer {:name :my-custom}))
+(def decode (m/decoder schema (mt/transformer {:name :my-custom})))
 
 (decode "ip/127.0.0.1")
-; => ["ip" "127.0.0.1"]
+;; => ["ip" "127.0.0.1"]
 ```
 
-## Converting Schemas 
+## Converting Schemas
 
 Example utility to convert schemas recursively:
 
@@ -534,7 +542,7 @@ Example utility to convert schemas recursively:
 ; [:tags [:set {::type :set} :string]]
 ; [:sub [:map {::type :map}
 ;        [:kw :string]
-;        [:data [:tuple {::type :tuple} 
+;        [:data [:tuple {::type :tuple}
 ;                :string
 ;                [:int {:gen/elements [1 2 3]}]
 ;                :string]]]]]

--- a/gen-tests.edn
+++ b/gen-tests.edn
@@ -1,0 +1,5 @@
+#kaocha/v1
+{:tests [{:id :generated
+          :test-paths  ["target/test-doc-blocks/test"]
+          :kaocha.hooks/post-load-test [lread.test-doc-blocks.kaocha.hooks/fail-on-no-tests-found]}]
+ :randomize? false}

--- a/test-doc-tests.edn
+++ b/test-doc-tests.edn
@@ -4,4 +4,5 @@
 {:tests [{:id :generated
           :test-paths  ["target/test-doc-blocks/test"]
           :kaocha.hooks/post-load-test [lread.test-doc-blocks.kaocha.hooks/fail-on-no-tests-found]}]
+ :reporter kaocha.report/documentation
  :randomize? false}

--- a/test-doc-tests.edn
+++ b/test-doc-tests.edn
@@ -1,3 +1,5 @@
+;; Needed to run tests generated with test-doc-blocks. For them to work we need :randomize? false, which
+;; is not what we want for the majority of the test cases.
 #kaocha/v1
 {:tests [{:id :generated
           :test-paths  ["target/test-doc-blocks/test"]


### PR DESCRIPTION
This PR adds an automated test step which generates Clojure tests from most of the examples in the documentation and runs them to see if they still work. It uses https://github.com/lread/test-doc-blocks to do the testing.

We have over two hundred examples in the readmes and these can be verified with test-doc-blocks. The syntax is very similar to what we are already using to document the correct usage and the result it produces in the REPL. Think:

```Clojure
(assoc {} :foo :bar)
;; => {:foo
;;     :bar}
```

# Pros
* Checks that examples keep working and reflect the current state of the library
* Nice way to avoid testing cases that won't work that doesn't mess up with the rendering in Github
* Adds over a hundred new test cases (admittedly most should be covered by the test suite)
* Can also test prints to stdout and stderr.

# Cons
* Can't check certain cases without making the examples more convoluted (for example generating data)
* Have to conform to the example writing format from test-doc-blocks