### PR TITLE
Fix JSON transformer string conversions when using enum or equality schemas

### DIFF
--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -251,44 +251,47 @@
 ;; decoders
 ;;
 
+(defn -base-json-decoders []
+  {'ident? -string->keyword
+   'simple-ident? -string->keyword
+   'qualified-ident? -string->keyword
+
+   'keyword? -string->keyword
+   'simple-keyword? -string->keyword
+   'qualified-keyword? -string->keyword
+
+   'symbol? -string->symbol
+   'simple-symbol? -string->symbol
+   'qualified-symbol? -string->symbol
+
+   'uuid? -string->uuid
+   'float? -number->float
+   'double? -number->double
+   'inst? -string->date
+   'integer? -number->long
+   'int? -number->long
+   'pos-int? -number->long
+   'neg-int? -number->long
+   'nat-int? -number->long
+   'zero? -number->long
+
+   #?@(:clj ['uri? -string->uri])
+
+   :float -number->float
+   :double -number->double
+   :int -number->long
+   :keyword -string->keyword
+   :symbol -string->symbol
+   :qualified-keyword -string->keyword
+   :qualified-symbol -string->symbol
+   :uuid -string->uuid
+   ;#?@(:clj [:uri -string->uri])
+
+   :set -sequential->set})
+
 (defn -json-decoders []
   (-add-child-compilers
-    {'ident? -string->keyword
-     'simple-ident? -string->keyword
-     'qualified-ident? -string->keyword
-
-     'keyword? -string->keyword
-     'simple-keyword? -string->keyword
-     'qualified-keyword? -string->keyword
-
-     'symbol? -string->symbol
-     'simple-symbol? -string->symbol
-     'qualified-symbol? -string->symbol
-
-     'uuid? -string->uuid
-     'float? -number->float
-     'double? -number->double
-     'inst? -string->date
-     'integer? -number->long
-     'int? -number->long
-     'pos-int? -number->long
-     'neg-int? -number->long
-     'nat-int? -number->long
-     'zero? -number->long
-
-     #?@(:clj ['uri? -string->uri])
-
-     :float -number->float
-     :double -number->double
-     :int -number->long
-     :keyword -string->keyword
-     :symbol -string->symbol
-     :qualified-keyword -string->keyword
-     :qualified-symbol -string->symbol
-     :uuid -string->uuid
-     ;#?@(:clj [:uri -string->uri])
-
-     :set -sequential->set}))
+    (-base-json-decoders)))
 
 (defn -json-encoders []
   (-add-child-compilers
@@ -317,7 +320,7 @@
 (defn -string-decoders []
   (-add-child-compilers
     (merge
-      (-json-decoders)
+      (-base-json-decoders)
       {'integer? -string->long
        'int? -string->long
        'pos-int? -string->long

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -308,8 +308,8 @@
      :qualified-keyword m/-keyword->string
      :qualified-symbol -any->string
      :uuid -any->string
-                                        ;#?@(:clj [:uri -any->string])
-                                        ;:bigdec any->string
+     ;#?@(:clj [:uri -any->string])
+     ;:bigdec any->string
 
      'inst? -date->string
      #?@(:clj ['ratio? -number->double])}))
@@ -352,27 +352,27 @@
 (defn -string-encoders []
   (-add-child-compilers
     (merge
-    (-json-encoders)
-    {'integer? -any->string
-     'int? -any->string
-     'pos-int? -any->string
-     'neg-int? -any->string
-     'nat-int? -any->string
-     'zero? -any->string
+      (-json-encoders)
+      {'integer? -any->string
+       'int? -any->string
+       'pos-int? -any->string
+       'neg-int? -any->string
+       'nat-int? -any->string
+       'zero? -any->string
 
-     :int -any->string
-     :float -any->string
-     :double -any->string
-     ;:boolean -any->string
+       :int -any->string
+       :float -any->string
+       :double -any->string
+       ;:boolean -any->string
 
-     :> -any->string
-     :>= -any->string
-     :< -any->string
-     :<= -any->string
-     :not= -any->string
+       :> -any->string
+       :>= -any->string
+       :< -any->string
+       :<= -any->string
+       :not= -any->string
 
-     'float -any->string
-     'double -any->string})))
+       'float -any->string
+       'double -any->string})))
 
 ;;
 ;; transformers

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -233,147 +233,146 @@
         (set? x) (seq x)
         :else x))
 
-(defn -infer-child-compiler [method]
-  (fn [schema _]
+(defn -infer-child-compiler
+  [x-coders]
+  (fn [schema _t]
     (some-> schema
-            (m/children)
-            (m/-infer)
-            {:keyword {:decode -string->keyword
-                       :encode m/-keyword->string}
-             :symbol {:decode -string->symbol}
-             :int {:decode -string->long}
-             :float {:decode -string->float}
-             :double {:decode -string->double}}
-            (method -any->string))))
+      (m/children)
+      (m/-infer)
+      x-coders)))
+
+(defn -add-child-compilers
+  [x-coders]
+  (assoc x-coders
+    :enum {:compile (-infer-child-compiler x-coders)}
+    := {:compile (-infer-child-compiler x-coders)}))
 
 ;;
 ;; decoders
 ;;
 
 (defn -json-decoders []
-  {'ident? -string->keyword
-   'simple-ident? -string->keyword
-   'qualified-ident? -string->keyword
+  (-add-child-compilers
+    {'ident? -string->keyword
+     'simple-ident? -string->keyword
+     'qualified-ident? -string->keyword
 
-   'keyword? -string->keyword
-   'simple-keyword? -string->keyword
-   'qualified-keyword? -string->keyword
+     'keyword? -string->keyword
+     'simple-keyword? -string->keyword
+     'qualified-keyword? -string->keyword
 
-   'symbol? -string->symbol
-   'simple-symbol? -string->symbol
-   'qualified-symbol? -string->symbol
+     'symbol? -string->symbol
+     'simple-symbol? -string->symbol
+     'qualified-symbol? -string->symbol
 
-   'uuid? -string->uuid
-   'float? -number->float
-   'double? -number->double
-   'inst? -string->date
-   'integer? -number->long
-   'int? -number->long
-   'pos-int? -number->long
-   'neg-int? -number->long
-   'nat-int? -number->long
-   'zero? -number->long
+     'uuid? -string->uuid
+     'float? -number->float
+     'double? -number->double
+     'inst? -string->date
+     'integer? -number->long
+     'int? -number->long
+     'pos-int? -number->long
+     'neg-int? -number->long
+     'nat-int? -number->long
+     'zero? -number->long
 
-   #?@(:clj ['uri? -string->uri])
+     #?@(:clj ['uri? -string->uri])
 
-   :enum {:compile (-infer-child-compiler :decode)}
-   := {:compile (-infer-child-compiler :decode)}
+     :float -number->float
+     :double -number->double
+     :int -number->long
+     :keyword -string->keyword
+     :symbol -string->symbol
+     :qualified-keyword -string->keyword
+     :qualified-symbol -string->symbol
+     :uuid -string->uuid
+     ;#?@(:clj [:uri -string->uri])
 
-   :float -number->float
-   :double -number->double
-   :int -number->long
-   :keyword -string->keyword
-   :symbol -string->symbol
-   :qualified-keyword -string->keyword
-   :qualified-symbol -string->symbol
-   :uuid -string->uuid
-   ;#?@(:clj [:uri -string->uri])
-
-   :set -sequential->set})
+     :set -sequential->set}))
 
 (defn -json-encoders []
-  {'keyword? m/-keyword->string
-   'simple-keyword? m/-keyword->string
-   'qualified-keyword? m/-keyword->string
+  (-add-child-compilers
+    {'keyword? m/-keyword->string
+     'simple-keyword? m/-keyword->string
+     'qualified-keyword? m/-keyword->string
 
-   'symbol? -any->string
-   'simple-symbol? -any->string
-   'qualified-symbol? -any->string
+     'symbol? -any->string
+     'simple-symbol? -any->string
+     'qualified-symbol? -any->string
 
-   'uuid? -any->string
-   #?@(:clj ['uri? -any->string])
+     'uuid? -any->string
+     #?@(:clj ['uri? -any->string])
 
-   :enum {:compile (-infer-child-compiler :encode)}
-   := {:compile (-infer-child-compiler :encode)}
+     :keyword m/-keyword->string
+     :symbol -any->string
+     :qualified-keyword m/-keyword->string
+     :qualified-symbol -any->string
+     :uuid -any->string
+                                        ;#?@(:clj [:uri -any->string])
+                                        ;:bigdec any->string
 
-   :keyword m/-keyword->string
-   :symbol -any->string
-   :qualified-keyword m/-keyword->string
-   :qualified-symbol -any->string
-   :uuid -any->string
-   ;#?@(:clj [:uri -any->string])
-   ;:bigdec any->string
-
-   'inst? -date->string
-   #?@(:clj ['ratio? -number->double])})
+     'inst? -date->string
+     #?@(:clj ['ratio? -number->double])}))
 
 (defn -string-decoders []
-  (merge
-   (-json-decoders)
-   {'integer? -string->long
-    'int? -string->long
-    'pos-int? -string->long
-    'neg-int? -string->long
-    'nat-int? -string->long
-    'zero? -string->long
+  (-add-child-compilers
+    (merge
+      (-json-decoders)
+      {'integer? -string->long
+       'int? -string->long
+       'pos-int? -string->long
+       'neg-int? -string->long
+       'nat-int? -string->long
+       'zero? -string->long
 
-    :int -string->long
-    :float -string->float
-    :double -string->double
-    :boolean -string->boolean
+       :int -string->long
+       :float -string->float
+       :double -string->double
+       :boolean -string->boolean
 
-    :> -string->long
-    :>= -string->long
-    :< -string->long
-    :<= -string->long
-    :not= -string->long
+       :> -string->long
+       :>= -string->long
+       :< -string->long
+       :<= -string->long
+       :not= -string->long
 
-    'number? -string->double
-    'float? -string->float
-    'double? -string->double
-    #?@(:clj ['rational? -string->double])
-    #?@(:clj ['decimal? -string->decimal])
+       'number? -string->double
+       'float? -string->float
+       'double? -string->double
+       #?@(:clj ['rational? -string->double])
+       #?@(:clj ['decimal? -string->decimal])
 
-    'boolean? -string->boolean
-    'false? -string->boolean
-    'true? -string->boolean
+       'boolean? -string->boolean
+       'false? -string->boolean
+       'true? -string->boolean
 
-    :map-of (-transform-map-keys m/-keyword->string)
-    :vector -sequential->vector}))
+       :map-of (-transform-map-keys m/-keyword->string)
+       :vector -sequential->vector})))
 
 (defn -string-encoders []
-  (merge
-   (-json-encoders)
-   {'integer? -any->string
-    'int? -any->string
-    'pos-int? -any->string
-    'neg-int? -any->string
-    'nat-int? -any->string
-    'zero? -any->string
+  (-add-child-compilers
+    (merge
+    (-json-encoders)
+    {'integer? -any->string
+     'int? -any->string
+     'pos-int? -any->string
+     'neg-int? -any->string
+     'nat-int? -any->string
+     'zero? -any->string
 
-    :int -any->string
-    :float -any->string
-    :double -any->string
-    ;:boolean -any->string
+     :int -any->string
+     :float -any->string
+     :double -any->string
+     ;:boolean -any->string
 
-    :> -any->string
-    :>= -any->string
-    :< -any->string
-    :<= -any->string
-    :not= -any->string
+     :> -any->string
+     :>= -any->string
+     :< -any->string
+     :<= -any->string
+     :not= -any->string
 
-    'float -any->string
-    'double -any->string}))
+     'float -any->string
+     'double -any->string})))
 
 ;;
 ;; transformers

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -293,29 +293,32 @@
   (-add-child-compilers
     (-base-json-decoders)))
 
+(defn -base-json-encoders []
+  {'keyword? m/-keyword->string
+   'simple-keyword? m/-keyword->string
+   'qualified-keyword? m/-keyword->string
+
+   'symbol? -any->string
+   'simple-symbol? -any->string
+   'qualified-symbol? -any->string
+
+   'uuid? -any->string
+   #?@(:clj ['uri? -any->string])
+
+   :keyword m/-keyword->string
+   :symbol -any->string
+   :qualified-keyword m/-keyword->string
+   :qualified-symbol -any->string
+   :uuid -any->string
+   ;#?@(:clj [:uri -any->string])
+   ;:bigdec any->string
+
+   'inst? -date->string
+   #?@(:clj ['ratio? -number->double])})
+
 (defn -json-encoders []
   (-add-child-compilers
-    {'keyword? m/-keyword->string
-     'simple-keyword? m/-keyword->string
-     'qualified-keyword? m/-keyword->string
-
-     'symbol? -any->string
-     'simple-symbol? -any->string
-     'qualified-symbol? -any->string
-
-     'uuid? -any->string
-     #?@(:clj ['uri? -any->string])
-
-     :keyword m/-keyword->string
-     :symbol -any->string
-     :qualified-keyword m/-keyword->string
-     :qualified-symbol -any->string
-     :uuid -any->string
-     ;#?@(:clj [:uri -any->string])
-     ;:bigdec any->string
-
-     'inst? -date->string
-     #?@(:clj ['ratio? -number->double])}))
+    (-base-json-encoders)))
 
 (defn -string-decoders []
   (-add-child-compilers
@@ -355,7 +358,7 @@
 (defn -string-encoders []
   (-add-child-compilers
     (merge
-      (-json-encoders)
+      (-base-json-encoders)
       {'integer? -any->string
        'int? -any->string
        'pos-int? -any->string

--- a/src/malli/transform.cljc
+++ b/src/malli/transform.cljc
@@ -235,7 +235,7 @@
 
 (defn -infer-child-compiler
   [x-coders]
-  (fn [schema _t]
+  (fn [schema _]
     (some-> schema
       (m/children)
       (m/-infer)

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -1167,6 +1167,7 @@
                  :equals2 "kikka"
                  :equals3 1
                  :equals4 1.1}
+
         decoded {:enum1 :kikka
                  :enum2 'kikka
                  :enum3 1
@@ -1174,11 +1175,32 @@
                  :equals1 :kikka
                  :equals2 'kikka
                  :equals3 1
-                 :equals4 1.1}]
+                 :equals4 1.1}
+
+        stringy-encoded {:enum1 "kikka"
+                         :enum2 "kikka"
+                         :enum3 "1"
+                         :enum4 "1.1"
+                         :equals1 "kikka"
+                         :equals2 "kikka"
+                         :equals3 "1"
+                         :equals4 "1.1"}
+        stringy-decoded {:enum1 :kikka
+                         :enum2 'kikka
+                         :enum3 "1"
+                         :enum4 "1.1"
+                         :equals1 :kikka
+                         :equals2 'kikka
+                         :equals3 "1"
+                         :equals4 "1.1"}]
     (testing "decoding children using the json transformer works"
-      (is (= decoded (m/decode child-inference-test-schema encoded (mt/json-transformer)))))
+      (is (= decoded (m/decode child-inference-test-schema encoded (mt/json-transformer))))
+      (is (= decoded (m/decode child-inference-test-schema decoded (mt/json-transformer)))))
+    (testing "invalid strings are not decoded by the json transformer"
+      (is (= stringy-decoded (m/decode child-inference-test-schema stringy-encoded (mt/json-transformer)))))
     (testing "encoding children using the json transformer works"
-      (is (= encoded (m/encode child-inference-test-schema decoded (mt/json-transformer)))))))
+      (is (= encoded (m/encode child-inference-test-schema decoded (mt/json-transformer))))
+      (is (= encoded (m/decode child-inference-test-schema encoded (mt/json-transformer)))))))
 
 (deftest child-inference-string-test
   (let [encoded {:enum1 "kikka"
@@ -1198,6 +1220,8 @@
                  :equals3 1
                  :equals4 1.1}]
     (testing "decoding children using the string transformer works"
-      (is (= decoded (m/decode child-inference-test-schema encoded (mt/string-transformer)))))
+      (is (= decoded (m/decode child-inference-test-schema encoded (mt/string-transformer))))
+      (is (= decoded (m/decode child-inference-test-schema decoded (mt/string-transformer)))))
     (testing "encoding children using the string transformer works"
-      (is (= encoded (m/encode child-inference-test-schema decoded (mt/string-transformer)))))))
+      (is (= encoded (m/encode child-inference-test-schema decoded (mt/string-transformer))))
+      (is (= encoded (m/encode child-inference-test-schema encoded (mt/string-transformer)))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -1197,10 +1197,11 @@
       (is (= decoded (m/decode child-inference-test-schema encoded (mt/json-transformer))))
       (is (= decoded (m/decode child-inference-test-schema decoded (mt/json-transformer)))))
     (testing "invalid strings are not decoded by the json transformer"
-      (is (= stringy-decoded (m/decode child-inference-test-schema stringy-encoded (mt/json-transformer)))))
+      (is (= stringy-decoded (m/decode child-inference-test-schema stringy-encoded (mt/json-transformer))))
+      (is (= stringy-decoded (m/decode child-inference-test-schema stringy-decoded (mt/json-transformer)))))
     (testing "encoding children using the json transformer works"
       (is (= encoded (m/encode child-inference-test-schema decoded (mt/json-transformer))))
-      (is (= encoded (m/decode child-inference-test-schema encoded (mt/json-transformer)))))))
+      (is (= encoded (m/encode child-inference-test-schema encoded (mt/json-transformer)))))))
 
 (deftest child-inference-string-test
   (let [encoded {:enum1 "kikka"

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -1125,41 +1125,79 @@
              (m/encode schema $ mt/string-transformer)
              (m/decode schema $ mt/string-transformer))))))
 
-(deftest inferring-child-decoders-test
-  (let [schema [:map
-                [:enum1 [:enum :kikka :kukka]]
-                [:enum2 [:enum 'kikka 'kukka]]
-                [:enum3 [:enum 1 2]]
-                [:enum4 [:enum 1.1 2.2]]
-                [:equals1 [:= :kikka]]
-                [:equals2 [:= 'kikka]]
-                [:equals3 [:= 1]]
-                [:equals4 [:= 1.1]]]
-        value {:enum1 "kikka"
-               :enum2 "kikka"
-               :enum3 "1"
-               :enum4 "1.1"
-               :equals1 "kikka"
-               :equals2 "kikka"
-               :equals3 "1"
-               :equals4 "1.1"}
-        expected {:enum1 :kikka
-                  :enum2 'kikka
-                  :enum3 1
-                  :enum4 1.1
-                  :equals1 :kikka
-                  :equals2 'kikka
-                  :equals3 1
-                  :equals4 1.1}]
-    (testing "decoding"
-      (testing "is not enabled by default"
-        (is (= value (m/decode schema value nil))))
-      (testing "works with json and string transformers"
-        (is (= expected (m/decode schema value (mt/json-transformer))))
-        (is (= expected (m/decode schema value (mt/string-transformer))))))
-    (testing "encoding"
-      (testing "is not enabled by default"
-        (is (= expected (m/encode schema expected nil))))
-      (testing "works with json and string transformers"
-        (is (= value (m/encode schema expected (mt/json-transformer))))
-        (is (= value (m/encode schema expected (mt/string-transformer))))))))
+(def child-inference-test-schema
+  [:map
+   [:enum1 [:enum :kikka :kukka]]
+   [:enum2 [:enum 'kikka 'kukka]]
+   [:enum3 [:enum 1 2]]
+   [:enum4 [:enum 1.1 2.2]]
+   [:equals1 [:= :kikka]]
+   [:equals2 [:= 'kikka]]
+   [:equals3 [:= 1]]
+   [:equals4 [:= 1.1]]])
+
+(deftest child-inference-default-test
+  (let [encoded {:enum1 "kikka"
+                 :enum2 "kikka"
+                 :enum3 "1"
+                 :enum4 "1.1"
+                 :equals1 "kikka"
+                 :equals2 "kikka"
+                 :equals3 "1"
+                 :equals4 "1.1"}
+        decoded {:enum1 :kikka
+                 :enum2 'kikka
+                 :enum3 1
+                 :enum4 1.1
+                 :equals1 :kikka
+                 :equals2 'kikka
+                 :equals3 1
+                 :equals4 1.1}]
+    (testing "decoding is not enabled by default"
+      (is (= encoded (m/decode child-inference-test-schema encoded nil))))
+    (testing "encoding is not enabled by default"
+      (is (= decoded (m/encode child-inference-test-schema decoded nil))))))
+
+(deftest child-inference-json-test
+  (let [encoded {:enum1 "kikka"
+                 :enum2 "kikka"
+                 :enum3 1
+                 :enum4 1.1
+                 :equals1 "kikka"
+                 :equals2 "kikka"
+                 :equals3 1
+                 :equals4 1.1}
+        decoded {:enum1 :kikka
+                 :enum2 'kikka
+                 :enum3 1
+                 :enum4 1.1
+                 :equals1 :kikka
+                 :equals2 'kikka
+                 :equals3 1
+                 :equals4 1.1}]
+    (testing "decoding children using the json transformer works"
+      (is (= decoded (m/decode child-inference-test-schema encoded (mt/json-transformer)))))
+    (testing "encoding children using the json transformer works"
+      (is (= encoded (m/encode child-inference-test-schema decoded (mt/json-transformer)))))))
+
+(deftest child-inference-string-test
+  (let [encoded {:enum1 "kikka"
+                 :enum2 "kikka"
+                 :enum3 "1"
+                 :enum4 "1.1"
+                 :equals1 "kikka"
+                 :equals2 "kikka"
+                 :equals3 "1"
+                 :equals4 "1.1"}
+        decoded {:enum1 :kikka
+                 :enum2 'kikka
+                 :enum3 1
+                 :enum4 1.1
+                 :equals1 :kikka
+                 :equals2 'kikka
+                 :equals3 1
+                 :equals4 1.1}]
+    (testing "decoding children using the string transformer works"
+      (is (= decoded (m/decode child-inference-test-schema encoded (mt/string-transformer)))))
+    (testing "encoding children using the string transformer works"
+      (is (= encoded (m/encode child-inference-test-schema decoded (mt/string-transformer)))))))


### PR DESCRIPTION
Resolves #1204

Starting with 0.13.0, when encoding or decoding enum or equality schemas using the JSON transformer, values are converted to and from strings:

```clj
(m/encode [:= 42] 42 mt/json-transformer) ;; => "42"
(m/encode [:enum 42] 42 mt/json-transformer) ;; => "42"

(m/decode [:= 42] "42" mt/json-transformer) ;; => 42
(m/decode [:enum 42] "42" mt/json-transformer) ;; => 42
```

I think this behavior is expected from the string transformer, but not from the JSON transformer. Here's what I'd expect:

```clj
(m/encode [:= 42] 42 mt/json-transformer) ;; => 42
(m/encode [:enum 42] 42 mt/json-transformer) ;; => 42

(m/decode [:= 42] "42" mt/json-transformer) ;; => "42"
(m/decode [:enum 42] "42" mt/json-transformer) ;; => "42"
```

This change addresses that by inferring the encoder or decoder to use for an equality or enum schema from all of the other encoders or decoders rather than using some manual overrides.

I don't know much about the internals of Malli, like the protocols involved or the way encoder or decoder compilation works, so there might be a better way to do this - I'm willing to take a shot at implementing that if someone has some pointers.