### PR TITLE
Avoid compilation warnings in cljs

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -150,27 +150,30 @@
    (defn -file-in-kondo-dir [options & paths]
      (apply io/file (into (get options :clj-kondo-dir-path []) paths))))
 
-(defn -types-dir-name
-  "Creates a directory name such as `malli-types-cljs` or `malli-types-clj`."
-  [key]
-  (str "malli-types-" (name key)))
+#?(:clj
+   (defn -types-dir-name
+     "Creates a directory name such as `malli-types-cljs` or `malli-types-clj`."
+     [key]
+     (str "malli-types-" (name key))))
 
-(defn -config-file-path [key options]
-  (-file-in-kondo-dir options ".clj-kondo" "imports" "metosin" (-types-dir-name key) "config.edn"))
+#?(:clj
+   (defn -config-file-path [key options]
+     (-file-in-kondo-dir options ".clj-kondo" "imports" "metosin" (-types-dir-name key) "config.edn")))
 
 ;;
 ;; public api
 ;;
 
-(defn clean!
-  "Cleans existing configurations from .clj-kondo directory"
-  ([options]
-   (clean! :clj options))
-  ([key options]
-   (.delete (-config-file-path key options))
-   ;; These are remnants from old locations where malli used to store the configuration files
-   (.delete (-file-in-kondo-dir options ".clj-kondo" "metosin" (-types-dir-name key) "config.edn"))
-   (.delete (-file-in-kondo-dir options ".clj-kondo" "configs" "malli" "config.edn"))))
+#?(:clj
+   (defn clean!
+     "Cleans existing configurations from .clj-kondo directory"
+     ([options]
+      (clean! :clj options))
+     ([key options]
+      (.delete (-config-file-path key options))
+      ;; These are remnants from old locations where malli used to store the configuration files
+      (.delete (-file-in-kondo-dir options ".clj-kondo" "metosin" (-types-dir-name key) "config.edn"))
+      (.delete (-file-in-kondo-dir options ".clj-kondo" "configs" "malli" "config.edn")))))
 
 (defn transform
   ([?schema]


### PR DESCRIPTION
Since 0.19.2, when using `malli.dev.cljs-kondo-preload` - following [clojurescript-function-instrumentation.md](https://github.com/metosin/malli/blob/master/docs/clojurescript-function-instrumentation.md) - it produces those warnings:

```
WARNING: Use of undeclared Var malli.clj-kondo/-file-in-kondo-dir at line 159 ______/malli/src/malli/clj_kondo.cljc
WARNING: Use of undeclared Var malli.clj-kondo/-file-in-kondo-dir at line 172 ______/malli/src/malli/clj_kondo.cljc
WARNING: Use of undeclared Var malli.clj-kondo/-file-in-kondo-dir at line 173 ______/malli/src/malli/clj_kondo.cljc
```

This PR fixes that by adding some `:clj` reader conditionals.

#### Tests:
`./bin/kaocha`
245 tests, 18732 assertions, 0 failures.

`/bin/node`
Running CLJS test in Node with optimizations :none
Ran 232 tests containing 18040 assertions.
0 failures, 0 errors.
Running CLJS test in Node with optimizations :advanced
Ran 227 tests containing 17950 assertions.
0 failures, 0 errors.