### PR TITLE
Reduce CLJS compiled bundle size

### DIFF
--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -71,3 +71,9 @@
 (def ^{:arglists '([[& preds]])} -some-pred
   #?(:clj  (-pred-composer or 16)
      :cljs (fn [preds] (fn [x] (boolean (some #(% x) preds))))))
+
+#?(:clj
+   (defmacro predicate-schemas* [var-syms]
+     `(-> {}
+          ~@(for [vsym var-syms]
+              `(malli.core/-register-var '~vsym ~vsym)))))


### PR DESCRIPTION
When the Clojurescript compiler encounters a call to `resolve` or a `var` macro, it inlines the whole metadata right at the callsite. This produces a lot of unnecessary code in the compiled output.

My proposal here is to rewrite `predicate-schemas` function to avoid using `#'` quoting. With these changes, I was able to reduce the compiled Malli size (with advanced optimizations) by 14 KB uncompressed (4KB gzipped).