### PR TITLE
lazily compute `:ref` validators until `-validator` is cheaper

### DIFF
--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2003,7 +2003,7 @@
                                                      (-validator (rf)))]
                                              (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
                                              @knot)))]
-                     (if lazy
+                     (if true #_lazy ;; lazily compute until -validator is cheaper
                        #((->validator) %)
                        (->validator))))))
            (-explainer [_ path]


### PR DESCRIPTION
Closes https://github.com/metosin/malli/issues/1269

Attempt to address startup time regression https://github.com/metosin/malli/issues/1269