### PR TITLE
Share pointer children

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build-clj:
+    timeout-minutes: 5
     strategy:
       matrix:
         # Supported Java versions: LTS releases and latest
@@ -44,6 +45,7 @@ jobs:
 
   build-cljs:
     name: ClojureScript
+    timeout-minutes: 5
     strategy:
       matrix:
         mode: [none, advanced, cherry-none, cherry-advanced]
@@ -80,6 +82,7 @@ jobs:
   build-bb:
     name: Babashka
 
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -111,6 +114,7 @@ jobs:
     # the examples are still valid.
     name: Doc Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
       - name: Setup Java 25

--- a/README.md
+++ b/README.md
@@ -3250,8 +3250,10 @@ Note that a similar result happens when a local registry overlaps with a custom/
 
 This optimization currently only shares results amongst the transitive children
 of a schema, not between different top-level schemas. For the previous schema,
-that means a new shared schemas is created for `::list-of` when `m/schema` is
-called again, even though everything including `registry` is the same as the previous call.
+that means a new shared schema is created for `::list-of` when the `m/schema` is
+called again, even though everything is the same as the previous call.
+A future change may introduce an API to improve sharing across unrelated `m/schema`
+calls.
 
 See also [Recursive Schemas](#recursive-schemas).
 

--- a/README.md
+++ b/README.md
@@ -3497,7 +3497,9 @@ For performance reasons, Malli heavily caches registry
 lookups once a schema has been created via `m/schema`.
 
 Don't rely on registry mutations to be recognized consistently
-unless all schemas are reparsed. Here's a simple example:
+unless all schemas are reparsed. Here's an illustrative example
+where the redefinition of `::node` from `:int` to `:string`
+is done _after_ the former has been cached, and hence is ineffective:
 
 ```clojure
 (def registry*

--- a/README.md
+++ b/README.md
@@ -3192,13 +3192,13 @@ Local registries can be persisted:
 ;; => true
 ```
 
-Due to local registries using dynamic scope,
-a naive implementation would parse registry entries lazily at use-sites.
-Since this would lead performance issues from redundant parsing of Schemas,
+Malli optimizes parsing local registries to maximally share their results.
+Since local registries use dynamic scope,
+a naive implementation of Malli references would parse registry entries lazily at use-sites,
+causing performance issues from redundant parsing of Schemas.
 Malli instead detects when the dynamic scope is identical and
 reuses already-parsed Schemas.
-Note that this optimization currently only shares results amongst the transitive children
-of a schema, not between different top-level schemas.
+
 For example, the three `::list-of` references share an identical Schema
 since their dynamic scopes are identical,
 parsing `::list-of` and `::element` only once.
@@ -3244,6 +3244,11 @@ Note that a similar result happens when a local registry overlaps with a custom/
           ::list-of]]
  {:registry registry})
 ```
+
+This optimization currently only shares results amongst the transitive children
+of a schema, not between different top-level schemas. For the previous schema,
+that means a new shared schemas is created for `::list-of` when `m/schema` is
+called again, even though everything including `registry` is the same as the previous call.
 
 See also [Recursive Schemas](#recursive-schemas).
 

--- a/README.md
+++ b/README.md
@@ -3192,6 +3192,41 @@ Local registries can be persisted:
 ;; => true
 ```
 
