### PR TITLE
Don't automatically remove files with each `emit!`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Malli is in well matured [alpha](README.md#alpha).
 ## UNRELEASED
 
 * `malli.clj-kondo/emit!` saves to `.clj-kondo/imports` now as recommended by clj-kondo. [#1216](https://github.com/metosin/malli/pull/1216)
+* `malli.clj-kondo/emit!` no longer deletes anything automatically. Use `malli.clj-kondo/clean!` to clean up.
 
 ## 0.19.1 (2025-06-09)
 * Technical release

--- a/README.md
+++ b/README.md
@@ -3300,6 +3300,15 @@ Emitting config into `./.clj-kondo/imports/metosin/malli-types-clj/config.edn`:
 (mc/emit!)
 ```
 
+Removing the generated configurations. Note that this removes also
+from locations where old versions of malli used to store the
+configuration file:
+
+<!-- :test-doc-blocks/skip -->
+```clojure
+(mc/clean!)
+```
+
 In action:
 
 ![malli](docs/img/clj-kondo.png)

--- a/README.md
+++ b/README.md
@@ -3293,7 +3293,7 @@ Generating `clj-kondo` configuration from current namespace:
 ;                             :ret :int}}}}}}}}
 ```
 
-Emitting confing into `./.clj-kondo/configs/malli/config.edn`:
+Emitting config into `./.clj-kondo/imports/metosin/malli-types-clj/config.edn`:
 
 <!-- :test-doc-blocks/skip -->
 ```clojure

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -187,7 +187,6 @@
       (save! config key nil))
      ([config key options]
       (let [cfg-file (-config-file-path key options)]
-        (clean! key options)
         (io/make-parents cfg-file)
         (spit cfg-file (with-out-str (fipp/pprint config {:width 120})))
         config))))

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -154,6 +154,9 @@
   [key]
   (str "malli-types-" (name key)))
 
+(defn -config-file-path [key options]
+  (-file-in-kondo-dir options ".clj-kondo" "imports" "metosin" (-types-dir-name key) "config.edn"))
+
 ;;
 ;; public api
 ;;
@@ -163,7 +166,8 @@
   ([options]
    (clean! :clj options))
   ([key options]
-   ;; delete the old files if they exist (does not throw)
+   (.delete (-config-file-path key options))
+   ;; These are remnants from old locations where malli used to store the configuration files
    (.delete (-file-in-kondo-dir options ".clj-kondo" "metosin" (-types-dir-name key) "config.edn"))
    (.delete (-file-in-kondo-dir options ".clj-kondo" "configs" "malli" "config.edn"))))
 
@@ -182,8 +186,7 @@
      ([config key]
       (save! config key nil))
      ([config key options]
-      (let [malli-types-dir (-types-dir-name key)
-            cfg-file (-file-in-kondo-dir options ".clj-kondo" "imports" "metosin" malli-types-dir "config.edn")]
+      (let [cfg-file (-config-file-path key options)]
         (clean! key options)
         (io/make-parents cfg-file)
         (spit cfg-file (with-out-str (fipp/pprint config {:width 120})))


### PR DESCRIPTION
Discussing the PR https://github.com/metosin/malli/pull/1216/files we decided that automatically deleting files from old configuration locations is a bad idea. This PR removes that automatic clean up and instead provides a function for cleaning the generated configs.