### PR TITLE
Set a random seed to ensure repeatability of tests

### DIFF
--- a/test/malli/parser_test.cljc
+++ b/test/malli/parser_test.cljc
@@ -93,7 +93,7 @@
                     parse (m/parser s)
                     unparse (m/parser s)]
                 (if expected-simple
-                  (doseq [g (mg/sample s)]
+                  (doseq [g (mg/sample s {:seed 0})]
                     (testing (pr-str g)
                       (let [p (parse g)]
                         (is (identical? g p))


### PR DESCRIPTION
Drawback to this is that the test doesn't exercise the code as fully as more random usage would.

Pro is that we don't get false negatives from CI tests as often.

Fixes #1236 