### PR TITLE
Sketch: tying the knot for ref validator

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2114,6 +2114,8 @@
                      (fn [x]
                        (if-let [f @vol]
                          (do (println "LAZY: TIED THE KNOT")
+                             ;;TODO exercise code path
+                             (throw (ex-info "LAZY: TIED THE KNOT" {}))
                              (f x))
                          (let [f (binding [*ref-validators* (assoc ref-validators id vol)]
                                    (-validator (rf)))]


### PR DESCRIPTION
This way we can fully compile a ref validator (faster & less memory, don't need to stop to compile each new level and cache).

Removing the dynamic variable here is a strong motivator for `-validator` to take `opts`. OTOH, we're gaining perf and only need to use dynamic variable once before its cached.