### PR TITLE
Reuse recursive ref-transformers

### DIFF
--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3681,3 +3681,19 @@
              "world" [:enum "maailma"])
       (is (= ["hello" "maailma"]
              (mapv (comp peek m/form m/deref-all) (m/children schema)))))))
+
+(deftest recursive-coercer-test
+  (let [count-into-schemas (atom 0)
+        reg (mr/simple-registry (assoc (m/default-schemas)
+                                       ::counting (m/-proxy-schema {:type ::counting
+                                                                    :fn (fn [p c o]
+                                                                          (assert (empty? c))
+                                                                          (swap! count-into-schemas inc)
+                                                                          [[] [] (m/schema :int o)])})))
+        ConsCell (m/schema [:schema {:registry {::cons [:maybe [:tuple ::counting [:ref ::cons]]]}} ::cons]
+                           {:registry reg})]
+    (is (= @count-into-schemas 2))
+    (is (m/coerce ConsCell [1 [2 [3 [4 nil]]]]))
+    (is (= @count-into-schemas 3)) ;; was 6
+    (is (m/coerce ConsCell [1 [2 [3 [4 [1 [2 [3 [4 nil]]]]]]]]))
+    (is (= @count-into-schemas 3)))) ;; was 10


### PR DESCRIPTION
This addresses a similar problem to [#1245 ](https://github.com/metosin/malli/pull/1245)but this time for transformers, not validators. The issue was discovered very recently in Metabase, where a decoder for a recursive schema definiton would grow infinitely, depending on the provided data (and from the look of it, the growth is quadratic). Here's a simplified reproducer:

```clj
(require '[clj-memory-meter.core :as mm])

(def my-sch
   [:schema
    {:registry {"hiccup" [:orn
                          [:node
                           [:catn
                            [:name keyword?]
                            [:props [:map-of keyword? any?]]
                            [:children [:* [:schema [:ref "hiccup"]]]]]]
                          [:primitive any?]]}}
    "hiccup"])

(def my-decoder (decoder my-sch (malli.transform/default-value-transformer)))

(mm/measure my-decoder) ;; 15.2 KiB - before any data has passed through the decoder

(defn generate-nested-hiccup [n]
   (if (zero? n)
     [:p {} "Hello, world of data"]
     [:div {} (generate-nested-hiccup (dec n))]))

(my-decoder (generate-nested-hiccup 100))
(mm/measure my-decoder)  ;; 157.3 KiB

(my-decoder (generate-nested-hiccup 200))
(mm/measure my-decoder) ;; 297.9 KiB - linear growth here but I've seen quadratic too
```

The solution is similar and inspired by @frenchy64's [#1245](https://github.com/metosin/malli/pull/1245), however, here I had the luxury of `options` map and so could avoid dynvar shenanigans. However, I would still need feedback on whether this approach is valid. Anyway, after the patch:

```clj
(def my-decoder (decoder my-sch (malli.transform/default-value-transformer)))

(mm/measure my-decoder) ; 42.0 KiB - initial footprint is bigger,
                        ; probably because it hangs onto a few more clojure.core vars

(my-decoder (generate-nested-hiccup 100))
(mm/measure my-decoder) ; 3.1 KiB - dropped down because I also benchmark with
                        ; https://github.com/metosin/malli/pull/1249, so you
                        ; can observe thunk cleaning at work

(my-decoder (generate-nested-hiccup 200))
(mm/measure my-decoder) ; 3.1 KiB - doesn't grow at all
```