### PR TITLE
[perf] Improve malli.core/-intercepting peformance

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -558,7 +558,9 @@
 
 (defn -intercepting
   ([interceptor] (-intercepting interceptor nil))
-  ([{:keys [enter leave]} f] (some->> [leave f enter] (keep identity) (seq) (apply -comp))))
+  ([{:keys [enter leave]} f]
+   (letfn [(comp-some [a b] (if (and a b) (-comp a b) (or a b)))]
+     (comp-some leave (comp-some f enter)))))
 
 (defn -into-transformer [x]
   (cond


### PR DESCRIPTION
Some minor space for improvement that I've spotted while working with Metabase. `-intercepting` just combines three functions via `comp`, but skips those that weren't provided. Instead of allocating a vector and transforming it, this PR spells out all cases explicitly. Slightly wordy, but no overhead.