### PR TITLE
clj-kondo: map bytes? to :array

### DIFF
--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -55,7 +55,7 @@
 (defmethod accept 'associative? [_ _ _ _] :associative)
 (defmethod accept 'sequential? [_ _ _ _] :sequential)
 (defmethod accept 'ratio? [_ _ _ _] :int) ;;??
-(defmethod accept 'bytes? [_ _ _ _] :char-sequence) ;;??
+(defmethod accept 'bytes? [_ _ _ _] :array)
 (defmethod accept 'ifn? [_ _ _ _] :ifn)
 (defmethod accept 'fn? [_ _ _ _] :fn)
 

--- a/src/malli/clj_kondo.cljc
+++ b/src/malli/clj_kondo.cljc
@@ -55,7 +55,7 @@
 (defmethod accept 'associative? [_ _ _ _] :associative)
 (defmethod accept 'sequential? [_ _ _ _] :sequential)
 (defmethod accept 'ratio? [_ _ _ _] :int) ;;??
-(defmethod accept 'bytes? [_ _ _ _] :array)
+#?(:clj (defmethod accept 'bytes? [_ _ _ _] :array))
 (defmethod accept 'ifn? [_ _ _ _] :ifn)
 (defmethod accept 'fn? [_ _ _ _] :fn)
 

--- a/test/malli/clj_kondo_test.cljc
+++ b/test/malli/clj_kondo_test.cljc
@@ -164,3 +164,8 @@
      (let [data (edn/read-string (slurp (io/file ".clj-kondo/imports/metosin/malli-types-clj/config.edn")))]
        (is (map? data))
        (is (= [:linters] (keys data))))))
+
+#?(:clj
+   (deftest fix-1276
+     (testing "bytes? should be mapped to :array"
+       (is (= :array (clj-kondo/transform bytes?))))))


### PR DESCRIPTION
Emit `:array` for `bytes?` so JVM `byte[]` matches array APIs like `alength` and clj-kondo stops reporting “char sequence” vs “array” for Malli-annotated code.

Fixes #1276