+Due to local registries using dynamic scope,
+a naive implementation would parse registry entries lazily at use-sites.
+Since this would lead performance issues from redundant parsing of Schemas,
+Malli instead detects when the dynamic scope is identical and
+reuses already-parsed Schemas.
+For example, the three `::list-of` references share an identical Schema
+since their dynamic scopes are identical,
+parsing `::list-of` and `::element` only once.
+
+<!-- :test-doc-blocks/skip -->
+```clojure
+[:schema {:registry {::list-of [:seqable ::element],
+                     ::element :string}}
+ [:tuple ::list-of
+         ::list-of
+         ::list-of]]
+```
+
+On the other hand, reusing names in overlapping registries to mean different things
+will disable this optimization.
+For example, in the following schema `::list-of` is used three times.
+The first two will share the same Schema instance, `[:seqable :string]`.
+The third is `[:seqable :int]`, and because the dynamic scope is
+different, both `::list-of` and `::element` will be entirely reparsed.
+
+<!-- :test-doc-blocks/skip -->
+```clojure
+[:schema {:registry {::list-of [:seqable ::element],
+                     ::element :string}}
+ [:tuple ::list-of
+         ::list-of
+         [:schema {:registry {::element :int}}
+          ::list-of]]]
+```
+
 See also [Recursive Schemas](#recursive-schemas).
 
 ### Changing the default registry

--- a/README.md
+++ b/README.md
@@ -3197,17 +3197,19 @@ a naive implementation would parse registry entries lazily at use-sites.
 Since this would lead performance issues from redundant parsing of Schemas,
 Malli instead detects when the dynamic scope is identical and
 reuses already-parsed Schemas.
+Note that this optimization currently only shares results amongst the transitive children
+of a schema, not between different top-level schemas.
 For example, the three `::list-of` references share an identical Schema
 since their dynamic scopes are identical,
 parsing `::list-of` and `::element` only once.
 
-<!-- :test-doc-blocks/skip -->
 ```clojure
-[:schema {:registry {::list-of [:seqable ::element],
-                     ::element :string}}
- [:tuple ::list-of
-         ::list-of
-         ::list-of]]
+(m/schema
+ [:schema {:registry {::list-of [:seqable ::element],
+                      ::element :string}}
+  [:tuple ::list-of
+          ::list-of
+          ::list-of]])
 ```
 
 On the other hand, reusing names in overlapping registries to mean different things
@@ -3217,14 +3219,30 @@ The first two will share the same Schema instance, `[:seqable :string]`.
 The third is `[:seqable :int]`, and because the dynamic scope is
 different, both `::list-of` and `::element` will be entirely reparsed.
 
-<!-- :test-doc-blocks/skip -->
 ```clojure
-[:schema {:registry {::list-of [:seqable ::element],
-                     ::element :string}}
- [:tuple ::list-of
-         ::list-of
+(m/schema
+ [:schema {:registry {::list-of [:seqable ::element],
+                      ::element :string}}
+  [:tuple ::list-of ;; shared
+          ::list-of ;; shared
+          [:schema {:registry {::element :int}}
+           ;; not shared, also reparses ::list-of 
+           ::list-of]]])
+```
+
+Note that a similar result happens when a local registry overlaps with a custom/global registry:
+
+```clojure
+(def registry {::list-of [:seqable ::element],
+               ::element :string}})
+
+(m/schema
+ [:tuple ::list-of ;; shared
+         ::list-of ;; shared
          [:schema {:registry {::element :int}}
-          ::list-of]]]
+          ;; not shared, also reparses ::list-of 
+          ::list-of]]
+ {:registry registry})
 ```
 
 See also [Recursive Schemas](#recursive-schemas).

--- a/README.md
+++ b/README.md
@@ -3233,8 +3233,11 @@ different, both `::list-of` and `::element` will be entirely reparsed.
 Note that a similar result happens when a local registry overlaps with a custom/global registry:
 
 ```clojure
-(def registry {::list-of [:seqable ::element],
-               ::element :string}})
+(def registry
+  (mr/composite-registry
+    {::list-of [:seqable ::element],
+     ::element :string}
+    m/default-registry}))
 
 (m/schema
  [:tuple ::list-of ;; shared

--- a/README.md
+++ b/README.md
@@ -3237,7 +3237,7 @@ Note that a similar result happens when a local registry overlaps with a custom/
   (mr/composite-registry
     {::list-of [:seqable ::element],
      ::element :string}
-    m/default-registry}))
+    m/default-registry))
 
 (m/schema
  [:tuple ::list-of ;; shared

--- a/README.md
+++ b/README.md
@@ -3248,14 +3248,15 @@ Note that a similar result happens when a local registry overlaps with a custom/
  {:registry registry})
 ```
 
-This optimization currently only shares results amongst the transitive children
+This optimization currently only shares results among the transitive children
 of a schema, not between different top-level schemas. For the previous schema,
 that means a new shared schema is created for `::list-of` when the `m/schema` is
 called again, even though everything is the same as the previous call.
 A future change may introduce an API to improve sharing across unrelated `m/schema`
 calls.
 
-See also [Recursive Schemas](#recursive-schemas).
+See also [Recursive Schemas](#recursive-schemas),
+[Mutable registries are a dev-time abstraction](#mutable-registries-are-a-dev-time-abstraction).
 
 ### Changing the default registry
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -321,6 +321,7 @@
 
 (defn -property-registry [m options f]
   (let [options (c/update options ::schema-cache #(or % (atom {})))]
+    ;;TODO implement letrec by turning vals into cached proxies, then resolving them all in the result
     (reduce-kv (fn [acc k v] (assoc acc k (f (-> (-pointer k v options) -children first)))) {} m)))
 
 (defn -delayed-registry [m f]
@@ -2083,84 +2084,86 @@
                        {:scope (-> options -registry mr/-schemas)
                         :name id})]
           (or (when ref-id
-                (-> schema-cache c/deref (c/get ref-id)))
+                (when-some [f (-> schema-cache c/deref (c/get ref-id))]
+                  (f)))
               (let [res
-                    (let [children (-vmap #(schema % options) children)
-                          child (nth children 0)
-                          form (delay (or (and (empty? properties) (or id (and raw (-form child))))
-                                          (-simple-form parent properties children -form options)))
-                          cache (-create-cache options)]
-                      ^{:type ::schema}
-                      (reify
-                        AST
-                        (-to-ast [this _]
-                          (cond
-                            id (-ast {:type type, :value id} (-properties this) (-options this))
-                            raw (-to-value-ast this)
-                            :else (-to-child-ast this)))
-                        Schema
-                        (-validator [_] (-validator child))
-                        (-explainer [_ path] (-explainer child (conj path 0)))
-                        (-parser [_] (-parser child))
-                        (-unparser [_] (-unparser child))
-                        (-transformer [this transformer method options]
-                          (-parent-children-transformer this children transformer method options))
-                        (-walk [this walker path options]
-                          (when (-accept walker this path options)
-                            (if (or (not id) ((-boolean-fn (::walk-schema-refs options false)) id))
-                              (-outer walker this path (-inner-indexed walker path children options) options)
-                              (-outer walker this path children options))))
-                        (-properties [_] properties)
-                        (-options [_] options)
-                        (-children [_] children)
-                        (-parent [_] parent)
-                        (-form [_] @form)
-                        Cached
-                        (-cache [_] cache)
-                        LensSchema
-                        (-keep [_])
-                        (-get [_ key default] (if (= key 0) child default))
-                        (-set [this key value] (if (= key 0) (-set-children this [value])
-                                                 (-fail! ::index-out-of-bounds {:schema this, :key key})))
-                        RefSchema
-                        (-ref [_] id)
-                        (-deref [_] child)
-                        RegexSchema
-                        (-regex-op? [_]
-                          (if internal
-                            (-regex-op? child)
-                            false))
-                        (-regex-validator [_]
-                          (if internal
-                            (-regex-validator child)
-                            (re/item-validator (-validator child))))
-                        (-regex-explainer [_ path]
-                          (if internal
-                            (-regex-explainer child path)
-                            (re/item-explainer path child (-explainer child path))))
-                        (-regex-parser [_]
-                          (if internal
-                            (-regex-parser child)
-                            (re/item-parser (parser child))))
-                        (-regex-unparser [_]
-                          (if internal
-                            (-regex-unparser child)
-                            (re/item-unparser (unparser child))))
-                        (-regex-transformer [_ transformer method options]
-                          (if internal
-                            (-regex-transformer child transformer method options)
-                            (re/item-transformer method (-validator child)
-                                                 (or (-transformer child transformer method options) identity))))
-                        (-regex-min-max [_ nested?]
-                          (if (and nested? (not internal))
-                            {:min 1 :max 1}
-                            (-regex-min-max child nested?)))
-                        #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))])))]
+                    (fn []
+                      (let [children (-vmap #(schema % options) children)
+                            child (nth children 0)
+                            form (delay (or (and (empty? properties) (or id (and raw (-form child))))
+                                            (-simple-form parent properties children -form options)))
+                            cache (-create-cache options)]
+                        ^{:type ::schema}
+                        (reify
+                          AST
+                          (-to-ast [this _]
+                            (cond
+                              id (-ast {:type type, :value id} (-properties this) (-options this))
+                              raw (-to-value-ast this)
+                              :else (-to-child-ast this)))
+                          Schema
+                          (-validator [_] (-validator child))
+                          (-explainer [_ path] (-explainer child (conj path 0)))
+                          (-parser [_] (-parser child))
+                          (-unparser [_] (-unparser child))
+                          (-transformer [this transformer method options]
+                            (-parent-children-transformer this children transformer method options))
+                          (-walk [this walker path options]
+                            (when (-accept walker this path options)
+                              (if (or (not id) ((-boolean-fn (::walk-schema-refs options false)) id))
+                                (-outer walker this path (-inner-indexed walker path children options) options)
+                                (-outer walker this path children options))))
+                          (-properties [_] properties)
+                          (-options [_] options)
+                          (-children [_] children)
+                          (-parent [_] parent)
+                          (-form [_] @form)
+                          Cached
+                          (-cache [_] cache)
+                          LensSchema
+                          (-keep [_])
+                          (-get [_ key default] (if (= key 0) child default))
+                          (-set [this key value] (if (= key 0) (-set-children this [value])
+                                                   (-fail! ::index-out-of-bounds {:schema this, :key key})))
+                          RefSchema
+                          (-ref [_] id)
+                          (-deref [_] child)
+                          RegexSchema
+                          (-regex-op? [_]
+                            (if internal
+                              (-regex-op? child)
+                              false))
+                          (-regex-validator [_]
+                            (if internal
+                              (-regex-validator child)
+                              (re/item-validator (-validator child))))
+                          (-regex-explainer [_ path]
+                            (if internal
+                              (-regex-explainer child path)
+                              (re/item-explainer path child (-explainer child path))))
+                          (-regex-parser [_]
+                            (if internal
+                              (-regex-parser child)
+                              (re/item-parser (parser child))))
+                          (-regex-unparser [_]
+                            (if internal
+                              (-regex-unparser child)
+                              (re/item-unparser (unparser child))))
+                          (-regex-transformer [_ transformer method options]
+                            (if internal
+                              (-regex-transformer child transformer method options)
+                              (re/item-transformer method (-validator child)
+                                                   (or (-transformer child transformer method options) identity))))
+                          (-regex-min-max [_ nested?]
+                            (if (and nested? (not internal))
+                              {:min 1 :max 1}
+                              (-regex-min-max child nested?)))
+                          #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))]))))]
                 ;(prn res ref-id)
-                (if ref-id
+                (if nil #_ref-id
                   (do ;(prn (count @schema-cache))
-                      (get (swap! schema-cache c/update ref-id #(or % res)) ref-id))
-                  res)))))
+                      ((get (swap! schema-cache c/update ref-id #(or % res)) ref-id)))
+                  (res))))))
       #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-into-schema this writer opts))]))))
 
 (defn -=>-schema []
@@ -2532,8 +2535,9 @@
   ([type properties children options]
    (let [properties' (when properties (when (pos? (count properties)) properties))
          r (when properties' (properties' :registry))
+         r (when r (-property-registry r options identity))
          options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
-         properties (if r (assoc properties' :registry (-property-registry r options identity)) properties')]
+         properties (if r (assoc properties' :registry r) properties')]
      (-into-schema (-lookup! type [type properties children] into-schema? false options) properties children options))))
 
 (defn type

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -320,8 +320,7 @@
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
 (defn -property-registry [m options f]
-  (let [options (assoc options ::allow-invalid-refs true)
-        options (c/update options ::schema-cache #(or % (atom {})))]
+  (let [options (c/update options ::schema-cache #(or % (atom {})))]
     (reduce-kv (fn [acc k v] (assoc acc k (f (-> (-pointer k v options) -children first)))) {} m)))
 
 (defn -delayed-registry [m f]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -324,7 +324,7 @@
         ref-id (when (and id schema-cache)
                  {:scope (-> options -registry mr/-schemas)
                   :name id})
-        ->child (-memoize (fn [] (schema child options)))]
+        ->child (-memoize #(schema child options))]
     ((if ref-id
        ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
        ->child))))
@@ -2537,8 +2537,7 @@
    (into-schema type properties children nil))
   ([type properties children options]
    (let [properties' (when properties (when (pos? (count properties)) properties))
-         r (when properties' (properties' :registry))
-         r (when r (-property-registry r options identity))
+         r (when properties' (some-> (properties' :registry) (-property-registry options identity)))
          options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
          properties (if r (assoc properties' :registry r) properties')]
      (-into-schema (-lookup! type [type properties children] into-schema? false options) properties children options))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -323,11 +323,15 @@
   (let [schema-cache (::schema-cache options)
         ref-id (when (and id schema-cache)
                  {:scope (-> options -registry mr/-schemas)
+                  :child child
                   :name id})
-        ->child (-memoize #(schema child options))]
-    ((if ref-id
-       ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
-       ->child))))
+        ->child (-memoize #(schema child options))
+        res ((if ref-id
+       ((swap! schema-cache c/update ref-id #(if % (do (prn "HIT" child) %) (do (prn "MISS" child) ->child))) ref-id)
+       ->child))]
+    (prn "RESULT" res)
+    res
+    ))
 
 (defn -property-registry [m options f]
   (let [schema-cache (or (::schema-cache options) (atom {}))
@@ -2091,6 +2095,7 @@
       (-into-schema [parent properties children options]
         (-check-children! type properties children 1 1)
         (let [child (-pointed id (nth children 0) options)
+              _ (prn "child" child properties)
               children [child]
               form (delay (or (and (empty? properties) (or id (and raw (-form child))))
                               (-simple-form parent properties children -form options)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2870,7 +2870,10 @@
          maybe-set-ref (fn [s r] (if (and ref-key r) (-update-properties s assoc ref-key r) s))]
      (-> (walk schema (fn [schema _ children _]
                         (cond (= :ref (type schema)) schema
-                              (-ref-schema? schema) (maybe-set-ref (deref (-set-children schema children)) (-ref schema))
+                              (-ref-schema? schema) (do (prn "ref-schema" schema (-ref schema))
+                                                        (let [res (maybe-set-ref (deref (-set-children schema children)) (-ref schema))]
+                                                          (prn "after set:" res)
+                                                          res))
                               :else (-set-children schema children)))
                {::walk-schema-refs true})
          (deref-all)))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -322,14 +322,7 @@
 (defn -property-registry [m options f]
   (let [schema-cache (or (::schema-cache options) (atom {}))
         options (c/update options ::schema-cache #(or % schema-cache))
-        options (c/update options :registry #(mr/lazy-registry
-                                               (or % (-registry options))
-                                               (fn [name default]
-                                                 (if-some [default (get m name)]
-                                                   (if-some [f (get @schema-cache name)]
-                                                     (f)
-                                                     default)
-                                                   default))))]
+        options (c/update options :registry #(mr/composite-registry m (or % (-registry options))))]
     (reduce-kv (fn [acc k v] (assoc acc k (f (-> (-pointer k v options) -children first)))) {} m)))
 
 (defn -delayed-registry [m f]
@@ -2090,88 +2083,81 @@
         (let [schema-cache (::schema-cache options)
               ref-id (when (and id schema-cache)
                        {:scope (-> options -registry mr/-schemas)
-                        :name id})]
-          (or (when ref-id
-                (when-some [f (-> schema-cache c/deref (c/get ref-id))]
-                  (f)))
-              (let [res
-                    (fn []
-                      (let [children (-vmap #(schema % options) children)
-                            child (nth children 0)
-                            form (delay (or (and (empty? properties) (or id (and raw (-form child))))
-                                            (-simple-form parent properties children -form options)))
-                            cache (-create-cache options)]
-                        ^{:type ::schema}
-                        (reify
-                          AST
-                          (-to-ast [this _]
-                            (cond
-                              id (-ast {:type type, :value id} (-properties this) (-options this))
-                              raw (-to-value-ast this)
-                              :else (-to-child-ast this)))
-                          Schema
-                          (-validator [_] (-validator child))
-                          (-explainer [_ path] (-explainer child (conj path 0)))
-                          (-parser [_] (-parser child))
-                          (-unparser [_] (-unparser child))
-                          (-transformer [this transformer method options]
-                            (-parent-children-transformer this children transformer method options))
-                          (-walk [this walker path options]
-                            (when (-accept walker this path options)
-                              (if (or (not id) ((-boolean-fn (::walk-schema-refs options false)) id))
-                                (-outer walker this path (-inner-indexed walker path children options) options)
-                                (-outer walker this path children options))))
-                          (-properties [_] properties)
-                          (-options [_] options)
-                          (-children [_] children)
-                          (-parent [_] parent)
-                          (-form [_] @form)
-                          Cached
-                          (-cache [_] cache)
-                          LensSchema
-                          (-keep [_])
-                          (-get [_ key default] (if (= key 0) child default))
-                          (-set [this key value] (if (= key 0) (-set-children this [value])
-                                                   (-fail! ::index-out-of-bounds {:schema this, :key key})))
-                          RefSchema
-                          (-ref [_] id)
-                          (-deref [_] child)
-                          RegexSchema
-                          (-regex-op? [_]
-                            (if internal
-                              (-regex-op? child)
-                              false))
-                          (-regex-validator [_]
-                            (if internal
-                              (-regex-validator child)
-                              (re/item-validator (-validator child))))
-                          (-regex-explainer [_ path]
-                            (if internal
-                              (-regex-explainer child path)
-                              (re/item-explainer path child (-explainer child path))))
-                          (-regex-parser [_]
-                            (if internal
-                              (-regex-parser child)
-                              (re/item-parser (parser child))))
-                          (-regex-unparser [_]
-                            (if internal
-                              (-regex-unparser child)
-                              (re/item-unparser (unparser child))))
-                          (-regex-transformer [_ transformer method options]
-                            (if internal
-                              (-regex-transformer child transformer method options)
-                              (re/item-transformer method (-validator child)
-                                                   (or (-transformer child transformer method options) identity))))
-                          (-regex-min-max [_ nested?]
-                            (if (and nested? (not internal))
-                              {:min 1 :max 1}
-                              (-regex-min-max child nested?)))
-                          #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))]))))]
-                ;(prn res ref-id)
-                (if nil #_ref-id ;;TODO tie the knot
-                  (do ;(prn (count @schema-cache))
-                      ((get (swap! schema-cache c/update ref-id #(or % res)) ref-id)))
-                  (res))))))
+                        :name id})
+              ->child (delay (schema (nth children 0) options))
+              child @(if ref-id
+                       ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
+                       ->child)
+              children [child]
+              form (delay (or (and (empty? properties) (or id (and raw (-form child))))
+                              (-simple-form parent properties children -form options)))
+              cache (-create-cache options)]
+          ^{:type ::schema}
+          (reify
+            AST
+            (-to-ast [this _]
+              (cond
+                id (-ast {:type type, :value id} (-properties this) (-options this))
+                raw (-to-value-ast this)
+                :else (-to-child-ast this)))
+            Schema
+            (-validator [_] (-validator child))
+            (-explainer [_ path] (-explainer child (conj path 0)))
+            (-parser [_] (-parser child))
+            (-unparser [_] (-unparser child))
+            (-transformer [this transformer method options]
+              (-parent-children-transformer this children transformer method options))
+            (-walk [this walker path options]
+              (when (-accept walker this path options)
+                (if (or (not id) ((-boolean-fn (::walk-schema-refs options false)) id))
+                  (-outer walker this path (-inner-indexed walker path children options) options)
+                  (-outer walker this path children options))))
+            (-properties [_] properties)
+            (-options [_] options)
+            (-children [_] children)
+            (-parent [_] parent)
+            (-form [_] @form)
+            Cached
+            (-cache [_] cache)
+            LensSchema
+            (-keep [_])
+            (-get [_ key default] (if (= key 0) child default))
+            (-set [this key value] (if (= key 0) (-set-children this [value])
+                                     (-fail! ::index-out-of-bounds {:schema this, :key key})))
+            RefSchema
+            (-ref [_] id)
+            (-deref [_] child)
+            RegexSchema
+            (-regex-op? [_]
+              (if internal
+                (-regex-op? child)
+                false))
+            (-regex-validator [_]
+              (if internal
+                (-regex-validator child)
+                (re/item-validator (-validator child))))
+            (-regex-explainer [_ path]
+              (if internal
+                (-regex-explainer child path)
+                (re/item-explainer path child (-explainer child path))))
+            (-regex-parser [_]
+              (if internal
+                (-regex-parser child)
+                (re/item-parser (parser child))))
+            (-regex-unparser [_]
+              (if internal
+                (-regex-unparser child)
+                (re/item-unparser (unparser child))))
+            (-regex-transformer [_ transformer method options]
+              (if internal
+                (-regex-transformer child transformer method options)
+                (re/item-transformer method (-validator child)
+                                     (or (-transformer child transformer method options) identity))))
+            (-regex-min-max [_ nested?]
+              (if (and nested? (not internal))
+                {:min 1 :max 1}
+                (-regex-min-max child nested?)))
+            #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))]))))
       #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-into-schema this writer opts))]))))
 
 (defn -=>-schema []

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -320,8 +320,16 @@
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
 (defn -property-registry [m options f]
-  (let [options (c/update options ::schema-cache #(or % (atom {})))]
-    ;;TODO implement letrec by turning vals into cached proxies, then resolving them all in the result
+  (let [schema-cache (or (::schema-cache options) (atom {}))
+        options (c/update options ::schema-cache #(or % schema-cache))
+        options (c/update options :registry #(mr/lazy-registry
+                                               (or % (-registry options))
+                                               (fn [name default]
+                                                 (if-some [default (get m name)]
+                                                   (if-some [f (get @schema-cache name)]
+                                                     (f)
+                                                     default)
+                                                   default))))]
     (reduce-kv (fn [acc k v] (assoc acc k (f (-> (-pointer k v options) -children first)))) {} m)))
 
 (defn -delayed-registry [m f]
@@ -2160,7 +2168,7 @@
                               (-regex-min-max child nested?)))
                           #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))]))))]
                 ;(prn res ref-id)
-                (if nil #_ref-id
+                (if nil #_ref-id ;;TODO tie the knot
                   (do ;(prn (count @schema-cache))
                       ((get (swap! schema-cache c/update ref-id #(or % res)) ref-id)))
                   (res))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -319,7 +319,7 @@
   ([] default-registry)
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
-(defn- -pointer-child [id child options]
+(defn- -pointed [id child options]
   (let [schema-cache (::schema-cache options)
         ref-id (when (and id schema-cache)
                  {:scope (-> options -registry mr/-schemas)
@@ -333,7 +333,7 @@
   (let [schema-cache (or (::schema-cache options) (atom {}))
         options (c/update options ::schema-cache #(or % schema-cache))
         options (c/update options :registry #(mr/composite-registry m (or % (-registry options))))]
-    (reduce-kv (fn [acc k v] (assoc acc k (f (-pointer-child k v options)))) {} m)))
+    (reduce-kv (fn [acc k v] (assoc acc k (f (-pointed k v options)))) {} m)))
 
 (defn -delayed-registry [m f]
   (reduce-kv (fn [acc k v] (assoc acc k (reify IntoSchema (-into-schema [_ _ _ options] (f v options))))) {} m))
@@ -342,14 +342,8 @@
   (let [registry (-registry options)]
     (or (mr/-schema registry ?schema)
         (when-some [p (some-> registry (mr/-schema (c/type ?schema)))]
-          (prn "found" ?schema)
           (when (schema? ?schema)
             (when (= p (-parent ?schema))
-              (prn "parent:" p)
-              (prn "type:" (-type p))
-              (prn "schema meta type:" (c/type ?schema))
-              (prn "schema type:" (-> ?schema -parent -type))
-              (prn "schema:" ?schema)
               (-fail! ::infinitely-expanding-schema {:schema ?schema})))
           (-into-schema p nil [?schema] options)))))
 
@@ -2096,7 +2090,7 @@
       (-children-schema [_ _])
       (-into-schema [parent properties children options]
         (-check-children! type properties children 1 1)
-        (let [child (-pointer-child id (nth children 0) options)
+        (let [child (-pointed id (nth children 0) options)
               children [child]
               form (delay (or (and (empty? properties) (or id (and raw (-form child))))
                               (-simple-form parent properties children -form options)))
@@ -2537,9 +2531,10 @@
    (into-schema type properties children nil))
   ([type properties children options]
    (let [properties' (when properties (when (pos? (count properties)) properties))
-         r (when properties' (some-> (properties' :registry) (-property-registry options identity)))
-         options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
-         properties (if r (assoc properties' :registry r) properties')]
+         r (when properties' (properties' :registry))
+         options (cond-> options (and r (not (::schema-cache options))) (assoc ::schema-cache (atom {})))
+         options (cond-> options r (-update :registry #(mr/composite-registry r (or % (-registry options)))))
+         properties (cond-> properties' r (assoc :registry (-property-registry r options identity)))]
      (-into-schema (-lookup! type [type properties children] into-schema? false options) properties children options))))
 
 (defn type

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2869,12 +2869,19 @@
    (let [schema (schema ?schema options)
          maybe-set-ref (fn [s r] (if (and ref-key r) (-update-properties s assoc ref-key r) s))]
      (-> (walk schema (fn [schema _ children _]
-                        (cond (= :ref (type schema)) schema
-                              (-ref-schema? schema) (do (prn "ref-schema" schema (-ref schema))
-                                                        (let [res (maybe-set-ref (deref (-set-children schema children)) (-ref schema))]
-                                                          (prn "after set:" res)
+                        (prn "top" schema children)
+                        (cond (= :ref (type schema)) (do (prn "walk ref")
+                                                         schema)
+                              (-ref-schema? schema) (do (prn "ref-schema" schema (-ref schema) (type schema))
+                                                        (let [cschema (-set-children schema children)
+                                                              _ (prn "cschema" cschema)
+                                                              dschema (deref schema)
+                                                              _ (prn "dschema" dschema)
+                                                              res (maybe-set-ref dschema (-ref schema))]
+                                                          (prn "after set:" res (type res))
                                                           res))
-                              :else (-set-children schema children)))
+                              :else (do (prn "set children" schema children)
+                                        (-set-children schema children))))
                {::walk-schema-refs true})
          (deref-all)))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -324,10 +324,10 @@
         ref-id (when (and id schema-cache)
                  {:scope (-> options -registry mr/-schemas)
                   :name id})
-        ->child (delay (schema child options))]
-    @(if ref-id
+        ->child (-memoize (fn [] (schema child options)))]
+    ((if ref-id
        ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
-       ->child)))
+       ->child))))
 
 (defn -property-registry [m options f]
   (let [schema-cache (or (::schema-cache options) (atom {}))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -320,8 +320,9 @@
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
 (defn -property-registry [m options f]
-  (let [options (assoc options ::allow-invalid-refs true)]
-    (reduce-kv (fn [acc k v] (assoc acc k (f (schema v options)))) {} m)))
+  (let [options (assoc options ::allow-invalid-refs true)
+        options (c/update options ::schema-cache #(or % (atom {})))]
+    (reduce-kv (fn [acc k v] (assoc acc k (f (-> (-pointer k v options) -children first)))) {} m)))
 
 (defn -delayed-registry [m f]
   (reduce-kv (fn [acc k v] (assoc acc k (reify IntoSchema (-into-schema [_ _ _ options] (f v options))))) {} m))
@@ -2078,77 +2079,89 @@
       (-children-schema [_ _])
       (-into-schema [parent properties children options]
         (-check-children! type properties children 1 1)
-        (let [children (-vmap #(schema % options) children)
-              child (nth children 0)
-              form (delay (or (and (empty? properties) (or id (and raw (-form child))))
-                              (-simple-form parent properties children -form options)))
-              cache (-create-cache options)]
-          ^{:type ::schema}
-          (reify
-            AST
-            (-to-ast [this _]
-              (cond
-                id (-ast {:type type, :value id} (-properties this) (-options this))
-                raw (-to-value-ast this)
-                :else (-to-child-ast this)))
-            Schema
-            (-validator [_] (-validator child))
-            (-explainer [_ path] (-explainer child (conj path 0)))
-            (-parser [_] (-parser child))
-            (-unparser [_] (-unparser child))
-            (-transformer [this transformer method options]
-              (-parent-children-transformer this children transformer method options))
-            (-walk [this walker path options]
-              (when (-accept walker this path options)
-                (if (or (not id) ((-boolean-fn (::walk-schema-refs options false)) id))
-                  (-outer walker this path (-inner-indexed walker path children options) options)
-                  (-outer walker this path children options))))
-            (-properties [_] properties)
-            (-options [_] options)
-            (-children [_] children)
-            (-parent [_] parent)
-            (-form [_] @form)
-            Cached
-            (-cache [_] cache)
-            LensSchema
-            (-keep [_])
-            (-get [_ key default] (if (= key 0) child default))
-            (-set [this key value] (if (= key 0) (-set-children this [value])
+        (let [schema-cache (::schema-cache options)
+              ref-id (when (and id schema-cache)
+                       {:scope (-> options -registry mr/-schemas)
+                        :name id})]
+          (or (when ref-id
+                (-> schema-cache c/deref (c/get ref-id)))
+              (let [res
+                    (let [children (-vmap #(schema % options) children)
+                          child (nth children 0)
+                          form (delay (or (and (empty? properties) (or id (and raw (-form child))))
+                                          (-simple-form parent properties children -form options)))
+                          cache (-create-cache options)]
+                      ^{:type ::schema}
+                      (reify
+                        AST
+                        (-to-ast [this _]
+                          (cond
+                            id (-ast {:type type, :value id} (-properties this) (-options this))
+                            raw (-to-value-ast this)
+                            :else (-to-child-ast this)))
+                        Schema
+                        (-validator [_] (-validator child))
+                        (-explainer [_ path] (-explainer child (conj path 0)))
+                        (-parser [_] (-parser child))
+                        (-unparser [_] (-unparser child))
+                        (-transformer [this transformer method options]
+                          (-parent-children-transformer this children transformer method options))
+                        (-walk [this walker path options]
+                          (when (-accept walker this path options)
+                            (if (or (not id) ((-boolean-fn (::walk-schema-refs options false)) id))
+                              (-outer walker this path (-inner-indexed walker path children options) options)
+                              (-outer walker this path children options))))
+                        (-properties [_] properties)
+                        (-options [_] options)
+                        (-children [_] children)
+                        (-parent [_] parent)
+                        (-form [_] @form)
+                        Cached
+                        (-cache [_] cache)
+                        LensSchema
+                        (-keep [_])
+                        (-get [_ key default] (if (= key 0) child default))
+                        (-set [this key value] (if (= key 0) (-set-children this [value])
                                                  (-fail! ::index-out-of-bounds {:schema this, :key key})))
-            RefSchema
-            (-ref [_] id)
-            (-deref [_] child)
-            RegexSchema
-            (-regex-op? [_]
-              (if internal
-                (-regex-op? child)
-                false))
-            (-regex-validator [_]
-              (if internal
-                (-regex-validator child)
-                (re/item-validator (-validator child))))
-            (-regex-explainer [_ path]
-              (if internal
-                (-regex-explainer child path)
-                (re/item-explainer path child (-explainer child path))))
-            (-regex-parser [_]
-              (if internal
-                (-regex-parser child)
-                (re/item-parser (parser child))))
-            (-regex-unparser [_]
-              (if internal
-                (-regex-unparser child)
-                (re/item-unparser (unparser child))))
-            (-regex-transformer [_ transformer method options]
-              (if internal
-                (-regex-transformer child transformer method options)
-                (re/item-transformer method (-validator child)
-                                     (or (-transformer child transformer method options) identity))))
-            (-regex-min-max [_ nested?]
-              (if (and nested? (not internal))
-                {:min 1 :max 1}
-                (-regex-min-max child nested?)))
-            #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))]))))
+                        RefSchema
+                        (-ref [_] id)
+                        (-deref [_] child)
+                        RegexSchema
+                        (-regex-op? [_]
+                          (if internal
+                            (-regex-op? child)
+                            false))
+                        (-regex-validator [_]
+                          (if internal
+                            (-regex-validator child)
+                            (re/item-validator (-validator child))))
+                        (-regex-explainer [_ path]
+                          (if internal
+                            (-regex-explainer child path)
+                            (re/item-explainer path child (-explainer child path))))
+                        (-regex-parser [_]
+                          (if internal
+                            (-regex-parser child)
+                            (re/item-parser (parser child))))
+                        (-regex-unparser [_]
+                          (if internal
+                            (-regex-unparser child)
+                            (re/item-unparser (unparser child))))
+                        (-regex-transformer [_ transformer method options]
+                          (if internal
+                            (-regex-transformer child transformer method options)
+                            (re/item-transformer method (-validator child)
+                                                 (or (-transformer child transformer method options) identity))))
+                        (-regex-min-max [_ nested?]
+                          (if (and nested? (not internal))
+                            {:min 1 :max 1}
+                            (-regex-min-max child nested?)))
+                        #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))])))]
+                ;(prn res ref-id)
+                (if ref-id
+                  (do ;(prn (count @schema-cache))
+                      (get (swap! schema-cache c/update ref-id #(or % res)) ref-id))
+                  res)))))
       #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-into-schema this writer opts))]))))
 
 (defn -=>-schema []
@@ -2585,7 +2598,7 @@
                            (into-schema t ?p (when (< 2 n) (subvec ?schema 2 n)) options)
                            (into-schema t nil (when (< 1 n) (subvec ?schema 1 n)) options)))
      :else (if-let [?schema' (and (-reference? ?schema) (-lookup ?schema options))]
-             (-pointer ?schema (schema ?schema' options) options)
+             (-pointer ?schema ?schema' options)
              (-> ?schema (-lookup! ?schema nil false options) (recur options))))))
 
 (defn form

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -325,13 +325,10 @@
                  {:scope (-> options -registry mr/-schemas)
                   :child child
                   :name id})
-        ->child (-memoize #(schema child options))
-        res ((if ref-id
-       ((swap! schema-cache c/update ref-id #(if % (do (prn "HIT" child) %) (do (prn "MISS" child) ->child))) ref-id)
-       ->child))]
-    (prn "RESULT" res)
-    res
-    ))
+        ->child (-memoize #(schema child options))]
+    ((if ref-id
+       ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
+       ->child))))
 
 (defn -property-registry [m options f]
   (let [schema-cache (or (::schema-cache options) (atom {}))
@@ -2095,7 +2092,6 @@
       (-into-schema [parent properties children options]
         (-check-children! type properties children 1 1)
         (let [child (-pointed id (nth children 0) options)
-              _ (prn "child" child properties)
               children [child]
               form (delay (or (and (empty? properties) (or id (and raw (-form child))))
                               (-simple-form parent properties children -form options)))
@@ -2874,19 +2870,9 @@
    (let [schema (schema ?schema options)
          maybe-set-ref (fn [s r] (if (and ref-key r) (-update-properties s assoc ref-key r) s))]
      (-> (walk schema (fn [schema _ children _]
-                        (prn "top" schema children)
-                        (cond (= :ref (type schema)) (do (prn "walk ref")
-                                                         schema)
-                              (-ref-schema? schema) (do (prn "ref-schema" schema (-ref schema) (type schema))
-                                                        (let [cschema (-set-children schema children)
-                                                              _ (prn "cschema" cschema)
-                                                              dschema (deref schema)
-                                                              _ (prn "dschema" dschema)
-                                                              res (maybe-set-ref dschema (-ref schema))]
-                                                          (prn "after set:" res (type res))
-                                                          res))
-                              :else (do (prn "set children" schema children)
-                                        (-set-children schema children))))
+                        (cond (= :ref (type schema)) schema
+                              (-ref-schema? schema) (maybe-set-ref (deref (-set-children schema children)) (-ref schema))
+                              :else (-set-children schema children)))
                {::walk-schema-refs true})
          (deref-all)))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -319,11 +319,21 @@
   ([] default-registry)
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
+(defn- -pointer-child [id child options]
+  (let [schema-cache (::schema-cache options)
+        ref-id (when (and id schema-cache)
+                 {:scope (-> options -registry mr/-schemas)
+                  :name id})
+        ->child (delay (schema child options))]
+    @(if ref-id
+       ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
+       ->child)))
+
 (defn -property-registry [m options f]
   (let [schema-cache (or (::schema-cache options) (atom {}))
         options (c/update options ::schema-cache #(or % schema-cache))
         options (c/update options :registry #(mr/composite-registry m (or % (-registry options))))]
-    (reduce-kv (fn [acc k v] (assoc acc k (f (-> (-pointer k v options) -children first)))) {} m)))
+    (reduce-kv (fn [acc k v] (assoc acc k (f (-pointer-child k v options)))) {} m)))
 
 (defn -delayed-registry [m f]
   (reduce-kv (fn [acc k v] (assoc acc k (reify IntoSchema (-into-schema [_ _ _ options] (f v options))))) {} m))
@@ -332,8 +342,14 @@
   (let [registry (-registry options)]
     (or (mr/-schema registry ?schema)
         (when-some [p (some-> registry (mr/-schema (c/type ?schema)))]
+          (prn "found" ?schema)
           (when (schema? ?schema)
             (when (= p (-parent ?schema))
+              (prn "parent:" p)
+              (prn "type:" (-type p))
+              (prn "schema meta type:" (c/type ?schema))
+              (prn "schema type:" (-> ?schema -parent -type))
+              (prn "schema:" ?schema)
               (-fail! ::infinitely-expanding-schema {:schema ?schema})))
           (-into-schema p nil [?schema] options)))))
 
@@ -2080,14 +2096,7 @@
       (-children-schema [_ _])
       (-into-schema [parent properties children options]
         (-check-children! type properties children 1 1)
-        (let [schema-cache (::schema-cache options)
-              ref-id (when (and id schema-cache)
-                       {:scope (-> options -registry mr/-schemas)
-                        :name id})
-              ->child (delay (schema (nth children 0) options))
-              child @(if ref-id
-                       ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
-                       ->child)
+        (let [child (-pointer-child id (nth children 0) options)
               children [child]
               form (delay (or (and (empty? properties) (or id (and raw (-form child))))
                               (-simple-form parent properties children -form options)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2132,7 +2132,7 @@
             (-keep [_])
             (-get [_ key default] (if (= key 0) child default))
             (-set [this key value] (if (= key 0) (-set-children this [value])
-                                     (-fail! ::index-out-of-bounds {:schema this, :key key})))
+                                                 (-fail! ::index-out-of-bounds {:schema this, :key key})))
             RefSchema
             (-ref [_] id)
             (-deref [_] child)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2004,6 +2004,7 @@
                             (when-not allow-invalid-refs
                               (-fail! ::invalid-ref {:type :ref, :ref ref}))))
              _ (when-not lazy (?schema))
+             ;;TODO use -pointed
              rf (-memoize #(schema (?schema) options))
              children (vec children)
              form (delay (-simple-form parent properties children identity options))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -342,10 +342,7 @@
        ->child))))
 
 (defn -property-registry [m options f]
-  (let [schema-cache (or (::schema-cache options) (atom {}))
-        options (c/update options ::schema-cache #(or % schema-cache))
-        options (c/update options :registry #(mr/composite-registry m (or % (-registry options))))]
-    (reduce-kv (fn [acc k v] (assoc acc k (f (-pointed k v options)))) {} m)))
+  (reduce-kv (fn [acc k v] (assoc acc k (f (-pointed k v options)))) {} m))
 
 (defn -delayed-registry [m f]
   (reduce-kv (fn [acc k v] (assoc acc k (reify IntoSchema (-into-schema [_ _ _ options] (f v options))))) {} m))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2008,7 +2008,7 @@
              children (vec children)
              form (delay (-simple-form parent properties children identity options))
              cache (-create-cache options)
-             shared-cache (-> options ::schema-cache :cache)
+             shared-cache (-memoize #(-shared-cache ref (?schema) options))
              ->parser (fn [f] (let [parser (-memoize (fn [] (f (rf))))]
                                 (fn [x] ((parser) x))))]
          ^{:type ::schema}
@@ -2017,27 +2017,18 @@
            (-to-ast [this _] (-to-value-ast this))
            Schema
            (-validator [this]
-             (if #_false true ;;TODO
-               (let [id (-identify-ref-schema this)
-                     id->validator *ref-validators*]
-                 (or (id->validator id)
-                     (let [knot (atom nil)
-                           rec #(@knot %)
-                           ->validator (fn []
-                                         (or @knot
-                                             (let [f (binding [*ref-validators* (assoc id->validator id rec)]
-                                                       (-validator (rf)))]
-                                               (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
-                                               @knot)))]
-                       (if true #_lazy ;; lazily compute until -validator is cheaper
-                         #((->validator) %)
-                         (->validator)))))
-               (or (:validator @cache)
-                   (let [knot (::validator-knot (swap! cache update ::validator-knot #(or % (atom nil))))
+             (let [id (-identify-ref-schema this)
+                   id->validator *ref-validators*]
+               (or (id->validator id)
+                   (let [knot (atom nil)
+                         rec #(@knot %)
                          ->validator (fn []
-                                       (compare-and-set! knot nil (-validator (rf))) ;; tie the knot (once), rec now callable
-                                       (:validator (swap! cache update :validator (fn [f] (or f #(@knot %))))))]
-                     (if lazy
+                                       (or @knot
+                                           (let [f (binding [*ref-validators* (assoc id->validator id rec)]
+                                                     (-validator (rf)))]
+                                             (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
+                                             @knot)))]
+                     (if true #_lazy ;; lazily compute until -validator is cheaper
                        #((->validator) %)
                        (->validator))))))
            (-explainer [_ path]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -331,14 +331,16 @@
 ;; pointers themselves parsing their children. This is automatically handled via
 ;; the :scope entry in the cache key. See corner cases in `eager-registry-parse-test`.
 (defn- -pointed [id child options]
-  (let [schema-cache (::schema-cache options)
-        ref-id (when (and id schema-cache)
+  (let [id->shared-cache (::id->shared-cache options)
+        ref-id (when (and id id->shared-cache)
                  {:scope (-> options -registry mr/-schemas)
                   :child child
                   :name id})
+        shared-cache (when ref-id
+                       (get (swap! id->shared-cache c/update ref-id #(or % (atom {}))) ref-id))
         ->child (-memoize #(schema child options))]
-    ((if ref-id
-       ((swap! schema-cache c/update ref-id #(or % ->child)) ref-id)
+    ((if shared-cache
+       (::->child (swap! shared-cache c/update ::->child #(or % ->child)))
        ->child))))
 
 (defn -property-registry [m options f]
@@ -2001,11 +2003,11 @@
                             (when-not allow-invalid-refs
                               (-fail! ::invalid-ref {:type :ref, :ref ref}))))
              _ (when-not lazy (?schema))
-             ;;TODO use -pointed
-             rf (-memoize #(schema (?schema) options))
+             rf (-memoize #(-pointed ref (?schema) options))
              children (vec children)
              form (delay (-simple-form parent properties children identity options))
              cache (-create-cache options)
+             shared-cache (-> options ::schema-cache :cache)
              ->parser (fn [f] (let [parser (-memoize (fn [] (f (rf))))]
                                 (fn [x] ((parser) x))))]
          ^{:type ::schema}
@@ -2014,18 +2016,27 @@
            (-to-ast [this _] (-to-value-ast this))
            Schema
            (-validator [this]
-             (let [id (-identify-ref-schema this)
-                   id->validator *ref-validators*]
-               (or (id->validator id)
-                   (let [knot (atom nil)
-                         rec #(@knot %)
+             (if #_false true ;;TODO
+               (let [id (-identify-ref-schema this)
+                     id->validator *ref-validators*]
+                 (or (id->validator id)
+                     (let [knot (atom nil)
+                           rec #(@knot %)
+                           ->validator (fn []
+                                         (or @knot
+                                             (let [f (binding [*ref-validators* (assoc id->validator id rec)]
+                                                       (-validator (rf)))]
+                                               (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
+                                               @knot)))]
+                       (if true #_lazy ;; lazily compute until -validator is cheaper
+                         #((->validator) %)
+                         (->validator)))))
+               (or (:validator @cache)
+                   (let [knot (::validator-knot (swap! cache update ::validator-knot #(or % (atom nil))))
                          ->validator (fn []
-                                       (or @knot
-                                           (let [f (binding [*ref-validators* (assoc id->validator id rec)]
-                                                     (-validator (rf)))]
-                                             (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
-                                             @knot)))]
-                     (if true #_lazy ;; lazily compute until -validator is cheaper
+                                       (compare-and-set! knot nil (-validator (rf))) ;; tie the knot (once), rec now callable
+                                       (:validator (swap! cache update :validator (fn [f] (or f #(@knot %))))))]
+                     (if lazy
                        #((->validator) %)
                        (->validator))))))
            (-explainer [_ path]
@@ -2542,7 +2553,7 @@
   ([type properties children options]
    (let [properties' (when properties (when (pos? (count properties)) properties))
          r (when properties' (properties' :registry))
-         options (if (and r (not (::schema-cache options))) (assoc options ::schema-cache (atom {})) options)
+         options (if (and r (not (::id->shared-cache options))) (assoc options ::id->shared-cache (atom {})) options)
          options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
          properties (if r (assoc properties' :registry (-property-registry r options identity)) properties')]
      (-into-schema (-lookup! type [type properties children] into-schema? false options) properties children options))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -14,7 +14,8 @@
 
 (declare schema schema? into-schema into-schema? type eval default-registry
          -simple-schema -val-schema -ref-schema -schema-schema -registry
-         parser unparser ast from-ast -instrument ^:private -safely-countable?)
+         parser unparser ast from-ast -instrument ^:private -safely-countable?
+         validator)
 
 ;;
 ;; protocols and records
@@ -129,7 +130,7 @@
   (-regex-validator [this]
     (if (-ref-schema? this)
       (-regex-validator (-deref this))
-      (re/item-validator (-validator this))))
+      (re/item-validator (validator this))))
 
   (-regex-explainer [this path]
     (if (-ref-schema? this)
@@ -149,7 +150,7 @@
   (-regex-transformer [this transformer method options]
     (if (-ref-schema? this)
       (-regex-transformer (-deref this) transformer method options)
-      (re/item-transformer method (-validator this) (or (-transformer this transformer method options) identity))))
+      (re/item-transformer method (validator this) (or (-transformer this transformer method options) identity))))
 
   (-regex-min-max [_ _] {:min 1, :max 1}))
 
@@ -680,7 +681,7 @@
   (let [this-transformer (-value-transformer transformer this method options)]
     (if (seq child-schemas)
       (let [transformers (-vmap #(or (-transformer % transformer method options) identity) child-schemas)
-            validators (-vmap -validator child-schemas)]
+            validators (-vmap validator child-schemas)]
         (-intercepting this-transformer
                        (if (= :decode method)
                          (fn [x]
@@ -787,7 +788,7 @@
 ;;
 
 (defn -simple-parser [s]
-  (let [validator (-validator s)]
+  (let [validator (validator s)]
     (fn [x] (if (validator x) x ::invalid))))
 
 (defn -simple-schema [props]
@@ -821,7 +822,7 @@
                   (if-let [pvalidator (when property-pred (property-pred properties))]
                     (fn [x] (and (pred x) (pvalidator x))) pred))
                 (-explainer [this path]
-                  (let [validator (-validator this)]
+                  (let [validator (validator this)]
                     (fn explain [x in acc]
                       (if-not (validator x) (conj acc (miu/-error path in this x)) acc))))
                 (-parser [this] (-simple-parser this))
@@ -899,7 +900,7 @@
         (reify
           Schema
           (-validator [_]
-            (let [validators (-vmap -validator children)] (miu/-every-pred validators)))
+            (let [validators (-vmap validator children)] (miu/-every-pred validators)))
           (-explainer [_ path]
             (let [explainers (-vmap (fn [[i c]] (-explainer c (conj path i))) (map-indexed vector children))]
               (fn explain [x in acc] (reduce (fn [acc' explainer] (explainer x in acc')) acc explainers))))
@@ -975,7 +976,7 @@
           AST
           (-to-ast [this _] (-entry-ast this (-entry-keyset entry-parser)))
           Schema
-          (-validator [this] (miu/-every-pred (-vmap (fn [[_ _ c]] (-validator c)) (-children this))))
+          (-validator [this] (miu/-every-pred (-vmap (fn [[_ _ c]] (validator c)) (-children this))))
           (-explainer [this path]
             (let [explainers (-vmap (fn [[k _ c]] (-explainer c (conj path k))) (-children this))]
               (fn explain [x in acc] (reduce (fn [acc' explainer] (explainer x in acc')) acc explainers))))
@@ -996,7 +997,7 @@
             ;; the unparsed value is checked against the remaining children.
             ;; if you want to modify a particular conjunct's unparsed value, you should remove all others.
             (let [ks (-vmap #(nth % 0) (-children this))
-                  validators (into {} (map (fn [[k _ c]] [k (-validator c)])) (-children this))
+                  validators (into {} (map (fn [[k _ c]] [k (validator c)])) (-children this))
                   unparsers (into {} (map (fn [[k _ c]] [k (-unparser c)])) (-children this))
                   nchildren (count children)]
               (fn [tags]
@@ -1048,7 +1049,7 @@
         (reify
           Schema
           (-validator [_]
-            (let [validators (-vmap -validator children)] (miu/-some-pred validators)))
+            (let [validators (-vmap validator children)] (miu/-some-pred validators)))
           (-explainer [_ path]
             (let [explainers (-vmap (fn [[i c]] (-explainer c (conj path i))) (map-indexed vector children))]
               (fn explain [x in acc]
@@ -1098,7 +1099,7 @@
           AST
           (-to-ast [this _] (-entry-ast this (-entry-keyset entry-parser)))
           Schema
-          (-validator [this] (miu/-some-pred (-vmap (fn [[_ _ c]] (-validator c)) (-children this))))
+          (-validator [this] (miu/-some-pred (-vmap (fn [[_ _ c]] (validator c)) (-children this))))
           (-explainer [this path]
             (let [explainers (-vmap (fn [[k _ c]] (-explainer c (conj path k))) (-children this))]
               (fn explain [x in acc]
@@ -1161,9 +1162,9 @@
           AST
           (-to-ast [this _] (-to-child-ast this))
           Schema
-          (-validator [_] (complement (-validator schema)))
+          (-validator [_] (complement (validator schema)))
           (-explainer [this path]
-            (let [validator (-validator this)]
+            (let [validator (validator this)]
               (fn explain [x in acc]
                 (if-not (validator x) (conj acc (miu/-error (conj path 0) in this x)) acc))))
           (-parser [this] (-simple-parser this))
@@ -1211,7 +1212,7 @@
            AST
            (-to-ast [this _] (-to-child-ast this))
            Schema
-           (-validator [_] (-validator schema))
+           (-validator [_] (validator schema))
            (-explainer [_ path] (-explainer schema path))
            (-parser [_] (-parser schema))
            (-unparser [_] (-unparser schema))
@@ -1302,10 +1303,10 @@
            Schema
            (-validator [this]
              (let [keyset (-entry-keyset (-entry-parser this))
-                   default-validator (some-> @default-schema (-validator))
+                   default-validator (some-> @default-schema (validator))
                    validators (cond-> (-vmap
                                        (fn [[key {:keys [optional]} value]]
-                                         (let [valid? (-validator value)
+                                         (let [valid? (validator value)
                                                default (boolean optional)]
                                            #?(:bb   (fn [m] (if-let [map-entry (find m key)] (valid? (val map-entry)) default))
                                               :clj  (let [not-found (Object.)]
@@ -1432,8 +1433,8 @@
              (-ast {:type :map-of, :key (ast key-schema), :value (ast value-schema)} properties options))
            Schema
            (-validator [_]
-             (let [key-valid? (-validator key-schema)
-                   value-valid? (-validator value-schema)]
+             (let [key-valid? (validator key-schema)
+                   value-valid? (validator value-schema)]
                (fn [m]
                  (and (map? m)
                       (validate-limits m)
@@ -1567,7 +1568,7 @@
                 (-to-ast [this _] (-to-child-ast this))
                 Schema
                 (-validator [_]
-                  (let [validator (-validator schema)]
+                  (let [validator (validator schema)]
                     (fn [x] (and (fpred x)
                                  (validate-limits x)
                                  (reduce (fn [acc v] (if (validator v) acc (reduced false))) true
@@ -1587,8 +1588,8 @@
                                                                      :default size))))
                                     (cond-> (or (explainer x (conj in (fin i x)) acc) acc) xs (recur (inc i) xs))
                                     acc)))))))
-                (-parser [_] (->parser (if bounded -validator -parser) (if bounded identity parse)))
-                (-unparser [_] (->parser (if bounded -validator -unparser) (if bounded identity unparse)))
+                (-parser [_] (->parser (if bounded validator -parser) (if bounded identity parse)))
+                (-unparser [_] (->parser (if bounded validator -unparser) (if bounded identity unparse)))
                 (-transformer [this transformer method options]
                   (let [collection? #(or (sequential? %) (set? %))
                         this-transformer (-value-transformer transformer this method options)
@@ -1650,7 +1651,7 @@
          (reify
            Schema
            (-validator [_]
-             (let [validators (into (array-map) (map-indexed vector (mapv -validator children)))]
+             (let [validators (into (array-map) (map-indexed vector (mapv validator children)))]
                (fn [x] (and (vector? x)
                             (= (count x) size)
                             (reduce-kv
@@ -1716,7 +1717,7 @@
           (-validator [_]
             (fn [x] (contains? schema x)))
           (-explainer [this path]
-            (let [validator (-validator this)]
+            (let [validator (validator this)]
               (fn explain [x in acc]
                 (if-not (validator x) (conj acc (miu/-error path in this x)) acc))))
           (-parser [this] (-simple-parser this))
@@ -1866,7 +1867,7 @@
           (-to-ast [this _] (-to-child-ast this))
           Schema
           (-validator [_]
-            (let [validator (-validator schema)]
+            (let [validator (validator schema)]
               (fn [x] (or (nil? x) (validator x)))))
           (-explainer [_ path]
             (let [explainer (-explainer schema (conj path 0))]
@@ -1931,7 +1932,7 @@
                            options))
            Schema
            (-validator [_]
-             (let [find (finder (reduce-kv (fn [acc k s] (assoc acc k (-validator s))) {} @dispatch-map))]
+             (let [find (finder (reduce-kv (fn [acc k s] (assoc acc k (validator s))) {} @dispatch-map))]
                (fn [x] (if-let [validator (find (dispatch x))] (validator x) false))))
            (-explainer [this path]
              (let [find (finder (reduce (fn [acc [k s]] (assoc acc k (-explainer s (conj path k)))) {} (-entries this)))]
@@ -2031,7 +2032,7 @@
                                          (-fail! ::ref-no-shared-cache))
                                        (or @knot
                                            (let [f (binding [*ref-validators* (assoc id->validator id rec)]
-                                                     (-validator (rf)))]
+                                                     (validator (rf)))]
                                              (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
                                              @knot)))]
                      (if true #_lazy ;; lazily compute until -validator is cheaper
@@ -2123,7 +2124,7 @@
                 raw (-to-value-ast this)
                 :else (-to-child-ast this)))
             Schema
-            (-validator [_] (-validator child))
+            (-validator [_] (validator child))
             (-explainer [_ path] (-explainer child (conj path 0)))
             (-parser [_] (-parser child))
             (-unparser [_] (-unparser child))
@@ -2157,7 +2158,7 @@
             (-regex-validator [_]
               (if internal
                 (-regex-validator child)
-                (re/item-validator (-validator child))))
+                (re/item-validator (validator child))))
             (-regex-explainer [_ path]
               (if internal
                 (-regex-explainer child path)
@@ -2173,7 +2174,7 @@
             (-regex-transformer [_ transformer method options]
               (if internal
                 (-regex-transformer child transformer method options)
-                (re/item-transformer method (-validator child)
+                (re/item-transformer method (validator child)
                                      (or (-transformer child transformer method options) identity))))
             (-regex-min-max [_ nested?]
               (if (and nested? (not internal))
@@ -2224,7 +2225,7 @@
                                   (cond-> acc e (into (map #(assoc % :path (conj path i), :in in) (:errors e)))))]
                       (-> (conj acc error) (-push 0 explain-input) (-push 1 explain-output) (-push 2 explain-guard)))
                     acc)))
-              (let [validator (-validator this)]
+              (let [validator (validator this)]
                 (fn explain [x in acc]
                   (if-not (validator x) (conj acc (miu/-error path in this x)) acc)))))
           (-parser [this] (-simple-parser this))
@@ -2249,8 +2250,8 @@
                 max (assoc :max max))))
           (-instrument-f [schema {:keys [scope report gen] :as props} f _options]
             (let [{:keys [min max input output guard]} (-function-info schema)
-                  [validate-input validate-output] (-vmap -validator [input output])
-                  validate-guard (or (some-> guard -validator) any?)
+                  [validate-input validate-output] (-vmap validator [input output])
+                  validate-guard (or (some-> guard validator) any?)
                   [wrap-input wrap-output wrap-guard] (-vmap #(contains? scope %) [:input :output :guard])
                   f (or (if gen (gen schema) f) (-fail! ::missing-function {:props props}))]
               (fn [& args]
@@ -2308,7 +2309,7 @@
                   (if-let [res (checker x)]
                     (conj acc (assoc (miu/-error path in this x) :check res))
                     acc)))
-              (let [validator (-validator this)]
+              (let [validator (validator this)]
                 (fn explain [x in acc]
                   (if-not (validator x) (conj acc (miu/-error path in this x)) acc)))))
           (-parser [this] (-simple-parser this))
@@ -2367,7 +2368,7 @@
         ^{:type ::schema}
         (reify
           Schema
-          (-validator [_] (-validator @schema))
+          (-validator [_] (validator @schema))
           (-explainer [_ path] (-explainer @schema (conj path ::in)))
           (-parser [_] (-parser @schema))
           (-unparser [_] (-unparser @schema))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2023,6 +2023,8 @@
                    (let [knot (atom nil)
                          rec #(@knot %)
                          ->validator (fn []
+                                       (when-not (shared-cache)
+                                         (-fail! ::ref-no-shared-cache))
                                        (or @knot
                                            (let [f (binding [*ref-validators* (assoc id->validator id rec)]
                                                      (-validator (rf)))]
@@ -2606,7 +2608,9 @@
      (vector? ?schema) (let [v #?(:clj ^IPersistentVector ?schema, :cljs ?schema)
                              t (-lookup! #?(:clj (.nth v 0), :cljs (nth v 0)) v into-schema? true options)
                              n #?(:bb (count v) :clj (.count v), :cljs (count v))
-                             ?p (when (> n 1) #?(:clj (.nth v 1), :cljs (nth v 1)))]
+                             ?p (when (> n 1) #?(:clj (.nth v 1), :cljs (nth v 1)))
+                             options (if (not (::id->shared-cache options)) (assoc options ::id->shared-cache (atom {})) options)
+                             ]
                          (if (or (nil? ?p) (map? ?p))
                            (into-schema t ?p (when (< 2 n) (subvec ?schema 2 n)) options)
                            (into-schema t nil (when (< 1 n) (subvec ?schema 1 n)) options)))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1987,8 +1987,6 @@
   {:scope (-> schema -options -registry mr/-schemas)
    :name (-ref schema)})
 
-(def ^:dynamic ^:private *ref-validators* {})
-
 (defn -ref-schema
   ([]
    (-ref-schema nil))
@@ -2013,7 +2011,6 @@
              children (vec children)
              form (delay (-simple-form parent properties children identity options))
              cache (-create-cache options)
-             shared-cache (-memoize #(-shared-cache ref (?schema) options))
              ->parser (fn [f] (let [parser (-memoize (fn [] (f (rf))))]
                                 (fn [x] ((parser) x))))]
          ^{:type ::schema}
@@ -2022,22 +2019,16 @@
            (-to-ast [this _] (-to-value-ast this))
            Schema
            (-validator [this]
-             (let [id (-identify-ref-schema this)
-                   id->validator *ref-validators*]
-               (or (id->validator id)
-                   (let [knot (atom nil)
-                         rec #(@knot %)
-                         ->validator (fn []
-                                       (when-not (shared-cache)
-                                         (-fail! ::ref-no-shared-cache))
-                                       (or @knot
-                                           (let [f (binding [*ref-validators* (assoc id->validator id rec)]
-                                                     (validator (rf)))]
-                                             (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
-                                             @knot)))]
-                     (if true #_lazy ;; lazily compute until -validator is cheaper
-                       #((->validator) %)
-                       (->validator))))))
+             (let [knot (atom nil)
+                   rec #(@knot %)
+                   ->validator (fn []
+                                 (or @knot
+                                     (let [f (validator (rf))]
+                                       (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
+                                       @knot)))]
+               (if true #_lazy
+                 #((->validator) %)
+                 (->validator))))
            (-explainer [_ path]
              (let [explainer (-memoize (fn [] (-explainer (rf) (into path [0 0]))))]
                (fn [x in acc] ((explainer) x in acc))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2551,7 +2551,7 @@
   ([type properties children options]
    (let [properties' (when properties (when (pos? (count properties)) properties))
          r (when properties' (properties' :registry))
-         options (-ensure-shared-cache options)
+         options (if r (-ensure-shared-cache options) options)
          options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
          properties (if r (assoc properties' :registry (-property-registry r options identity)) properties')]
      (-into-schema (-lookup! type [type properties children] into-schema? false options) properties children options))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -327,6 +327,10 @@
                     :name id}]
         (get (swap! id->shared-cache c/update ref-id #(or % (atom {}))) ref-id)))))
 
+(defn- -ensure-shared-cache [options]
+  (cond-> options
+    (not (::id->shared-cache options)) (assoc ::id->shared-cache (atom {}))))
+
 ;; In [:schema {:registry {::foo :tuple} [:or ::foo ::foo]] there are
 ;; two pointers ::foo (in the :or) and one pointed-to schema :tuple (in the registry).
 ;; Since the pointers share identical scopes, they should share an identical child.
@@ -2604,18 +2608,17 @@
   ([?schema options]
    (cond
      (schema? ?schema) ?schema
-     (into-schema? ?schema) (-into-schema ?schema nil nil options)
+     (into-schema? ?schema) (-into-schema ?schema nil nil (-ensure-shared-cache options))
      (vector? ?schema) (let [v #?(:clj ^IPersistentVector ?schema, :cljs ?schema)
                              t (-lookup! #?(:clj (.nth v 0), :cljs (nth v 0)) v into-schema? true options)
                              n #?(:bb (count v) :clj (.count v), :cljs (count v))
                              ?p (when (> n 1) #?(:clj (.nth v 1), :cljs (nth v 1)))
-                             options (if (not (::id->shared-cache options)) (assoc options ::id->shared-cache (atom {})) options)
-                             ]
+                             options (-ensure-shared-cache options)]
                          (if (or (nil? ?p) (map? ?p))
                            (into-schema t ?p (when (< 2 n) (subvec ?schema 2 n)) options)
                            (into-schema t nil (when (< 1 n) (subvec ?schema 1 n)) options)))
      :else (if-let [?schema' (and (-reference? ?schema) (-lookup ?schema options))]
-             (-pointer ?schema ?schema' options)
+             (-pointer ?schema ?schema' (-ensure-shared-cache options))
              (-> ?schema (-lookup! ?schema nil false options) (recur options))))))
 
 (defn form
@@ -2903,7 +2906,7 @@
                          options (cond-> options r (-update :registry #(mr/composite-registry r (or % (-registry options)))))
                          ast (cond-> ?ast r (-update :properties #(assoc % :registry (-property-registry r options identity))))]
                      (cond (and (into-schema? s) (-ast? s)) (-from-ast s ast options)
-                           (into-schema? s) (-into-schema s (:properties ast) (-vmap #(from-ast % options) (:children ast)) options)
+                           (into-schema? s) (-into-schema s (:properties ast) (-vmap #(from-ast % options) (:children ast)) (-ensure-shared-cache options))
                            :else s))
                    (-fail! ::invalid-ast {:ast ?ast}))
      :else (-fail! ::invalid-ast {:ast ?ast}))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -1975,18 +1975,6 @@
            #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-schema this writer opts))]))))
      #?@(:cljs [IPrintWithWriter (-pr-writer [this writer opts] (-pr-writer-into-schema this writer opts))]))))
 
-;; returns an identifier for the :ref schema in the context of its dynamic scope.
-;; useful for detecting cycles.
-;; copied to malli.generator
-(defn- -identify-ref-schema [schema]
-  ;; TODO mr/-schemas doesn't seem right, making defn private for now.
-  ;; e.g., we only care about property registry entries, not schema constructors.
-  ;; a better approach might be to accumulate a 'seen' map from name => ?schema
-  ;; that we add to every time we deref a ref, and if we expand the same name again
-  ;; with the same seen map, it's a cycle.
-  {:scope (-> schema -options -registry mr/-schemas)
-   :name (-ref schema)})
-
 (defn -ref-schema
   ([]
    (-ref-schema nil))
@@ -2035,7 +2023,7 @@
            (-parser [_] (->parser -parser))
            (-unparser [_] (->parser -unparser))
            (-transformer [this transformer method options]
-             (let [key [(-identify-ref-schema this) method]]
+             (let [key [this method]]
                (or (some-> (get-in options [::ref-transformer-cache key]) clojure.core/deref)
                    (let [knot (atom nil)
                          this-transformer (-value-transformer transformer this method options)
@@ -2079,7 +2067,7 @@
            ParserInfo
            (-parser-info [this opts]
              (let [cycles (::parser-info-cycles opts #{})
-                   ref-id (-identify-ref-schema this)]
+                   ref-id this]
                (if (cycles ref-id)
                  {:simple-parser true}
                  (-parser-info (-deref this) (assoc opts ::parser-info-cycles (conj cycles ref-id))))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2068,17 +2068,11 @@
            AST
            (-to-ast [this _] (-to-value-ast this))
            Schema
-           (-validator [this]
-             (let [knot (atom nil)
-                   rec #(@knot %)
-                   ->validator (fn []
-                                 (or @knot
-                                     (let [f (validator (rf))]
-                                       (compare-and-set! knot nil f) ;; tie the knot (once), rec now callable
-                                       @knot)))]
-               (if true #_lazy
-                 #((->validator) %)
-                 (->validator))))
+           (-validator [_]
+             (let [knot (atom nil)]
+               (fn [x]
+                 ((or @knot (swap! knot #(or % (validator (rf)))))
+                  x))))
            (-explainer [_ path]
              (let [explainer (-memoize (fn [] (-explainer (rf) (into path [0 0]))))]
                (fn [x in acc] ((explainer) x in acc))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -319,6 +319,14 @@
   ([] default-registry)
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
+(defn- -shared-cache [id child options]
+  (when id
+    (when-some [id->shared-cache (::id->shared-cache options)]
+      (let [ref-id {:scope (-> options -registry mr/-schemas)
+                    :child child
+                    :name id}]
+        (get (swap! id->shared-cache c/update ref-id #(or % (atom {}))) ref-id)))))
+
 ;; In [:schema {:registry {::foo :tuple} [:or ::foo ::foo]] there are
 ;; two pointers ::foo (in the :or) and one pointed-to schema :tuple (in the registry).
 ;; Since the pointers share identical scopes, they should share an identical child.
@@ -331,15 +339,8 @@
 ;; pointers themselves parsing their children. This is automatically handled via
 ;; the :scope entry in the cache key. See corner cases in `eager-registry-parse-test`.
 (defn- -pointed [id child options]
-  (let [id->shared-cache (::id->shared-cache options)
-        ref-id (when (and id id->shared-cache)
-                 {:scope (-> options -registry mr/-schemas)
-                  :child child
-                  :name id})
-        shared-cache (when ref-id
-                       (get (swap! id->shared-cache c/update ref-id #(or % (atom {}))) ref-id))
-        ->child (-memoize #(schema child options))]
-    ((if shared-cache
+  (let [->child (-memoize #(schema child options))]
+    ((if-some [shared-cache (-shared-cache id child options)]
        (::->child (swap! shared-cache c/update ::->child #(or % ->child)))
        ->child))))
 

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2545,9 +2545,9 @@
   ([type properties children options]
    (let [properties' (when properties (when (pos? (count properties)) properties))
          r (when properties' (properties' :registry))
-         options (cond-> options (and r (not (::schema-cache options))) (assoc ::schema-cache (atom {})))
-         options (cond-> options r (-update :registry #(mr/composite-registry r (or % (-registry options)))))
-         properties (cond-> properties' r (assoc :registry (-property-registry r options identity)))]
+         options (if (and r (not (::schema-cache options))) (assoc options ::schema-cache (atom {})) options)
+         options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
+         properties (if r (assoc properties' :registry (-property-registry r options identity)) properties')]
      (-into-schema (-lookup! type [type properties children] into-schema? false options) properties children options))))
 
 (defn type

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2069,10 +2069,8 @@
            (-to-ast [this _] (-to-value-ast this))
            Schema
            (-validator [_]
-             (let [knot (atom nil)]
-               (fn [x]
-                 ((or @knot (swap! knot #(or % (validator (rf)))))
-                  x))))
+             (let [validator (-memoize #(validator (rf)))]
+               (fn [x] ((validator) x))))
            (-explainer [_ path]
              (let [explainer (-memoize (fn [] (-explainer (rf) (into path [0 0]))))]
                (fn [x in acc] ((explainer) x in acc))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -2551,7 +2551,7 @@
   ([type properties children options]
    (let [properties' (when properties (when (pos? (count properties)) properties))
          r (when properties' (properties' :registry))
-         options (if (and r (not (::id->shared-cache options))) (assoc options ::id->shared-cache (atom {})) options)
+         options (-ensure-shared-cache options)
          options (if r (-update options :registry #(mr/composite-registry r (or % (-registry options)))) options)
          properties (if r (assoc properties' :registry (-property-registry r options identity)) properties')]
      (-into-schema (-lookup! type [type properties children] into-schema? false options) properties children options))))

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -319,6 +319,17 @@
   ([] default-registry)
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
+;; In [:schema {:registry {::foo :tuple} [:or ::foo ::foo]] there are
+;; two pointers ::foo (in the :or) and one pointed-to schema :tuple (in the registry).
+;; Since the pointers share identical scopes, they should share an identical child.
+;;
+;; The `-pointer` helper ensures this sharing in (typically) two phases:
+;; 1. the pointed schema cache is seeded via `-property-registry`
+;; 2. the cache is used to resolve each pointer's child in the implementation
+;;
+;; In situations involving nested registries, the cache can also be populated by the
+;; pointers themselves parsing their children. This is automatically handled via
+;; the :scope entry in the cache key. See corner cases in `eager-registry-parse-test`.
 (defn- -pointed [id child options]
   (let [schema-cache (::schema-cache options)
         ref-id (when (and id schema-cache)

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -320,6 +320,68 @@
   ([] default-registry)
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
+;; ## Identifying schema recursion
+;;
+;; Refs are uniquely identified by their paired name and scope. If we see a ref with the
+;; same name and scope as another ref we've dereferenced previously, we know that this is a recursion
+;; point back to the previously seen ref. The rest of this section explains why.
+;;
+;; Refs resolve via dynamic scope, which means its dereferenced value is the latest binding found
+;; while expanding the schema until the point of finding the ref.
+;; This makes the (runtime) scope at the ref's location part of a ref's identity---if the scope
+;; is different, then it's (possibly) not the same ref because scope determines how schemas
+;; transitively expand.
+;;
+;; To illustrate why a ref's name is an insufficient identifier, here is a schema that is equivalent to `[:= 42]`:
+;;
+;;   [:schema {:registry {::a [:schema {:registry {::a [:= 42]}}
+;;                             ;; (2)
+;;                             [:ref ::a]]}}
+;;    ;; (1)
+;;    [:ref ::a]]
+;;
+;; If we identify refs just by name, we would have incorrectly detected (2) to be an (infinitely expanding) recursive
+;; reference.
+;;
+;; In studying the previous example, we might think that since (1) and (2) deref to different schemas, it might sufficient to identify refs just by their derefs.
+;; Unfortunately this just pushes the problem elsewhere.
+;;
+;; For example, here is another schema equivalent to `[:= 42]`:
+;;
+;;   [:schema {:registry {::a [:ref ::b] ;; (2)
+;;                        ::b [:schema {:registry {::a [:ref ::b] ;; (4)
+;;                                                 ::b [:= 42]}}
+;;                             ;; (3)
+;;                             [:ref ::a]]}}
+;;    ;; (1)
+;;    [:ref ::a]]
+;;
+;; If we identified ::a by its deref, it would look like (3) deref'ing to (4)
+;; is a recursion point after witnessing (1) deref'ing to (2), since (2) == (4). Except this
+;; is wrong since it's a different ::b at (2) and (4)! OTOH, if we identified (2) and (4) with their
+;; dynamic scopes along with their form, they would be clearly different. Indeed, this
+;; is another way to identify refs: pairing their derefs with their deref's scopes.
+;; It is slightly more direct to use the ref's direct name and scope, which is why
+;; we choose that identifier. The more general insight is that any schema is identified by its form+scope
+;; (note: but only after trimming the scope of irrelevant bindings, see next pararaph).
+;; That insight may be useful for detecting recursion at places other than refs.
+;;
+;; Ref identifiers could be made smarter by trimming irrelevant entries in identifying scope.
+;; Not all scope differences are relevant, so generators may expand more than strictly necessary
+;; in the quest to find the "same" ref schema again. It could skip over refs that generate exactly the
+;; same values, but their scopes are uninterestingly different (eg., unused bindings are different).
+;;
+;; For example, the following schema is recursive "in spirit" between (1) and (2), but since ::b
+;; changes, the scope will differ, so the recursion will be detected between (2) and itself instead
+;; (where the scope is constant):
+;;
+;;   [:schema {:registry {::a [:schema {:registry {::b :boolean}}
+;;                             ;; (2)
+;;                             [:or [:ref ::a] [:ref ::b]]]}}
+;;    [:schema {:registry {::b :int}}
+;;     ;; (1)
+;;     [:or [:ref ::a] [:ref ::b]]]]
+
 (defn- -shared-cache [id child options]
   (when id
     (when-some [id->shared-cache (::id->shared-cache options)]

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -320,68 +320,6 @@
   ([] default-registry)
   ([opts] (or (when opts (mr/registry (opts :registry))) default-registry)))
 
-;; ## Identifying schema recursion
-;;
-;; Refs are uniquely identified by their paired name and scope. If we see a ref with the
-;; same name and scope as another ref we've dereferenced previously, we know that this is a recursion
-;; point back to the previously seen ref. The rest of this section explains why.
-;;
-;; Refs resolve via dynamic scope, which means its dereferenced value is the latest binding found
-;; while expanding the schema until the point of finding the ref.
-;; This makes the (runtime) scope at the ref's location part of a ref's identity---if the scope
-;; is different, then it's (possibly) not the same ref because scope determines how schemas
-;; transitively expand.
-;;
-;; To illustrate why a ref's name is an insufficient identifier, here is a schema that is equivalent to `[:= 42]`:
-;;
-;;   [:schema {:registry {::a [:schema {:registry {::a [:= 42]}}
-;;                             ;; (2)
-;;                             [:ref ::a]]}}
-;;    ;; (1)
-;;    [:ref ::a]]
-;;
-;; If we identify refs just by name, we would have incorrectly detected (2) to be an (infinitely expanding) recursive
-;; reference.
-;;
-;; In studying the previous example, we might think that since (1) and (2) deref to different schemas, it might sufficient to identify refs just by their derefs.
-;; Unfortunately this just pushes the problem elsewhere.
-;;
-;; For example, here is another schema equivalent to `[:= 42]`:
-;;
-;;   [:schema {:registry {::a [:ref ::b] ;; (2)
-;;                        ::b [:schema {:registry {::a [:ref ::b] ;; (4)
-;;                                                 ::b [:= 42]}}
-;;                             ;; (3)
-;;                             [:ref ::a]]}}
-;;    ;; (1)
-;;    [:ref ::a]]
-;;
-;; If we identified ::a by its deref, it would look like (3) deref'ing to (4)
-;; is a recursion point after witnessing (1) deref'ing to (2), since (2) == (4). Except this
-;; is wrong since it's a different ::b at (2) and (4)! OTOH, if we identified (2) and (4) with their
-;; dynamic scopes along with their form, they would be clearly different. Indeed, this
-;; is another way to identify refs: pairing their derefs with their deref's scopes.
-;; It is slightly more direct to use the ref's direct name and scope, which is why
-;; we choose that identifier. The more general insight is that any schema is identified by its form+scope
-;; (note: but only after trimming the scope of irrelevant bindings, see next pararaph).
-;; That insight may be useful for detecting recursion at places other than refs.
-;;
-;; Ref identifiers could be made smarter by trimming irrelevant entries in identifying scope.
-;; Not all scope differences are relevant, so generators may expand more than strictly necessary
-;; in the quest to find the "same" ref schema again. It could skip over refs that generate exactly the
-;; same values, but their scopes are uninterestingly different (eg., unused bindings are different).
-;;
-;; For example, the following schema is recursive "in spirit" between (1) and (2), but since ::b
-;; changes, the scope will differ, so the recursion will be detected between (2) and itself instead
-;; (where the scope is constant):
-;;
-;;   [:schema {:registry {::a [:schema {:registry {::b :boolean}}
-;;                             ;; (2)
-;;                             [:or [:ref ::a] [:ref ::b]]]}}
-;;    [:schema {:registry {::b :int}}
-;;     ;; (1)
-;;     [:or [:ref ::a] [:ref ::b]]]]
-
 (defn- -shared-cache [id child options]
   (when id
     (when-some [id->shared-cache (::id->shared-cache options)]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -450,8 +450,9 @@
    (generator ?schema nil))
   ([?schema options]
    (if (::rec-gen options)
-     ;; if ::rec-gen exists then we're under a gen/recursive-gen.
-     ;; we disable the cache avoid pinning the generator to the base case (scalar-ref-gen in -ref-gen).
+     ;; if ::rec-gen exists then we're under a gen/recursive-gen via -ref-gen.
+     ;; we disable cache writes to avoid pinning the generator to the scalar generator,
+     ;; and disable cache reads to avoid returning the recursive case when the scalar generator is used.
      (-create (m/schema ?schema options) options)
      (m/-cached (m/schema ?schema options) :generator #(-create % options)))))
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -290,10 +290,10 @@
 ;;
 ;;   [:schema {:registry {::a [:schema {:registry {::b :boolean}}
 ;;                             ;; (2)
-;;                             [:or [:ref ::a] [:ref ::b]]]}}
+;;                             [:or [:ref ::b] [:ref ::a]]]}}
 ;;    [:schema {:registry {::b :int}}
 ;;     ;; (1)
-;;     [:or [:ref ::a] [:ref ::b]]]]
+;;     [:or [:ref ::b] [:ref ::a]]]]
 
 ;; copied to malli.core
 (defn- -identify-ref-schema [schema]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -250,72 +250,10 @@
 ;; (this is why this particular base case is so useful) and then propagate the (smaller) generator
 ;; supplied by `gen/recursive-gen` to convert recursive references.
 
-;; ## Identifying schema recursion
-;;
-;; Refs are uniquely identified by their paired name and scope. If we see a ref with the
-;; same name and scope as another ref we've dereferenced previously, we know that this is a recursion
-;; point back to the previously seen ref. The rest of this section explains why.
-;;
-;; Refs resolve via dynamic scope, which means its dereferenced value is the latest binding found
-;; while expanding the schema until the point of finding the ref.
-;; This makes the (runtime) scope at the ref's location part of a ref's identity---if the scope
-;; is different, then it's (possibly) not the same ref because scope determines how schemas
-;; transitively expand.
-;;
-;; To illustrate why a ref's name is an insufficient identifier, here is a schema that is equivalent to `[:= 42]`:
-;;
-;;   [:schema {:registry {::a [:schema {:registry {::a [:= 42]}}
-;;                             ;; (2)
-;;                             [:ref ::a]]}}
-;;    ;; (1)
-;;    [:ref ::a]]
-;;
-;; If we identify refs just by name, we would have incorrectly detected (2) to be an (infinitely expanding) recursive
-;; reference.
-;;
-;; In studying the previous example, we might think that since (1) and (2) deref to different schemas, it might sufficient to identify refs just by their derefs.
-;; Unfortunately this just pushes the problem elsewhere.
-;;
-;; For example, here is another schema equivalent to `[:= 42]`:
-;;
-;;   [:schema {:registry {::a [:ref ::b] ;; (2)
-;;                        ::b [:schema {:registry {::a [:ref ::b] ;; (4)
-;;                                                 ::b [:= 42]}}
-;;                             ;; (3)
-;;                             [:ref ::a]]}}
-;;    ;; (1)
-;;    [:ref ::a]]
-;;
-;; If we identified ::a by its deref, it would look like (3) deref'ing to (4)
-;; is a recursion point after witnessing (1) deref'ing to (2), since (2) == (4). Except this
-;; is wrong since it's a different ::b at (2) and (4)! OTOH, if we identified (2) and (4) with their
-;; dynamic scopes along with their form, they would be clearly different. Indeed, this
-;; is another way to identify refs: pairing their derefs with their deref's scopes.
-;; It is slightly more direct to use the ref's direct name and scope, which is why
-;; we choose that identifier. The more general insight is that any schema is identified by its form+scope
-;; (note: but only after trimming the scope of irrelevant bindings, see next pararaph).
-;; That insight may be useful for detecting recursion at places other than refs.
-;;
-;; Ref identifiers could be made smarter by trimming irrelevant entries in identifying scope.
-;; Not all scope differences are relevant, so generators may expand more than strictly necessary
-;; in the quest to find the "same" ref schema again. It could skip over refs that generate exactly the
-;; same values, but their scopes are uninterestingly different (eg., unused bindings are different).
-;;
-;; For example, the following schema is recursive "in spirit" between (1) and (2), but since ::b
-;; changes, the scope will differ, so the recursion will be detected between (2) and itself instead
-;; (where the scope is constant):
-;;
-;;   [:schema {:registry {::a [:schema {:registry {::b :boolean}}
-;;                             ;; (2)
-;;                             [:or [:ref ::b] [:ref ::a]]]}}
-;;    [:schema {:registry {::b :int}}
-;;     ;; (1)
-;;     [:or [:ref ::b] [:ref ::a]]]]
-
-;; copied to malli.core
 (defn- -identify-ref-schema [schema]
-  {:scope (-> schema m/-options m/-registry mr/-schemas)
-   :name (m/-ref schema)})
+  ;; different :ref instances share the same child if they represent the same schema
+  ;; (perhaps with different name or metadata attached to the :ref itself).
+  (m/-deref schema))
 
 (defn -ref-gen [schema options]
   (let [ref-id (-identify-ref-schema schema)]
@@ -515,7 +453,8 @@
    (generator ?schema nil))
   ([?schema options]
    (if (::rec-gen options)
-     ;; disable cache while calculating recursive schemas. caches don't distinguish options.
+     ;; if ::rec-gen exists then we're under a gen/recursive-gen.
+     ;; we disable the cache avoid pinning the generator to the the base case (scalar-ref-gen in -ref-gen).
      (-create (m/schema ?schema options) options)
      (m/-cached (m/schema ?schema options) :generator #(-create % options)))))
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -250,16 +250,13 @@
 ;; (this is why this particular base case is so useful) and then propagate the (smaller) generator
 ;; supplied by `gen/recursive-gen` to convert recursive references.
 
-(defn- -identify-ref-schema [schema]
-  ;; different :ref instances share the same child if they represent the same schema
-  ;; (perhaps with different name or metadata attached to the :ref itself).
-  (m/deref schema))
-
 (defn -ref-gen [schema options]
-  (let [ref-id (-identify-ref-schema schema)]
+  (let [dschema (m/deref schema)
+        ;; different :ref instances share the same child if they represent the same schema
+        ;; (perhaps with different name or metadata attached to the :ref itself).
+        ref-id dschema]
     (or (force (get-in options [::rec-gen ref-id]))
-        (let [scalar-ref-gen (delay (-never-gen options))
-              dschema (m/deref schema)]
+        (let [scalar-ref-gen (delay (-never-gen options))]
           (cond->> (generator dschema (assoc-in options [::rec-gen ref-id] scalar-ref-gen))
             (realized? scalar-ref-gen) (gen/recursive-gen
                                         #(generator dschema (assoc-in options [::rec-gen ref-id] %))))))))

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -253,7 +253,7 @@
 (defn- -identify-ref-schema [schema]
   ;; different :ref instances share the same child if they represent the same schema
   ;; (perhaps with different name or metadata attached to the :ref itself).
-  (m/-deref schema))
+  (m/deref schema))
 
 (defn -ref-gen [schema options]
   (let [ref-id (-identify-ref-schema schema)]
@@ -454,7 +454,7 @@
   ([?schema options]
    (if (::rec-gen options)
      ;; if ::rec-gen exists then we're under a gen/recursive-gen.
-     ;; we disable the cache avoid pinning the generator to the the base case (scalar-ref-gen in -ref-gen).
+     ;; we disable the cache avoid pinning the generator to the base case (scalar-ref-gen in -ref-gen).
      (-create (m/schema ?schema options) options)
      (m/-cached (m/schema ?schema options) :generator #(-create % options)))))
 

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -233,8 +233,75 @@
 ;; (this is why this particular base case is so useful) and then propagate the (smaller) generator
 ;; supplied by `gen/recursive-gen` to convert recursive references.
 
+;; ## Identifying schema recursion
+;;
+;; Refs are uniquely identified by their paired name and scope. If we see a ref with the
+;; same name and scope as another ref we've dereferenced previously, we know that this is a recursion
+;; point back to the previously seen ref. The rest of this section explains why.
+;;
+;; Refs resolve via dynamic scope, which means its dereferenced value is the latest binding found
+;; while expanding the schema until the point of finding the ref.
+;; This makes the (runtime) scope at the ref's location part of a ref's identity---if the scope
+;; is different, then it's (possibly) not the same ref because scope determines how schemas
+;; transitively expand.
+;;
+;; To illustrate why a ref's name is an insufficient identifier, here is a schema that is equivalent to `[:= 42]`:
+;;
+;;   [:schema {:registry {::a [:schema {:registry {::a [:= 42]}}
+;;                             ;; (2)
+;;                             [:ref ::a]]}}
+;;    ;; (1)
+;;    [:ref ::a]]
+;;
+;; If we identify refs just by name, we would have incorrectly detected (2) to be an (infinitely expanding) recursive
+;; reference.
+;;
+;; In studying the previous example, we might think that since (1) and (2) deref to different schemas, it might sufficient to identify refs just by their derefs.
+;; Unfortunately this just pushes the problem elsewhere.
+;;
+;; For example, here is another schema equivalent to `[:= 42]`:
+;;
+;;   [:schema {:registry {::a [:ref ::b] ;; (2)
+;;                        ::b [:schema {:registry {::a [:ref ::b] ;; (4)
+;;                                                 ::b [:= 42]}}
+;;                             ;; (3)
+;;                             [:ref ::a]]}}
+;;    ;; (1)
+;;    [:ref ::a]]
+;;
+;; If we identified ::a by its deref, it would look like (3) deref'ing to (4)
+;; is a recursion point after witnessing (1) deref'ing to (2), since (2) == (4). Except this
+;; is wrong since it's a different ::b at (2) and (4)! OTOH, if we identified (2) and (4) with their
+;; dynamic scopes along with their form, they would be clearly different. Indeed, this
+;; is another way to identify refs: pairing their derefs with their deref's scopes.
+;; It is slightly more direct to use the ref's direct name and scope, which is why
+;; we choose that identifier. The more general insight is that any schema is identified by its form+scope
+;; (note: but only after trimming the scope of irrelevant bindings, see next pararaph).
+;; That insight may be useful for detecting recursion at places other than refs.
+;;
+;; Ref identifiers could be made smarter by trimming irrelevant entries in identifying scope.
+;; Not all scope differences are relevant, so generators may expand more than strictly necessary
+;; in the quest to find the "same" ref schema again. It could skip over refs that generate exactly the
+;; same values, but their scopes are uninterestingly different (eg., unused bindings are different).
+;;
+;; For example, the following schema is recursive "in spirit" between (1) and (2), but since ::b
+;; changes, the scope will differ, so the recursion will be detected between (2) and itself instead
+;; (where the scope is constant):
+;;
+;;   [:schema {:registry {::a [:schema {:registry {::b :boolean}}
+;;                             ;; (2)
+;;                             [:or [:ref ::a] [:ref ::b]]]}}
+;;    [:schema {:registry {::b :int}}
+;;     ;; (1)
+;;     [:or [:ref ::a] [:ref ::b]]]]
+
+;; copied to malli.core
+(defn- -identify-ref-schema [schema]
+  {:scope (-> schema m/-options m/-registry mr/-schemas)
+   :name (m/-ref schema)})
+
 (defn -ref-gen [schema options]
-  (let [ref-id schema]
+  (let [ref-id (-identify-ref-schema schema)]
     (or (force (get-in options [::rec-gen ref-id]))
         (let [scalar-ref-gen (delay (-never-gen options))
               dschema (m/deref schema)]
@@ -430,7 +497,10 @@
   ([?schema]
    (generator ?schema nil))
   ([?schema options]
-   (m/-cached (m/schema ?schema options) :generator #(-create % options))))
+   (if (::rec-gen options)
+     ;; disable cache while calculating recursive schemas. caches don't distinguish options.
+     (-create (m/schema ?schema options) options)
+     (m/-cached (m/schema ?schema options) :generator #(-create % options)))))
 
 (defn generate
   ([?gen-or-schema]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -430,10 +430,7 @@
   ([?schema]
    (generator ?schema nil))
   ([?schema options]
-   (if (::rec-gen options)
-     ;; disable cache while calculating recursive schemas. caches don't distinguish options.
-     (-create (m/schema ?schema options) options)
-     (m/-cached (m/schema ?schema options) :generator #(-create % options)))))
+   (m/-cached (m/schema ?schema options) :generator #(-create % options))))
 
 (defn generate
   ([?gen-or-schema]

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -233,75 +233,8 @@
 ;; (this is why this particular base case is so useful) and then propagate the (smaller) generator
 ;; supplied by `gen/recursive-gen` to convert recursive references.
 
-;; ## Identifying schema recursion
-;;
-;; Refs are uniquely identified by their paired name and scope. If we see a ref with the
-;; same name and scope as another ref we've dereferenced previously, we know that this is a recursion
-;; point back to the previously seen ref. The rest of this section explains why.
-;;
-;; Refs resolve via dynamic scope, which means its dereferenced value is the latest binding found
-;; while expanding the schema until the point of finding the ref.
-;; This makes the (runtime) scope at the ref's location part of a ref's identity---if the scope
-;; is different, then it's (possibly) not the same ref because scope determines how schemas
-;; transitively expand.
-;;
-;; To illustrate why a ref's name is an insufficient identifier, here is a schema that is equivalent to `[:= 42]`:
-;;
-;;   [:schema {:registry {::a [:schema {:registry {::a [:= 42]}}
-;;                             ;; (2)
-;;                             [:ref ::a]]}}
-;;    ;; (1)
-;;    [:ref ::a]]
-;;
-;; If we identify refs just by name, we would have incorrectly detected (2) to be an (infinitely expanding) recursive
-;; reference.
-;;
-;; In studying the previous example, we might think that since (1) and (2) deref to different schemas, it might sufficient to identify refs just by their derefs.
-;; Unfortunately this just pushes the problem elsewhere.
-;;
-;; For example, here is another schema equivalent to `[:= 42]`:
-;;
-;;   [:schema {:registry {::a [:ref ::b] ;; (2)
-;;                        ::b [:schema {:registry {::a [:ref ::b] ;; (4)
-;;                                                 ::b [:= 42]}}
-;;                             ;; (3)
-;;                             [:ref ::a]]}}
-;;    ;; (1)
-;;    [:ref ::a]]
-;;
-;; If we identified ::a by its deref, it would look like (3) deref'ing to (4)
-;; is a recursion point after witnessing (1) deref'ing to (2), since (2) == (4). Except this
-;; is wrong since it's a different ::b at (2) and (4)! OTOH, if we identified (2) and (4) with their
-;; dynamic scopes along with their form, they would be clearly different. Indeed, this
-;; is another way to identify refs: pairing their derefs with their deref's scopes.
-;; It is slightly more direct to use the ref's direct name and scope, which is why
-;; we choose that identifier. The more general insight is that any schema is identified by its form+scope
-;; (note: but only after trimming the scope of irrelevant bindings, see next pararaph).
-;; That insight may be useful for detecting recursion at places other than refs.
-;;
-;; Ref identifiers could be made smarter by trimming irrelevant entries in identifying scope.
-;; Not all scope differences are relevant, so generators may expand more than strictly necessary
-;; in the quest to find the "same" ref schema again. It could skip over refs that generate exactly the
-;; same values, but their scopes are uninterestingly different (eg., unused bindings are different).
-;;
-;; For example, the following schema is recursive "in spirit" between (1) and (2), but since ::b
-;; changes, the scope will differ, so the recursion will be detected between (2) and itself instead
-;; (where the scope is constant):
-;;
-;;   [:schema {:registry {::a [:schema {:registry {::b :boolean}}
-;;                             ;; (2)
-;;                             [:or [:ref ::a] [:ref ::b]]]}}
-;;    [:schema {:registry {::b :int}}
-;;     ;; (1)
-;;     [:or [:ref ::a] [:ref ::b]]]]
-
-;; copied to malli.core
-(defn- -identify-ref-schema [schema]
-  {:scope (-> schema m/-options m/-registry mr/-schemas)
-   :name (m/-ref schema)})
-
 (defn -ref-gen [schema options]
-  (let [ref-id (-identify-ref-schema schema)]
+  (let [ref-id schema]
     (or (force (get-in options [::rec-gen ref-id]))
         (let [scalar-ref-gen (delay (-never-gen options))
               dschema (m/deref schema)]

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -90,8 +90,7 @@
         (-schema [_ name]
           (or (@cache* name)
               (when-let [schema (provider name @registry*)]
-                (swap! cache* assoc name schema)
-                schema)))
+                (get (swap! cache* assoc name #(or % schema)) name))))
         (-schemas [_] @cache*))))))
 
 (defn schema

--- a/src/malli/registry.cljc
+++ b/src/malli/registry.cljc
@@ -90,7 +90,8 @@
         (-schema [_ name]
           (or (@cache* name)
               (when-let [schema (provider name @registry*)]
-                (get (swap! cache* assoc name #(or % schema)) name))))
+                (swap! cache* assoc name schema)
+                schema)))
         (-schemas [_] @cache*))))))
 
 (defn schema

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3477,6 +3477,12 @@
                                                                                                             ::user [:map [:id ::user-id]]}}
                                                                                         ::user]
                                                                                        {::m/ref-key :id}))))
+    (is (= ::m/schema (-> (m/deref-all [:schema {:registry {::user-id :int
+                                                            ::user [:map [:id ::user-id]]}}
+                                        ::user]
+                                       {::m/ref-key :id})
+                          (m/-get :id nil)
+                          m/type)))
     ;;FIXME root cause, wrapped in extra ::schema
     (is (= :int (-> (m/deref-recursive [:schema {:registry {::user-id :int
                                                             ::user [:map [:id ::user-id]]}}
@@ -3484,6 +3490,15 @@
                                        {::m/ref-key :id})
                     (m/-get :id nil)
                     m/type)))
+    ;;FIXME root cause, -set-children doesn't take
+    (is (= [:int {:id :malli.core-test/user-id}]
+           (-> (m/schema [:schema {:registry {::user-id :int}}
+                          ::user-id]
+                         {::m/ref-key :id})
+               m/deref
+               (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
+               m/deref
+               m/form)))
     (is (= [:map
             [:id :uuid]
             [:name :string]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3468,8 +3468,9 @@
                          [:map [:y :int]]]
                         {:registry registry}))))
         (is (= [:map {:id ::xymap}
-                [::x [:int {:id ::x}]]
-                [::y [:int {:id ::y}]]]
+                ;;FIXME
+                [::x ::x #_[:int {:id ::x}]]
+                [::y ::y #_[:int {:id ::y}]]]
                (m/form (m/deref-recursive
                         [:schema {:registry {::x :int
                                              ::y :int
@@ -3692,11 +3693,11 @@
                                                                           [[] [] (m/schema :int o)])})))
         ConsCell (m/schema [:schema {:registry {::cons [:maybe [:tuple ::counting [:ref ::cons]]]}} ::cons]
                            {:registry reg})]
-    (is (= @count-into-schemas 2))
+    (is (= @count-into-schemas 1))
     (is (m/coerce ConsCell [1 [2 [3 [4 nil]]]]))
-    (is (= @count-into-schemas 3)) ;; was 6
+    (is (= @count-into-schemas 1))
     (is (m/coerce ConsCell [1 [2 [3 [4 [1 [2 [3 [4 nil]]]]]]]]))
-    (is (= @count-into-schemas 3)))) ;; was 10
+    (is (= @count-into-schemas 1))))
 
 (defn is-counting-times [?schema i]
   (let [count-into-schemas (atom 0)
@@ -3728,21 +3729,30 @@
   ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 1)
   ;; before: expanded via -property-registry 2x and -pointer 1x
-  ;; after: expanded via -property-registry 2x
-  (is-counting-times [:schema {:registry (array-map ::FOO ::BAR ::BAR ::counting)} ::FOO] 2)
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry (array-map ::FOO ::BAR ::BAR ::counting)} ::FOO] 1)
+  (let [count-into-schemas (atom 0)
+        reg (mr/simple-registry (assoc (m/default-schemas)
+                                       ::counting (m/-proxy-schema {:type ::counting
+                                                                    :fn (fn [p c o]
+                                                                          (assert (empty? c))
+                                                                          (swap! count-into-schemas inc)
+                                                                          [[] [] (m/schema :int o)])})))
+        s (m/-property-registry (array-map ::FOO ::BAR ::BAR ::counting) {:registry reg} identity)]
+    (is (= @count-into-schemas 1)))
   ;; before: expanded via -property-registry 2x and -pointer 2x
-  ;; after: expanded via -property-registry 2x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 2)
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 1)
   ;; before: expanded via -property-registry 2x and -pointer 3x
-  ;; after: expanded via -property-registry 2x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 2)
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 1)
   ;; before: expanded via -property-registry 3x and -pointer 1x
-  ;; after: expanded via -property-registry 3x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 3)
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 1)
   ;; before: expanded via -property-registry 3x and -pointer 2x
-  ;; after: expanded via -property-registry 3x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 3)
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 1)
   ;; before: expanded via -property-registry 3x and -pointer 3x
-  ;; after: expanded via -property-registry 3x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 3)
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 1)
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3785,7 +3785,6 @@
    ::creates-4194304-validators [:tuple ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators]})
 
 (deftest exponential-registry-test
-  (is-counting-times [:schema {:registry exponential-registry} ::creates-4194304-validators] 1)
   (let [count-ops (atom {})
         reg (mr/simple-registry (assoc (m/default-schemas)
                                        ::counting 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3490,23 +3490,6 @@
                                        {::m/ref-key :id})
                     (m/-get :id nil)
                     m/type)))
-    ;;FIXME root cause, -set-children doesn't take
-    (is (= [:int {:id :malli.core-test/user-id}]
-           (-> (m/schema [:schema {:registry {::user-id :int}}
-                          ::user-id]
-                         {::m/ref-key :id})
-               m/deref
-               (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
-               m/deref
-               m/form)
-           (-> (m/schema [:schema {:registry {::user-id :int}}
-                          ::user-id]
-                         {::m/ref-key :id})
-               m/deref
-               (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
-               m/children
-               first
-               m/form)))
     (is (= [:map
             [:id :uuid]
             [:name :string]
@@ -3867,4 +3850,22 @@
                        [:schema {:registry {::UNRELATED :int}}
                         ::BAZ]]]
                      2) ;; improvement: could be 1 in practice, because ::UNRELATED doesn't change ::BAZ
+
+  ;; :child entry in -pointed cache allows us to update pointers.
+  (is (= [:int {:id :malli.core-test/user-id}]
+         (-> (m/schema [:schema {:registry {::user-id :int}}
+                        ::user-id]
+                       {::m/ref-key :id})
+             m/deref
+             (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
+             m/deref
+             m/form)
+         (-> (m/schema [:schema {:registry {::user-id :int}}
+                        ::user-id]
+                       {::m/ref-key :id})
+             m/deref
+             (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
+             m/children
+             first
+             m/form)))
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3697,3 +3697,29 @@
     (is (= @count-into-schemas 3)) ;; was 6
     (is (m/coerce ConsCell [1 [2 [3 [4 [1 [2 [3 [4 nil]]]]]]]]))
     (is (= @count-into-schemas 3)))) ;; was 10
+
+(defn is-counting-times [?schema i]
+  (let [count-into-schemas (atom 0)
+        reg (mr/simple-registry (assoc (m/default-schemas)
+                                       ::counting (m/-proxy-schema {:type ::counting
+                                                                    :fn (fn [p c o]
+                                                                          (assert (empty? c))
+                                                                          (swap! count-into-schemas inc)
+                                                                          [[] [] (m/schema :int o)])})))
+        s (m/schema ?schema {:registry reg})]
+    (is (= @count-into-schemas i))))
+
+(deftest eager-registry-parse-test
+  (is-counting-times :int 0)
+  (is-counting-times ::counting 1)
+  (is-counting-times [:schema {:registry {::BAR ::counting}} [:ref ::BAR]] 1)
+  (is-counting-times [:schema {:registry {::BAR ::counting}} ::BAR] 2)
+  (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR]] 3)
+  (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 4)
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} ::FOO] 3)
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 4)
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 5)
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 4)
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 5)
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 6)
+)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3757,4 +3757,16 @@
   ;; before: expanded via -property-registry 3x and -pointer 3x
   ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 1)
+  ;; same dynamic scope (::FOO and ::BAR are the same in the inner schema)
+  ;; expanded via -property-registry on the outer schema, reused in inner -property-registry
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
+                      [:schema {:registry {::FOO ::BAR ::BAR ::counting}}
+                       ::BAZ]]
+                     1)
+  ;; different dynamic scope (::BAR is different in the inner schema)
+  ;; expanded via -property-registry on the outer schema, reexpanded in inner -property-registry
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
+                      [:schema {:registry {::FOO ::BAR ::BAR [:tuple ::counting]}}
+                       ::BAZ]]
+                     2)
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3718,15 +3718,18 @@
   (is-counting-times [:schema {:registry {::BAR ::counting}} :int] 1)
   ;; expanded via -property-registry
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:ref ::BAR]] 1)
-  ;; expanded via -property-registry and -pointer
-  (is-counting-times [:schema {:registry {::BAR ::counting}} ::BAR] 2)
-  ;; expanded via -property-registry 1x and -pointer 2x
-  (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR]] 3)
-  ;; expanded via -property-registry 1x and -pointer 3x
-  (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 4)
+  ;; before: expanded via -property-registry and -pointer
+  ;; after: expanded via -property-registry
+  (is-counting-times [:schema {:registry {::BAR ::counting}} ::BAR] 1)
+  ;; before: expanded via -property-registry 1x and -pointer 2x
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR]] 1)
+  ;; before: expanded via -property-registry 1x and -pointer 3x
+  ;; after: expanded via -property-registry 1x
+  (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 1)
   ;; before: expanded via -property-registry 2x and -pointer 1x
   ;; after: expanded via -property-registry 1x and -pointer 1x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} ::FOO] 2)
+  (is-counting-times [:schema {:registry (array-map ::FOO ::BAR ::BAR ::counting)} ::FOO] 2)
   ;; before: expanded via -property-registry 2x and -pointer 2x
   ;; after: expanded via -property-registry 1x and -pointer 2x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 3)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3716,54 +3716,25 @@
   (is-counting-times :int 0)
   ;; directly expanded
   (is-counting-times ::counting 1)
-  ;; expanded via -property-registry
+  ;; expanded via -property-registry, then with pointer due to unchanged dynamic scope
   (is-counting-times [:schema {:registry {::BAR ::counting}} :int] 1)
-  ;; expanded via -property-registry
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:ref ::BAR]] 1)
-  ;; before: expanded via -property-registry and -pointer
-  ;; after: expanded via -property-registry
   (is-counting-times [:schema {:registry {::BAR ::counting}} ::BAR] 1)
-  ;; before: expanded via -property-registry 1x and -pointer 2x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR]] 1)
-  ;; before: expanded via -property-registry 1x and -pointer 3x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 1)
-  ;; before: expanded via -property-registry 2x and -pointer 1x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry (array-map ::FOO ::BAR ::BAR ::counting)} ::FOO] 1)
-  (let [count-into-schemas (atom 0)
-        reg (mr/simple-registry (assoc (m/default-schemas)
-                                       ::counting (m/-proxy-schema {:type ::counting
-                                                                    :fn (fn [p c o]
-                                                                          (assert (empty? c))
-                                                                          (swap! count-into-schemas inc)
-                                                                          [[] [] (m/schema :int o)])})))
-        s (m/-property-registry (array-map ::FOO ::BAR ::BAR ::counting) {:registry reg} identity)]
-    (is (= @count-into-schemas 1)))
-  ;; before: expanded via -property-registry 2x and -pointer 2x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 1)
-  ;; before: expanded via -property-registry 2x and -pointer 3x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 1)
-  ;; before: expanded via -property-registry 3x and -pointer 1x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 1)
-  ;; before: expanded via -property-registry 3x and -pointer 2x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 1)
-  ;; before: expanded via -property-registry 3x and -pointer 3x
-  ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 1)
-  ;; same dynamic scope (::FOO and ::BAR are the same in the inner schema)
-  ;; expanded via -property-registry on the outer schema, reused in inner -property-registry
+  ;; since ::FOO and ::BAR are identical, ::counting is shared between the two registries and pointer
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
                       [:schema {:registry {::FOO ::BAR ::BAR ::counting}}
                        ::BAZ]]
                      1)
-  ;; different dynamic scope (::BAR is different in the inner schema)
-  ;; expanded via -property-registry on the outer schema, reexpanded in inner -property-registry
+  ;; since ::BAR is different in the inner schema, ::counting in each registry is not shared.
+  ;; pointer shares inner registry version (the tuple)
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
                       [:schema {:registry {::FOO ::BAR ::BAR [:tuple ::counting]}}
                        ::BAZ]]
@@ -3772,14 +3743,15 @@
                       [:schema {:registry {::BAR [:tuple ::counting]}}
                        ::BAZ]]
                      2)
-  ;; different dynamic scope (extra ref ::UNRELATED is in scope in the inner schema)
-  ;; expanded via -property-registry on the outer schema, reexpanded in inner -pointer ::BAZ reference
+  ;; even though ::UNRELATED doesn't change ::counting in practice, it prevents ::counting from being shared
+  ;; between the pointer and registry.
+  ;; future improvement: could be 1 in practice, because ::UNRELATED doesn't change ::BAZ so could share
+  ;; ::counting with outer registry
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
                       [:tuple ::BAZ
                        [:schema {:registry {::UNRELATED :int}}
                         ::BAZ]]]
-                     2) ;; improvement: could be 1 in practice, because ::UNRELATED doesn't change ::BAZ
-
+                     2)
   ;; :child entry in -pointed cache allows us to update pointers.
   (is (= [:int {:id :malli.core-test/user-id}]
          (-> (m/schema [:schema {:registry {::user-id :int}}
@@ -3796,8 +3768,7 @@
              (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
              m/children
              first
-             m/form)))
-)
+             m/form))))
 
 (def exponential-registry
   {::creates-1-validator ::counting
@@ -3843,5 +3814,7 @@
         s (m/schema [:schema {:registry exponential-registry} ::creates-4194304-validators] {:registry reg})]
     (is (= @count-ops {:-into-schema 1}))
     (is (m/validator s))
-    ;;FIXME cache each level of validators
-    (is (= @count-ops {:-into-schema 1, :-validator 4194304}))))
+    (is (= @count-ops
+           {:-into-schema 1,
+            ;;TODO cache each level of validators, should be 1-4
+            :-validator 4194304}))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3468,9 +3468,11 @@
     (is (= [:map {:id ::user} [:id :int]] (m/form (m/deref-recursive [:schema {:registry {::user [:map [:id :int]]}}
                                                                       ::user]
                                                                      {::m/ref-key :id}))))
+    ;;FIXME
     (is (= [:map [:id :int]] (m/form (m/deref-recursive [:schema {:registry {::user-id :int
                                                                              ::user [:map [:id ::user-id]]}}
                                                          ::user]))))
+    ;;FIXME
     (is (= [:map {:id ::user} [:id [:int {:id ::user-id}]]] (m/form (m/deref-recursive [:schema {:registry {::user-id :int
                                                                                                             ::user [:map [:id ::user-id]]}}
                                                                                         ::user]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3433,6 +3433,17 @@
                                                           :var resolve}})
                (every? (m/validator $) (mg/sample schema))))))))
 
+(def dr-schema [:schema {:registry {::user-id :uuid
+                                    ::address [:map
+                                               [:street :string]
+                                               [:lonlat {:optional true} [:tuple :double :double]]]
+                                    ::user [:map
+                                            [:id ::user-id]
+                                            [:name :string]
+                                            [:friends {:optional true} [:set [:ref ::user]]]
+                                            [:address ::address]]}}
+                ::user])
+
 (deftest deref-recursive-test
   (let [schema [:schema {:registry {::user-id :uuid
                                     ::address [:map
@@ -3444,6 +3455,26 @@
                                             [:friends {:optional true} [:set [:ref ::user]]]
                                             [:address ::address]]}}
                 ::user]]
+    (is (= :uuid (m/form (m/deref-recursive [:schema {:registry {::user-id :uuid}} ::user-id]))))
+    (is (= [:uuid {:id ::user-id}] (m/form (m/deref-recursive [:schema {:registry {::user-id :uuid}} ::user-id]
+                                                              {::m/ref-key :id}))))
+    (is (= :map (m/form (m/deref-recursive [:schema {:registry {::user [:map]}}
+                                            ::user]))))
+    (is (= [:map {:id ::user}] (m/form (m/deref-recursive [:schema {:registry {::user [:map]}}
+                                                           ::user]
+                                                          {::m/ref-key :id}))))
+    (is (= :map (m/form (m/deref-recursive [:schema {:registry {::user [:map]}}
+                                            ::user]))))
+    (is (= [:map {:id ::user} [:id :int]] (m/form (m/deref-recursive [:schema {:registry {::user [:map [:id :int]]}}
+                                                                      ::user]
+                                                                     {::m/ref-key :id}))))
+    (is (= [:map [:id :int]] (m/form (m/deref-recursive [:schema {:registry {::user-id :int
+                                                                             ::user [:map [:id ::user-id]]}}
+                                                         ::user]))))
+    (is (= [:map {:id ::user} [:id [:int {:id ::user-id}]]] (m/form (m/deref-recursive [:schema {:registry {::user-id :int
+                                                                                                            ::user [:map [:id ::user-id]]}}
+                                                                                        ::user]
+                                                                                       {::m/ref-key :id}))))
     (is (= [:map
             [:id :uuid]
             [:name :string]
@@ -3451,8 +3482,8 @@
             [:address [:map
                        [:street :string]
                        [:lonlat {:optional true} [:tuple :double :double]]]]]
-           (m/form (m/deref-recursive schema))
-           (m/form (m/deref-recursive schema {::m/ref-key nil}))))
+           (m/form (m/deref-recursive dr-schema))
+           (m/form (m/deref-recursive dr-schema {::m/ref-key nil}))))
     (is (= [:map {:id ::user}
             [:id [:uuid {:id ::user-id}]]
             [:name :string]
@@ -3460,7 +3491,7 @@
             [:address [:map {:id ::address}
                        [:street :string]
                        [:lonlat {:optional true} [:tuple :double :double]]]]]
-           (m/form (m/deref-recursive schema {::m/ref-key :id}))))
+           (m/form (m/deref-recursive dr-schema {::m/ref-key :id}))))
     (testing "util schemas"
       (let [registry (merge (m/default-schemas) (mu/schemas))]
         (is (= [:map [:x :int] [:y :int]]
@@ -3469,10 +3500,34 @@
                          [:map [:x :int]]
                          [:map [:y :int]]]
                         {:registry registry}))))
+        (is (= ::xymap
+               (m/-ref (m/deref
+                         [:schema {:registry {::x :int
+                                              ::y :int
+                                              ::xmap [:map ::x]
+                                              ::ymap [:map ::y]
+                                              ::xymap [:merge ::xmap ::ymap]}}
+                          ::xymap]
+                         {:registry registry, ::m/ref-key :id}))))
+        (is (= ::x
+               (m/-ref (m/-get (m/deref-all
+                                 [:schema {:registry {::x :int
+                                                      ::y :int
+                                                      ::xmap [:map ::x]
+                                                      ::ymap [:map ::y]
+                                                      ::xymap [:merge ::xmap ::ymap]}}
+                                  ::xymap]
+                                 {:registry registry, ::m/ref-key :id})
+                               ::x
+                               nil))))
+        (is (= [:int {:id ::x}]
+               (m/form (m/deref-recursive
+                         [:schema {:registry {::x :int}}
+                          ::x]
+                         {::m/ref-key :id}))))
         (is (= [:map {:id ::xymap}
-                ;;FIXME
-                [::x ::x #_[:int {:id ::x}]]
-                [::y ::y #_[:int {:id ::y}]]]
+                [::x [:int {:id ::x}]]
+                [::y [:int {:id ::y}]]]
                (m/form (m/deref-recursive
                         [:schema {:registry {::x :int
                                              ::y :int
@@ -3480,7 +3535,7 @@
                                              ::ymap [:map ::y]
                                              ::xymap [:merge ::xmap ::ymap]}}
                          ::xymap]
-                        {:registry registry, ::m/ref-key :id}))))))))
+                        {:registry (merge (m/default-schemas) (mu/schemas)), ::m/ref-key :id}))))))))
 
 (deftest seqable-schema-test
   (is (m/validate [:seqable :int] nil))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3710,16 +3710,30 @@
     (is (= @count-into-schemas i))))
 
 (deftest eager-registry-parse-test
+  ;; not mentioned
   (is-counting-times :int 0)
+  ;; directly expanded
   (is-counting-times ::counting 1)
+  ;; expanded via -property-registry
+  (is-counting-times [:schema {:registry {::BAR ::counting}} :int] 1)
+  ;; expanded via -property-registry
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:ref ::BAR]] 1)
+  ;; expanded via -property-registry and -pointer
   (is-counting-times [:schema {:registry {::BAR ::counting}} ::BAR] 2)
+  ;; expanded via -property-registry 1x and -pointer 2x
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR]] 3)
+  ;; expanded via -property-registry 1x and -pointer 3x
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 4)
+  ;; expanded via -property-registry 2x and -pointer 1x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} ::FOO] 3)
+  ;; expanded via -property-registry 2x and -pointer 2x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 4)
+  ;; expanded via -property-registry 2x and -pointer 3x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 5)
+  ;; expanded via -property-registry 3x and -pointer 1x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 4)
+  ;; expanded via -property-registry 3x and -pointer 2x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 5)
+  ;; expanded via -property-registry 3x and -pointer 3x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 6)
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3477,6 +3477,13 @@
                                                                                                             ::user [:map [:id ::user-id]]}}
                                                                                         ::user]
                                                                                        {::m/ref-key :id}))))
+    ;;FIXME root cause, wrapped in extra ::schema
+    (is (= :int (-> (m/deref-recursive [:schema {:registry {::user-id :int
+                                                            ::user [:map [:id ::user-id]]}}
+                                        ::user]
+                                       {::m/ref-key :id})
+                    (m/-get :id nil)
+                    m/type)))
     (is (= [:map
             [:id :uuid]
             [:name :string]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3090,7 +3090,9 @@
     (let [one-level-schema [:map {:registry {:my/string-like :string}}
                             [:entry [:my/string-like {:some "prop"}]]]]
 
-      (is (true? (m/validate one-level-schema {:entry "a"})))))
+      (is (true? (m/validate one-level-schema {:entry "a"})))
+      #_
+      (is (false? (m/validate one-level-schema {:entry :a})))))
 
   (testing "testcase from #451"
     (let [opts {:registry {:string (m/-string-schema)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3724,16 +3724,22 @@
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR]] 3)
   ;; expanded via -property-registry 1x and -pointer 3x
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 4)
-  ;; expanded via -property-registry 2x and -pointer 1x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} ::FOO] 3)
-  ;; expanded via -property-registry 2x and -pointer 2x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 4)
-  ;; expanded via -property-registry 2x and -pointer 3x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 5)
-  ;; expanded via -property-registry 3x and -pointer 1x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 4)
-  ;; expanded via -property-registry 3x and -pointer 2x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 5)
-  ;; expanded via -property-registry 3x and -pointer 3x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 6)
+  ;; before: expanded via -property-registry 2x and -pointer 1x
+  ;; after: expanded via -property-registry 1x and -pointer 1x
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} ::FOO] 2)
+  ;; before: expanded via -property-registry 2x and -pointer 2x
+  ;; after: expanded via -property-registry 1x and -pointer 2x
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 3)
+  ;; before: expanded via -property-registry 2x and -pointer 3x
+  ;; after: expanded via -property-registry 2x and -pointer 3x
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 4)
+  ;; before: expanded via -property-registry 3x and -pointer 1x
+  ;; after: expanded via -property-registry 1x and -pointer 1x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 2)
+  ;; before: expanded via -property-registry 3x and -pointer 2x
+  ;; after: expanded via -property-registry 3x and -pointer 2x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 3)
+  ;; before: expanded via -property-registry 3x and -pointer 3x
+  ;; after: expanded via -property-registry 3x and -pointer 3x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 4)
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3498,6 +3498,14 @@
                m/deref
                (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
                m/deref
+               m/form)
+           (-> (m/schema [:schema {:registry {::user-id :int}}
+                          ::user-id]
+                         {::m/ref-key :id})
+               m/deref
+               (m/-set-children [(m/schema [:int {:id :malli.core-test/user-id}])])
+               m/children
+               first
                m/form)))
     (is (= [:map
             [:id :uuid]

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3731,15 +3731,15 @@
   ;; after: expanded via -property-registry 1x and -pointer 2x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 3)
   ;; before: expanded via -property-registry 2x and -pointer 3x
-  ;; after: expanded via -property-registry 2x and -pointer 3x
+  ;; after: expanded via -property-registry 1x and -pointer 3x
   (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 4)
   ;; before: expanded via -property-registry 3x and -pointer 1x
   ;; after: expanded via -property-registry 1x and -pointer 1x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 2)
   ;; before: expanded via -property-registry 3x and -pointer 2x
-  ;; after: expanded via -property-registry 3x and -pointer 2x
+  ;; after: expanded via -property-registry 1x and -pointer 2x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 3)
   ;; before: expanded via -property-registry 3x and -pointer 3x
-  ;; after: expanded via -property-registry 3x and -pointer 3x
+  ;; after: expanded via -property-registry 1x and -pointer 3x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 4)
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3728,21 +3728,21 @@
   ;; after: expanded via -property-registry 1x
   (is-counting-times [:schema {:registry {::BAR ::counting}} [:tuple ::BAR ::BAR ::BAR]] 1)
   ;; before: expanded via -property-registry 2x and -pointer 1x
-  ;; after: expanded via -property-registry 1x and -pointer 1x
+  ;; after: expanded via -property-registry 2x
   (is-counting-times [:schema {:registry (array-map ::FOO ::BAR ::BAR ::counting)} ::FOO] 2)
   ;; before: expanded via -property-registry 2x and -pointer 2x
-  ;; after: expanded via -property-registry 1x and -pointer 2x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 3)
+  ;; after: expanded via -property-registry 2x
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO]] 2)
   ;; before: expanded via -property-registry 2x and -pointer 3x
-  ;; after: expanded via -property-registry 1x and -pointer 3x
-  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 4)
+  ;; after: expanded via -property-registry 2x
+  (is-counting-times [:schema {:registry {::FOO ::BAR ::BAR ::counting}} [:tuple ::FOO ::FOO ::FOO]] 2)
   ;; before: expanded via -property-registry 3x and -pointer 1x
-  ;; after: expanded via -property-registry 1x and -pointer 1x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 2)
+  ;; after: expanded via -property-registry 3x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 3)
   ;; before: expanded via -property-registry 3x and -pointer 2x
-  ;; after: expanded via -property-registry 1x and -pointer 2x
+  ;; after: expanded via -property-registry 3x
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 3)
   ;; before: expanded via -property-registry 3x and -pointer 3x
-  ;; after: expanded via -property-registry 1x and -pointer 3x
-  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 4)
+  ;; after: expanded via -property-registry 3x
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 3)
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3710,6 +3710,7 @@
         s (m/schema ?schema {:registry reg})]
     (is (= @count-into-schemas i))))
 
+
 (deftest eager-registry-parse-test
   ;; not mentioned
   (is-counting-times :int 0)
@@ -3797,3 +3798,20 @@
              first
              m/form)))
 )
+
+(def exponential-registry
+  {::creates-1-validator ::counting
+   ::creates-2-validators [:tuple ::creates-1-validator ::creates-1-validator ::creates-1-validator ::creates-1-validator]
+   ::creates-16-validators [:tuple ::creates-2-validators ::creates-2-validators ::creates-2-validators ::creates-2-validators]
+   ::creates-64-validators [:tuple ::creates-16-validators ::creates-16-validators ::creates-16-validators ::creates-16-validators]
+   ::creates-256-validators [:tuple ::creates-64-validators ::creates-64-validators ::creates-64-validators ::creates-64-validators]
+   ::creates-1024-validators [:tuple ::creates-256-validators ::creates-256-validators ::creates-256-validators ::creates-256-validators]
+   ::creates-4096-validators [:tuple ::creates-1024-validators ::creates-1024-validators ::creates-1024-validators ::creates-1024-validators]
+   ::creates-16384-validators [:tuple ::creates-4096-validators ::creates-4096-validators ::creates-4096-validators ::creates-4096-validators]
+   ::creates-65536-validators [:tuple ::creates-16384-validators ::creates-16384-validators ::creates-16384-validators ::creates-16384-validators]
+   ::creates-262144-validators [:tuple ::creates-65536-validators ::creates-65536-validators ::creates-65536-validators ::creates-65536-validators]
+   ::creates-1048576-validators [:tuple ::creates-262144-validators ::creates-262144-validators ::creates-262144-validators ::creates-262144-validators]
+   ::creates-4194304-validators [:tuple ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators]})
+
+(deftest exponential-registry-test
+  (is-counting-times [:schema {:registry exponential-registry} ::creates-4194304-validators] 1))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3843,5 +3843,5 @@
         s (m/schema [:schema {:registry exponential-registry} ::creates-4194304-validators] {:registry reg})]
     (is (= @count-ops {:-into-schema 1}))
     (is (m/validator s))
-    ;;FIXME
+    ;;FIXME cache each level of validators
     (is (= @count-ops {:-into-schema 1, :-validator 4194304}))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3769,4 +3769,15 @@
                       [:schema {:registry {::FOO ::BAR ::BAR [:tuple ::counting]}}
                        ::BAZ]]
                      2)
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
+                      [:schema {:registry {::BAR [:tuple ::counting]}}
+                       ::BAZ]]
+                     2)
+  ;; different dynamic scope (extra ref ::UNRELATED is in scope in the inner schema)
+  ;; expanded via -property-registry on the outer schema, reexpanded in inner -pointer ::BAZ reference
+  (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
+                      [:tuple ::BAZ
+                       [:schema {:registry {::UNRELATED :int}}
+                        ::BAZ]]]
+                     2) ;; improvement: could be 1 in practice, because ::UNRELATED doesn't change ::BAZ
 )

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3091,7 +3091,6 @@
                             [:entry [:my/string-like {:some "prop"}]]]]
 
       (is (true? (m/validate one-level-schema {:entry "a"})))
-      #_
       (is (false? (m/validate one-level-schema {:entry :a})))))
 
   (testing "testcase from #451"
@@ -3433,17 +3432,6 @@
                                                           :var resolve}})
                (every? (m/validator $) (mg/sample schema))))))))
 
-(def dr-schema [:schema {:registry {::user-id :uuid
-                                    ::address [:map
-                                               [:street :string]
-                                               [:lonlat {:optional true} [:tuple :double :double]]]
-                                    ::user [:map
-                                            [:id ::user-id]
-                                            [:name :string]
-                                            [:friends {:optional true} [:set [:ref ::user]]]
-                                            [:address ::address]]}}
-                ::user])
-
 (deftest deref-recursive-test
   (let [schema [:schema {:registry {::user-id :uuid
                                     ::address [:map
@@ -3455,41 +3443,6 @@
                                             [:friends {:optional true} [:set [:ref ::user]]]
                                             [:address ::address]]}}
                 ::user]]
-    (is (= :uuid (m/form (m/deref-recursive [:schema {:registry {::user-id :uuid}} ::user-id]))))
-    (is (= [:uuid {:id ::user-id}] (m/form (m/deref-recursive [:schema {:registry {::user-id :uuid}} ::user-id]
-                                                              {::m/ref-key :id}))))
-    (is (= :map (m/form (m/deref-recursive [:schema {:registry {::user [:map]}}
-                                            ::user]))))
-    (is (= [:map {:id ::user}] (m/form (m/deref-recursive [:schema {:registry {::user [:map]}}
-                                                           ::user]
-                                                          {::m/ref-key :id}))))
-    (is (= :map (m/form (m/deref-recursive [:schema {:registry {::user [:map]}}
-                                            ::user]))))
-    (is (= [:map {:id ::user} [:id :int]] (m/form (m/deref-recursive [:schema {:registry {::user [:map [:id :int]]}}
-                                                                      ::user]
-                                                                     {::m/ref-key :id}))))
-    ;;FIXME
-    (is (= [:map [:id :int]] (m/form (m/deref-recursive [:schema {:registry {::user-id :int
-                                                                             ::user [:map [:id ::user-id]]}}
-                                                         ::user]))))
-    ;;FIXME
-    (is (= [:map {:id ::user} [:id [:int {:id ::user-id}]]] (m/form (m/deref-recursive [:schema {:registry {::user-id :int
-                                                                                                            ::user [:map [:id ::user-id]]}}
-                                                                                        ::user]
-                                                                                       {::m/ref-key :id}))))
-    (is (= ::m/schema (-> (m/deref-all [:schema {:registry {::user-id :int
-                                                            ::user [:map [:id ::user-id]]}}
-                                        ::user]
-                                       {::m/ref-key :id})
-                          (m/-get :id nil)
-                          m/type)))
-    ;;FIXME root cause, wrapped in extra ::schema
-    (is (= :int (-> (m/deref-recursive [:schema {:registry {::user-id :int
-                                                            ::user [:map [:id ::user-id]]}}
-                                        ::user]
-                                       {::m/ref-key :id})
-                    (m/-get :id nil)
-                    m/type)))
     (is (= [:map
             [:id :uuid]
             [:name :string]
@@ -3497,8 +3450,8 @@
             [:address [:map
                        [:street :string]
                        [:lonlat {:optional true} [:tuple :double :double]]]]]
-           (m/form (m/deref-recursive dr-schema))
-           (m/form (m/deref-recursive dr-schema {::m/ref-key nil}))))
+           (m/form (m/deref-recursive schema))
+           (m/form (m/deref-recursive schema {::m/ref-key nil}))))
     (is (= [:map {:id ::user}
             [:id [:uuid {:id ::user-id}]]
             [:name :string]
@@ -3506,7 +3459,7 @@
             [:address [:map {:id ::address}
                        [:street :string]
                        [:lonlat {:optional true} [:tuple :double :double]]]]]
-           (m/form (m/deref-recursive dr-schema {::m/ref-key :id}))))
+           (m/form (m/deref-recursive schema {::m/ref-key :id}))))
     (testing "util schemas"
       (let [registry (merge (m/default-schemas) (mu/schemas))]
         (is (= [:map [:x :int] [:y :int]]
@@ -3515,31 +3468,6 @@
                          [:map [:x :int]]
                          [:map [:y :int]]]
                         {:registry registry}))))
-        (is (= ::xymap
-               (m/-ref (m/deref
-                         [:schema {:registry {::x :int
-                                              ::y :int
-                                              ::xmap [:map ::x]
-                                              ::ymap [:map ::y]
-                                              ::xymap [:merge ::xmap ::ymap]}}
-                          ::xymap]
-                         {:registry registry, ::m/ref-key :id}))))
-        (is (= ::x
-               (m/-ref (m/-get (m/deref-all
-                                 [:schema {:registry {::x :int
-                                                      ::y :int
-                                                      ::xmap [:map ::x]
-                                                      ::ymap [:map ::y]
-                                                      ::xymap [:merge ::xmap ::ymap]}}
-                                  ::xymap]
-                                 {:registry registry, ::m/ref-key :id})
-                               ::x
-                               nil))))
-        (is (= [:int {:id ::x}]
-               (m/form (m/deref-recursive
-                         [:schema {:registry {::x :int}}
-                          ::x]
-                         {::m/ref-key :id}))))
         (is (= [:map {:id ::xymap}
                 [::x [:int {:id ::x}]]
                 [::y [:int {:id ::y}]]]
@@ -3550,7 +3478,7 @@
                                              ::ymap [:map ::y]
                                              ::xymap [:merge ::xmap ::ymap]}}
                          ::xymap]
-                        {:registry (merge (m/default-schemas) (mu/schemas)), ::m/ref-key :id}))))))))
+                        {:registry registry, ::m/ref-key :id}))))))))
 
 (deftest seqable-schema-test
   (is (m/validate [:seqable :int] nil))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3814,4 +3814,34 @@
    ::creates-4194304-validators [:tuple ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators]})
 
 (deftest exponential-registry-test
-  (is-counting-times [:schema {:registry exponential-registry} ::creates-4194304-validators] 1))
+  (is-counting-times [:schema {:registry exponential-registry} ::creates-4194304-validators] 1)
+  (let [count-ops (atom {})
+        reg (mr/simple-registry (assoc (m/default-schemas)
+                                       ::counting 
+                                       (reify m/IntoSchema
+                                         (-type [_] ::counting)
+                                         (-type-properties [_])
+                                         (-properties-schema [_ _])
+                                         (-children-schema [_ _])
+                                         (-into-schema [parent properties children options]
+                                           (swap! count-ops update :-into-schema (fnil inc 0))
+                                           ^{:type ::m/schema}
+                                           (reify m/Schema
+                                             (-validator [_]
+                                               (swap! count-ops update :-validator (fnil inc 0))
+                                               any?)
+                                             (-explainer [_ path])
+                                             (-parser [_])
+                                             (-unparser [_])
+                                             (-transformer [this transformer method options])
+                                             (-walk [this walker path options])
+                                             (-properties [_] properties)
+                                             (-options [_] options)
+                                             (-children [_] children)
+                                             (-parent [_] parent)
+                                             (-form [_] ::counting))))))
+        s (m/schema [:schema {:registry exponential-registry} ::creates-4194304-validators] {:registry reg})]
+    (is (= @count-ops {:-into-schema 1}))
+    (is (m/validator s))
+    ;;FIXME
+    (is (= @count-ops {:-into-schema 1, :-validator 4194304}))))

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3704,15 +3704,18 @@
         reg (mr/simple-registry (assoc (m/default-schemas)
                                        ::counting (m/-proxy-schema {:type ::counting
                                                                     :fn (fn [p c o]
-                                                                          (assert (empty? c))
                                                                           (swap! count-into-schemas inc)
-                                                                          [[] [] (m/schema :int o)])})))]
+                                                                          [[] [] (m/schema (into [:tuple] c) o)])})
+                                       ))]
     {:reg reg :counter count-into-schemas}))
 
-(defn is-counting-times [?schema i]
-  (let [{:keys [reg counter]} (counting-registry)
-        s (m/schema ?schema {:registry reg})]
-    (is (= @counter i))))
+(defn is-counting-times
+  ([?schema i] (is-counting-times ?schema identity i))
+  ([?schema f i]
+   (let [{:keys [reg counter]} (counting-registry)
+         s (m/schema ?schema {:registry reg})]
+     (f s)
+     (is (= @counter i)))))
 
 (deftest eager-registry-parse-test
   ;; not mentioned
@@ -3732,11 +3735,15 @@
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 1)
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 1)
   ;; :ref shares pointed child with property registry
-  (let [{:keys [reg counter]} (counting-registry)
-        s (-> [:schema {:registry {::BAR ::counting}} [:ref ::BAR]]
-              (m/deref-all {:registry reg}))]
-    (is (= :int (m/form s)))
-    (is (= @counter 1)))
+  (is-counting-times [:schema {:registry {::BAR ::counting}} [:ref ::BAR]]
+                     (fn [s]
+                       (assert (m/validate s [])))
+                     1)
+  ;; :ref ties the knot
+  (is-counting-times [:schema {:registry {::rec [:maybe [::counting [:ref ::rec]]]}} [:ref ::rec]]
+                     (fn [s]
+                       (assert (m/validate s (nth (iterate vector nil) 10))))
+                     1)
   ;; since ::FOO and ::BAR are identical, ::counting is shared between the two registries and pointer
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
                       [:schema {:registry {::FOO ::BAR ::BAR ::counting}}

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3744,6 +3744,36 @@
                      (fn [s]
                        (assert (m/validate s (nth (iterate vector nil) 10))))
                      1)
+  (is-counting-times [:schema {:registry {::cons [:maybe [::counting pos-int? [:ref ::cons]]]}} ::cons]
+                     (fn [s]
+                       (assert (m/validate s (nth (iterate #(do [10 %]) nil) 10))))
+                     1)
+  ;; mutual :ref's tie the knot
+  (is-counting-times [:schema
+                      {:registry {::ping [::counting [:= "ping"] [:maybe [:ref ::pong]]]
+                                  ::pong [::counting [:= "pong"] [:maybe [:ref ::ping]]]}}
+                      ::ping]
+                     (fn [s]
+                       (assert (m/validate s (nth (iterate #(do ["ping" ["pong" %]]) ["ping" nil]) 10))))
+                     2)
+  (is-counting-times [:schema {:registry {::a [:schema {:registry {::a [::counting [:= 42]]}}
+                                               [:ref ::a]]}}
+                      [:ref ::a]]
+                     #(assert (m/validate % [42]))
+                     1)
+  (is-counting-times [:schema {:registry {::a [:ref ::b]
+                                          ::b [:schema {:registry {::a [:ref ::b]
+                                                                   ::b [::counting [:= 42]]}}
+                                               [:ref ::a]]}}
+                      [:ref ::a]]
+                     #(assert (m/validate % [42]))
+                     1)
+  (is-counting-times [:schema {:registry {::a [:schema {:registry {::b [::counting :boolean]}}
+                                               [:or [:ref ::b] [:ref ::a]]]}}
+                      [:schema {:registry {::b [::counting :int]}}
+                       [:maybe [:or [:ref ::b] [:ref ::a]]]]]
+                     #(assert (m/validate % [true]))
+                     2)
   ;; since ::FOO and ::BAR are identical, ::counting is shared between the two registries and pointer
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
                       [:schema {:registry {::FOO ::BAR ::BAR ::counting}}

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3710,7 +3710,6 @@
         s (m/schema ?schema {:registry reg})]
     (is (= @count-into-schemas i))))
 
-
 (deftest eager-registry-parse-test
   ;; not mentioned
   (is-counting-times :int 0)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3699,16 +3699,20 @@
     (is (m/coerce ConsCell [1 [2 [3 [4 [1 [2 [3 [4 nil]]]]]]]]))
     (is (= @count-into-schemas 1))))
 
-(defn is-counting-times [?schema i]
+(defn counting-registry []
   (let [count-into-schemas (atom 0)
         reg (mr/simple-registry (assoc (m/default-schemas)
                                        ::counting (m/-proxy-schema {:type ::counting
                                                                     :fn (fn [p c o]
                                                                           (assert (empty? c))
                                                                           (swap! count-into-schemas inc)
-                                                                          [[] [] (m/schema :int o)])})))
+                                                                          [[] [] (m/schema :int o)])})))]
+    {:reg reg :counter count-into-schemas}))
+
+(defn is-counting-times [?schema i]
+  (let [{:keys [reg counter]} (counting-registry)
         s (m/schema ?schema {:registry reg})]
-    (is (= @count-into-schemas i))))
+    (is (= @counter i))))
 
 (deftest eager-registry-parse-test
   ;; not mentioned
@@ -3727,6 +3731,12 @@
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} ::BAZ] 1)
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ]] 1)
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}} [:tuple ::BAZ ::BAZ ::BAZ]] 1)
+  ;; :ref shares pointed child with property registry
+  (let [{:keys [reg counter]} (counting-registry)
+        s (-> [:schema {:registry {::BAR ::counting}} [:ref ::BAR]]
+              (m/deref-all {:registry reg}))]
+    (is (= :int (m/form s)))
+    (is (= @counter 1)))
   ;; since ::FOO and ::BAR are identical, ::counting is shared between the two registries and pointer
   (is-counting-times [:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR ::counting}}
                       [:schema {:registry {::FOO ::BAR ::BAR ::counting}}
@@ -3771,17 +3781,28 @@
 
 (def exponential-registry
   {::creates-1-validator ::counting
-   ::creates-2-validators [:tuple ::creates-1-validator ::creates-1-validator ::creates-1-validator ::creates-1-validator]
-   ::creates-16-validators [:tuple ::creates-2-validators ::creates-2-validators ::creates-2-validators ::creates-2-validators]
-   ::creates-64-validators [:tuple ::creates-16-validators ::creates-16-validators ::creates-16-validators ::creates-16-validators]
-   ::creates-256-validators [:tuple ::creates-64-validators ::creates-64-validators ::creates-64-validators ::creates-64-validators]
-   ::creates-1024-validators [:tuple ::creates-256-validators ::creates-256-validators ::creates-256-validators ::creates-256-validators]
-   ::creates-4096-validators [:tuple ::creates-1024-validators ::creates-1024-validators ::creates-1024-validators ::creates-1024-validators]
-   ::creates-16384-validators [:tuple ::creates-4096-validators ::creates-4096-validators ::creates-4096-validators ::creates-4096-validators]
-   ::creates-65536-validators [:tuple ::creates-16384-validators ::creates-16384-validators ::creates-16384-validators ::creates-16384-validators]
-   ::creates-262144-validators [:tuple ::creates-65536-validators ::creates-65536-validators ::creates-65536-validators ::creates-65536-validators]
-   ::creates-1048576-validators [:tuple ::creates-262144-validators ::creates-262144-validators ::creates-262144-validators ::creates-262144-validators]
-   ::creates-4194304-validators [:tuple ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators]})
+   ::creates-2-validators [:tuple ::creates-1-validator ::creates-1-validator
+                           ::creates-1-validator ::creates-1-validator]
+   ::creates-16-validators [:tuple ::creates-2-validators ::creates-2-validators
+                            ::creates-2-validators ::creates-2-validators]
+   ::creates-64-validators [:tuple ::creates-16-validators ::creates-16-validators
+                            ::creates-16-validators ::creates-16-validators]
+   ::creates-256-validators [:tuple ::creates-64-validators ::creates-64-validators
+                             ::creates-64-validators ::creates-64-validators]
+   ::creates-1024-validators [:tuple ::creates-256-validators ::creates-256-validators
+                              ::creates-256-validators ::creates-256-validators]
+   ::creates-4096-validators [:tuple ::creates-1024-validators ::creates-1024-validators
+                              ::creates-1024-validators ::creates-1024-validators]
+   ::creates-16384-validators [:tuple ::creates-4096-validators ::creates-4096-validators
+                               ::creates-4096-validators ::creates-4096-validators]
+   ::creates-65536-validators [:tuple ::creates-16384-validators ::creates-16384-validators
+                               ::creates-16384-validators ::creates-16384-validators]
+   ::creates-262144-validators [:tuple ::creates-65536-validators ::creates-65536-validators
+                                ::creates-65536-validators ::creates-65536-validators]
+   ::creates-1048576-validators [:tuple ::creates-262144-validators ::creates-262144-validators
+                                 ::creates-262144-validators ::creates-262144-validators]
+   ::creates-4194304-validators [:tuple ::creates-1048576-validators ::creates-1048576-validators
+                                 ::creates-1048576-validators ::creates-1048576-validators]})
 
 (deftest exponential-registry-test
   (let [count-ops (atom {})

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3835,5 +3835,4 @@
     (is (m/validator s))
     (is (= @count-ops
            {:-into-schema 1,
-            ;;TODO cache each level of validators, should be 1-4
-            :-validator 4194304}))))
+            :-validator 1}))))


### PR DESCRIPTION
Schemas like `[:schema {:registry {::FOO :bar}} ::FOO]` now create `:bar` once (before, twice). This is regardless of how many times `::FOO` is mentioned in the registry or body

For example it also holds for

```clojure
[:schema {:registry {::BAZ ::FOO ::FOO ::BAR ::BAR :bar}} [:tuple ::BAZ ::BAZ ::BAZ]]
```

which would previously create 3 copies of `:bar` via `-property-registry`, then 3 additional copies via `[:tuple ::BAZ ::BAZ ::BAZ]` for a total of 6 copies (now 1).

The situation is more subtle for nested registries, see the tests.

This tackles exponential duplication of schemas. Previously, `(m/schema [:schema {:registry exponential-schema}} ::creates-4194304-validators])` would create at least 4,194,304 copies of `::counting`, now only 1. I'm not sure of the exact number because of OOM errors, but it could be closer to 20 million.

```clojure
(def exponential-registry
  {::creates-1-validator ::counting
   ::creates-2-validators [:tuple ::creates-1-validator ::creates-1-validator ::creates-1-validator ::creates-1-validator]
   ::creates-16-validators [:tuple ::creates-2-validators ::creates-2-validators ::creates-2-validators ::creates-2-validators]
   ::creates-64-validators [:tuple ::creates-16-validators ::creates-16-validators ::creates-16-validators ::creates-16-validators]
   ::creates-256-validators [:tuple ::creates-64-validators ::creates-64-validators ::creates-64-validators ::creates-64-validators]
   ::creates-1024-validators [:tuple ::creates-256-validators ::creates-256-validators ::creates-256-validators ::creates-256-validators]
   ::creates-4096-validators [:tuple ::creates-1024-validators ::creates-1024-validators ::creates-1024-validators ::creates-1024-validators]
   ::creates-16384-validators [:tuple ::creates-4096-validators ::creates-4096-validators ::creates-4096-validators ::creates-4096-validators]
   ::creates-65536-validators [:tuple ::creates-16384-validators ::creates-16384-validators ::creates-16384-validators ::creates-16384-validators]
   ::creates-262144-validators [:tuple ::creates-65536-validators ::creates-65536-validators ::creates-65536-validators ::creates-65536-validators]
   ::creates-1048576-validators [:tuple ::creates-262144-validators ::creates-262144-validators ::creates-262144-validators ::creates-262144-validators]
   ::creates-4194304-validators [:tuple ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators ::creates-1048576-validators]})
```

Note: `(m/validator [:schema {:registry exponential-schema}} ::creates-4194304-validators])` still calls `m/-validator` 4,194,304 times, as noted in the `TODO` at the bottom of `malli.core-test` in this PR. This can be tackled separately.

Metabase works around this a similar issue [here](https://github.com/metabase/metabase/blob/64d2e589b2ccca746ff52a924ecfc04ed83b9b08/src/metabase/util/malli/registry.cljc#L126-L169) by creating their own `:ref` implementation. We don't handle `:ref` here yet.