### PR TITLE
Fix for nbb (babashka ClojureScript) compatibility

### DIFF
--- a/src/malli/impl/util.cljc
+++ b/src/malli/impl/util.cljc
@@ -72,8 +72,7 @@
   #?(:clj  (-pred-composer or 16)
      :cljs (fn [preds] (fn [x] (boolean (some #(% x) preds))))))
 
-#?(:clj
-   (defmacro predicate-schemas* [var-syms]
-     `(-> {}
-          ~@(for [vsym var-syms]
-              `(malli.core/-register-var '~vsym ~vsym)))))
+(defmacro predicate-schemas* [var-syms]
+  `(-> {}
+       ~@(for [vsym var-syms]
+           `(malli.core/-register-var '~vsym ~vsym))))

--- a/src/malli/sci.cljc
+++ b/src/malli/sci.cljc
@@ -1,10 +1,16 @@
 (ns malli.sci
-  (:require [borkdude.dynaload :as dynaload]))
+  (:require #?@(:org.babashka/nbb []
+                :default [[borkdude.dynaload :as dynaload]])))
 
 (defn evaluator [options fail!]
-  #?(:bb      (fn []
-                (fn [form]
-                  (load-string (str "(ns user (:require [malli.core :as m]))\n" form))))
+  #?(:org.babashka/nbb
+     (fn []
+       (fn [form]
+         (load-string (str "(ns user (:require [malli.core :as m]))\n" form))))
+     :bb
+     (fn []
+       (fn [form]
+         (load-string (str "(ns user (:require [malli.core :as m]))\n" form))))
      :default (let [eval-string* (dynaload/dynaload 'sci.core/eval-string* {:default nil})
                     init (dynaload/dynaload 'sci.core/init {:default nil})
                     fork (dynaload/dynaload 'sci.core/fork {:default nil})]


### PR DESCRIPTION
This PR makes malli work with [nbb](https://github.com/babashka/nbb) — a
ClojureScript scripting environment powered by SCI (Small Clojure Interpreter).
Malli 0.17.0 works with nbb, but 0.18.0+ broke due to two issues. This PR
fixes both with minimal changes (2 files, ~20 lines), with zero behavioral
change for standard Clojure/ClojureScript users.

Depends on [babashka/nbb#407](https://github.com/babashka/nbb/issues/407)
(exposing `IPrintWithWriter` in nbb), which has been fixed on nbb master.

### Issue 1: `predicate-schemas*` JVM-only macro (introduced in 0.19.0)

The `predicate-schemas*` macro in `malli.impl.util` was wrapped in
`#?(:clj ...)`. In standard ClojureScript, the CLJS compiler runs this macro
on the JVM at compile time. In nbb/SCI (self-hosted ClojureScript), there is
no separate JVM compile step, so the macro was unavailable.

**Fix** (`impl/util.cljc`): Remove the `#?(:clj ...)` guard from the `defmacro`. The macro
body is portable Clojure (just `for` + quasiquoting, no JVM interop), so it
works in both JVM and self-hosted ClojureScript. This follows the same pattern
as `malli.core/assert`, which is also an unguarded `defmacro` in a `.cljc`
file. The existing `(:require-macros malli.impl.util)` in `core.cljc` ensures
it is loaded as a macro in ClojureScript contexts.

### Issue 2: `borkdude.dynaload` not deref-able under nbb

The `:default` evaluator path in `malli.sci` uses `dynaload` to load SCI
functions, then derefs them. In nbb, `dynaload` loads but the result cannot
be deref'd (`IDeref` protocol error), so the evaluator fails at runtime.

**Fix** (`sci.cljc`): Add `:org.babashka/nbb` reader conditional to skip the
`dynaload` require and use `load-string` directly for the evaluator (same
approach as `:bb`).

## Changes

- `src/malli/impl/util.cljc` — remove `#?(:clj)` guard from `predicate-schemas*` macro
- `src/malli/sci.cljc` — conditional require and nbb evaluator

**No changes to `core.cljc`.** The `IPrintWithWriter` issue that previously
required 46 reader conditionals is now resolved upstream in
[babashka/nbb#407](https://github.com/babashka/nbb/issues/407).

All existing tests pass.

## Testing

Verified with nbb dev build (includes nbb#407 fix) on macOS, both Node.js and bun:

```
$ node ~/nbb/lib/nbb_main.js -e '
(require (quote [malli.core :as m]))
(prn (m/validate [:map [:x int?] [:y int?]] {:x 1 :y 2}))     ;; true
(prn (m/validate [:map [:x int?] [:y int?]] {:x 1 :y "bad"}))  ;; false
(prn (m/validate [:or int? string?] "hello"))                   ;; true
(prn (m/parse [:* [:catn [:p string?] [:v [:altn [:s string?] [:b boolean?]]]]]
              ["-x" "foo" "-v" true]))
'
```

---
*This PR was authored with [Claude Code](https://claude.com/claude-code)*