### PR TITLE
[perf] Optimize -parent-child-transformer

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -603,11 +603,10 @@
   (let [parent-transformer (-value-transformer transformer parent method options)
         child-transformer
         (reduce (fn [acc child]
-                  (if-some [transformer (-transformer child transformer method options)]
-                    (if acc
+                  (let [transformer (-transformer child transformer method options)]
+                    (if (and acc transformer)
                       (-comp transformer acc)
-                      transformer)
-                    acc))
+                      (or acc transformer))))
                 nil children)]
     (-intercepting parent-transformer child-transformer)))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -601,8 +601,14 @@
 
 (defn -parent-children-transformer [parent children transformer method options]
   (let [parent-transformer (-value-transformer transformer parent method options)
-        child-transformers (into [] (keep #(-transformer % transformer method options)) children)
-        child-transformer (when (seq child-transformers) (apply -comp (rseq child-transformers)))]
+        child-transformer
+        (reduce (fn [acc child]
+                  (if-some [transformer (-transformer child transformer method options)]
+                    (if acc
+                      (-comp transformer acc)
+                      transformer)
+                    acc))
+                nil children)]
     (-intercepting parent-transformer child-transformer)))
 
 (defn -map-transformer [ts]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -604,9 +604,11 @@
         child-transformer
         (reduce (fn [acc child]
                   (let [transformer (-transformer child transformer method options)]
-                    (if (and acc transformer)
-                      (-comp transformer acc)
-                      (or acc transformer))))
+                    (if acc
+                      (if transformer
+                        (-comp transformer acc)
+                        acc)
+                      transformer)))
                 nil children)]
     (-intercepting parent-transformer child-transformer)))
 


### PR DESCRIPTION
Computing a child-transformer in a single `reduce` achieves several benefits:
1. No need to accumulate intermediate child transformers into a vector.
2. No need to reverse the vector direction - calling `-comp` on the next child and the accumulator achieves that naturally.
3. For the very common case where there is just one child, the vector overhead is gone completely.