### PR TITLE
Gen min max for :+ and :* sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Malli is in well matured [alpha](README.md#alpha).
 * **BREAKING** FIX: `json-transformer` is now better at inferring en/decoders for `:enum` and `:=`. [#1205](https://github.com/metosin/malli/pull/1205)
   * For example `[:enum 1 2 3]` gets encoded as a JSON number, not a string.
   * If you need the old behaviour, you can override the en/decoders using properties. [See docs.](README.md#advanced-transformations)
+* Value generation: `:+` and `:*` now support generator directives `:gen/min`, `:gen/max` as well as `:min` and `:max` schema directives [#1208](https://github.com/metosin/malli/pull/1208)
 
 ## 0.18.0 (2025-05-12)
 

--- a/README.md
+++ b/README.md
@@ -2168,13 +2168,14 @@ Schemas can be used to generate values:
  {:seed 10})
 ; => [-109024846 -2 25432]
 
-;; When composing sequence schemas, the directives effect the definition they are associated with,
-;; such that:
-(mg/generate [:* {:gen/min 2 :gen/max 3} ; 2 - 3 repetitions of
-              [:cat
-               [:+ {:gen/min 2 :gen/max 3} :int] ; 2 - 3 repetitions of int
-               [:* {:gen/min 1 :gen/max 2} :string]]] ; followed by 1-2 repetitions of string
-             {:seed 10})
+;; When composing sequence schemas, the directives effect the definition they are
+;; associated with, such that:
+(mg/generate
+ [:* {:gen/min 2 :gen/max 3} ; 2 - 3 repetitions of
+  [:cat
+   [:+ {:gen/min 2 :gen/max 3} :int] ; 2 - 3 repetitions of int
+   [:* {:gen/min 1 :gen/max 2} :string]]] ; followed by 1-2 repetitions of string
+ {:seed 10})
 
 ; => (-812 1283 "Q9beps1Yn3c3VP9" "4XHdn1mgudSlNpVyxOrQIiR5pd5ocs" 114 -14284153 "8SSR9033czAO05")
 

--- a/README.md
+++ b/README.md
@@ -2168,6 +2168,16 @@ Schemas can be used to generate values:
  {:seed 10})
 ; => [-109024846 -2 25432]
 
+;; When composing sequence schemas, the directives effect the definition they are associated with,
+;; such that:
+(mg/generate [:* {:gen/min 2 :gen/max 3} ; 2 - 3 repetitions of
+              [:cat
+               [:+ {:gen/min 2 :gen/max 3} :int] ; 2 - 3 repetitions of int
+               [:* {:gen/min 1 :gen/max 2} :string]]] ; followed by 1-2 repetitions of string
+             {:seed 10})
+
+; => (-812 1283 "Q9beps1Yn3c3VP9" "4XHdn1mgudSlNpVyxOrQIiR5pd5ocs" 114 -14284153 "8SSR9033czAO05")
+
 ;; :gen/infinite? & :gen/NaN? for :double
 (mg/generate
   [:double {:gen/infinite? true, :gen/NaN? true}]

--- a/README.md
+++ b/README.md
@@ -2149,6 +2149,12 @@ Schemas can be used to generate values:
   {:seed 1})
 ; => [-8522515 -1433 -1 1]
 
+;; :gen/min & gen/max works for :+ and :* as well
+(mg/generate
+ [:+ {:gen/min 2 :gen/max 10} :int]
+ {:seed 10})
+; => [-109024846 -2 25432]
+
 ;; :gen/infinite? & :gen/NaN? for :double
 (mg/generate
   [:double {:gen/infinite? true, :gen/NaN? true}]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -335,7 +335,13 @@
 
 (defn -*-gen [schema options]
   (let [child (-child schema options)]
-    (cond->> (gen-vector (when (= :+ (::-*-gen-mode options)) {:min 1}) (generator child (dissoc options ::-*-gen-mode)))
+    (cond->> (gen-vector
+              (cond-> (-min-max schema options)
+                ;; When generating from :+ the base minimum value must be 1
+                ;; to ensure that :+ is always fulfilled
+                (= :+ (::-*-gen-mode options))
+                (update :min (fnil max 1)))
+              (generator child (dissoc options ::-*-gen-mode)))
       (m/-regex-op? child) gen-fcat)))
 
 (defn -+-gen [schema options]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -42,7 +42,7 @@
 ;;
 ;; Use `-unreachable-gen?` to test whether your child generator generates no values (we'll call this an "unreachable" schema/generator).
 ;; If your parent generator cannot generate values, use `-never-gen` to return an unreachable generator.
-;; 
+;;
 ;; Here are a few examples---compare them with the logic in their respective -schema-generator methods:
 ;;   [:maybe M] would generate like :nil if M were unreachable.
 ;;   [:map [:a M]] would itself be unreachable if M were unreachable.
@@ -210,8 +210,8 @@
 ;;
 ;; For infinitely expanding schemas, this will return an unreachable generator--when the base case generator is used,
 ;; the error message in `-never-gen` will advise users that their schema is infinite.
-;; 
-;; 
+;;
+;;
 ;; Examples of base cases of some recursive schemas:
 ;;
 ;; Schema:    [:schema {:registry {::cons [:maybe [:vector [:tuple pos-int? [:ref ::cons]]]]}} ::cons]
@@ -233,11 +233,11 @@
 ;; supplied by `gen/recursive-gen` to convert recursive references.
 
 ;; ## Identifying schema recursion
-;; 
+;;
 ;; Refs are uniquely identified by their paired name and scope. If we see a ref with the
 ;; same name and scope as another ref we've dereferenced previously, we know that this is a recursion
 ;; point back to the previously seen ref. The rest of this section explains why.
-;; 
+;;
 ;; Refs resolve via dynamic scope, which means its dereferenced value is the latest binding found
 ;; while expanding the schema until the point of finding the ref.
 ;; This makes the (runtime) scope at the ref's location part of a ref's identity---if the scope
@@ -245,7 +245,7 @@
 ;; transitively expand.
 ;;
 ;; To illustrate why a ref's name is an insufficient identifier, here is a schema that is equivalent to `[:= 42]`:
-;; 
+;;
 ;;   [:schema {:registry {::a [:schema {:registry {::a [:= 42]}}
 ;;                             ;; (2)
 ;;                             [:ref ::a]]}}
@@ -277,7 +277,7 @@
 ;; we choose that identifier. The more general insight is that any schema is identified by its form+scope
 ;; (note: but only after trimming the scope of irrelevant bindings, see next pararaph).
 ;; That insight may be useful for detecting recursion at places other than refs.
-;; 
+;;
 ;; Ref identifiers could be made smarter by trimming irrelevant entries in identifying scope.
 ;; Not all scope differences are relevant, so generators may expand more than strictly necessary
 ;; in the quest to find the "same" ref schema again. It could skip over refs that generate exactly the
@@ -345,6 +345,7 @@
       (m/-regex-op? child) gen-fcat)))
 
 (defn -+-gen [schema options]
+  ;; :+ generator is a specific case of :* schema with the minimum amount of elements is 1 instead of 0
   (-*-gen schema (assoc options ::-*-gen-mode :+)))
 
 (defn -repeat-gen [schema options]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -315,7 +315,14 @@
       [:string {:gen/min 10, :max 20}]
 
       [:+ {:min 10 :max 20} :int]
+      [:+ {:gen/min 10 :max 20} :int]
+      [:+ {:min 10 :gen/max 20} :int]
+      [:+ {:gen/min 10 :gen/max 20} :int]
+
       [:* {:min 10 :max 20} :int]
+      [:* {:gen/min 10 :max 20} :int]
+      [:* {:min 10 :gen/max 20} :int]
+      [:* {:gen/min 10 :gen/max 20} :int]
 
       [:vector {:min 1, :gen/min 10, :max 100, :gen/max 20} int?]
       [:set {:min 1, :gen/min 10, :max 100, :gen/max 20} int?]

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -314,6 +314,9 @@
       [:set {:min 10, :gen/max 20} int?]
       [:string {:gen/min 10, :max 20}]
 
+      [:+ {:min 10 :max 20} :int]
+      [:* {:min 10 :max 20} :int]
+
       [:vector {:min 1, :gen/min 10, :max 100, :gen/max 20} int?]
       [:set {:min 1, :gen/min 10, :max 100, :gen/max 20} int?]
       [:string {:min 1, :gen/min 10, :max 100, :gen/max 20}]))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -321,6 +321,9 @@
       [:set {:min 1, :gen/min 10, :max 100, :gen/max 20} int?]
       [:string {:min 1, :gen/min 10, :max 100, :gen/max 20}]))
 
+  (testing ":+ enforces a minimum count of 1 generated elements"
+    (every? #(<= 1 %) (map count (mg/sample [:+ :int] {:size 1000}))))
+
   (testing "invalid properties"
     (are [schema]
       (thrown? #?(:clj Exception, :cljs js/Error) (mg/sample schema {:size 1000}))


### PR DESCRIPTION
This is a (partial) fix for #1168

It makes sure that `:+` and `:*` use the :gen/min :gen/max etc options that are supported by other collection schemas.

I think it fixes the issue that the OG reporter had. 