### PR TITLE
Add support for JSON Schema If-Then-Else via :if

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Data-driven Schemas for Clojure/Script and [babashka](#babashka).
 - Tools for [Programming with Schemas](#programming-with-schemas)
 - [Parsing](#parsing-values) and [Unparsing](#unparsing-values) values
 - [Enumeration](#enumeration-schemas), [Sequence](#sequence-schemas), [Vector](#vector-schemas), and [Set](#set-schemas) Schemas
-- [Persisting schemas](#persisting-schemas), even [function schemas](#serializable-functions)
+- [Persisting schemas](#persisting-schemas), even [function schemas](#serializable-functions) and [conditionals](#conditional-schemas)
 - Immutable, Mutable, Dynamic, Lazy and Local [Schema Registries](#schema-registry)
 - [Schema Transformations](#schema-Transformation) to [JSON Schema](#json-schema), [Swagger2](#swagger2), and [descriptions in english](#description)
 - [Multi-schemas](#multi-schemas), [Recursive Schemas](#recursive-schemas) and [Default values](#default-values)
@@ -720,6 +720,37 @@ Use `:maybe` to express that an element should match some schema OR be `nil`:
 ;; => false
 ```
 
+## Conditional schemas
+
+`:if` can be used to express a simple if/when like conditional:
+
+```clojure
+(def habitable-planets [:if [:map [:planet [:= "Earth"]]]
+                        [:map [:habitable [:= true]]]
+                        [:map [:habitable [:= false]]]])
+
+(m/validate habitable-planets {:planet "Earth" :habitable true})
+;; => true
+(m/validate habitable-planets {:planet "Earth" :habitable false})
+;; => false
+(m/validate habitable-planets {:planet "Jupiter" :habitable true})
+;; => false
+(m/validate habitable-planets {:planet "Neptune" :habitable false})
+;; => true
+```
+Nesting and more complex schemas can be used as well:
+```clojure
+(def gas-giants [:if [:map [:planet [:enum "Jupiter" "Saturn"]]]
+                 [:map [:size [:= :massive]]]
+                 habitable-planets])
+
+(m/validate gas-giants {:planet "Jupiter"})
+;; => false
+(m/validate gas-giants {:planet "Jupiter" :size :massive})
+;; => true
+(m/validate gas-giants {:planet "Earth" :habitable true})
+;; => true
+```
 ## Error messages
 
 Detailed errors with `m/explain`:
@@ -2973,6 +3004,31 @@ Full override with `:json-schema` property:
   [:map {:json-schema {:type "file"}}
    [:file any?]])
 ;; =>  {:type "file"}
+```
+
+#### Conditional support
+
+[If-Then-Else conditional](https://json-schema.org/understanding-json-schema/reference/conditionals#ifthenelse) is 
+supported via `:if`
+```clojure
+(json-schema/transform
+  [:if
+   [:map [:kikka [:= 6]]]
+   [:map [:temppu [:= :kukka]]]
+   [:map [:lahjus [:= :suklaa]]]])
+;; =>  {:if {:properties {:kikka {:const 6}}, :required [:kikka]},
+;;      :then {:properties {:temppu {:const :kukka}}, :required [:temppu]}
+;;      :else {:properties {:lahjus {:const :suklaa}}, :required [:lahjus]}}
+```
+For conformance you may also produce `:type "object"` into maps if required with `{:omit-condition-type false}`. 
+`Else` branch is also optional.
+```clojure
+(json-schema/transform
+  [:if {:omit-condition-type false}
+   [:map [:juupas [:= true]]]
+   [:map [:eipas [:= false]]]])
+;; =>  {:if {:type "object", :properties {:juupas {:const true}}, :required [:juupas]}
+;;      :then {:type "object", :properties {:eipas {:const false}}, :required [:eipas]}}
 ```
 
 ### Swagger2

--- a/src/malli/core.cljc
+++ b/src/malli/core.cljc
@@ -3023,6 +3023,102 @@
                                   :re-transformer (fn [_ children] (apply re/alt-transformer children))
                                   :re-min-max (fn [_ children] (reduce -re-alt-min-max {:max 0} (-vmap last children)))})})
 
+(defn -if-conditional-schema
+  "Malli schema for JSON Schema's If-Then-Else conditional support.
+
+   Usage:
+   ```
+   [::jse/if [:map [:x [:= true]]]  ; IF
+             [:map [:y int?]]       ; THEN
+             [:map [:y string?]]]   ; ELSE
+  ```
+  Validates the same as:
+  ```
+  [:or [:and [:map [:x [:= true]]]         ; IF
+             [:map [:y int?]]]             ; THEN
+       [:and [:not [:map [:x [:= true]]]]  ; NOT IF
+             [:map [:y string?]]]]         ; ELSE
+  ```
+
+  The `ELSE` branch can be omitted for `when`-like behavior."
+  []
+  ^{:type ::into-schema}
+  (reify IntoSchema
+    (-type [_] :if)
+    (-type-properties [_])
+    (-properties-schema [_ _])
+    (-children-schema [_ _])
+    (-into-schema [parent {:keys [tags] :as properties} children options]
+      (-check-children! ::if properties children 2 3)
+      (let [condition' (schema (nth children 0) options)
+            then' (schema (nth children 1) options)
+            else' (when (= 3 (count children))
+                    (schema (nth children 2) options))
+            condition-v (validator condition')
+            equivalent-schema' (schema (if else'
+                                         [:or
+                                          [:and condition' then']
+                                          [:and [:not condition'] else']]
+                                         [:and condition' then'])
+                                       options)]
+        ^{:type ::schema}
+        (reify
+          Schema
+          (-validator [this]
+            (let [then-v (validator then')
+                  else-v (when else' (validator else'))]
+              (fn [value]
+                (if (condition-v value)
+                  (then-v value)
+                  (if else-v (else-v value) true)))))
+          (-explainer [this path]
+            (let [then-explainer (-explainer then' (conj path 'then))
+                  else-explainer (when else' (-explainer else' (conj path 'else)))]
+              (fn explain [x in acc]
+                (if (condition-v x)
+                  (let [before (count acc)
+                        acc' (then-explainer x in acc)]
+                    (if (> (count acc') before)
+                      (into (subvec (vec acc') 0 before)
+                            (map #(assoc % :branch 'then))
+                            (subvec (vec acc') before))
+                      acc'))
+                  (if else-explainer
+                    (let [before (count acc)
+                          acc' (else-explainer x in acc)]
+                      (if (> (count acc') before)
+                        (into (subvec (vec acc') 0 before)
+                              (map #(assoc % :branch 'else))
+                              (subvec (vec acc') before))
+                        acc'))
+                    acc)))))
+          (-parser [_]
+            (let [then-p (-parser then')
+                  else-p (when else' (-parser else'))]
+              (fn [x]
+                (if (condition-v x)
+                  (then-p x)
+                  (if else-p (else-p x) x)))))
+          (-unparser [_]
+            (let [then-u (-unparser then')
+                  else-u (when else' (-unparser else'))]
+              (fn [x]
+                (if (condition-v x)
+                  (then-u x)
+                  (if else-u (else-u x) x)))))
+          (-transformer [this transformer method options]
+            (-transformer equivalent-schema' transformer method options))
+          (-walk [this walker path options]
+            (-walk-leaf this walker path options))
+          (-properties [this] properties)
+          (-options [this] options)
+          (-children [this] children)
+          (-parent [this] parent)
+          (-form [this] form))))))
+
+(defn conditional-schemas []
+  {:if (-if-conditional-schema)})
+
 (defn base-schemas []
   {:and (-and-schema)
    :andn (-andn-schema)
@@ -3050,7 +3146,7 @@
    ::schema (-schema-schema {:raw true})})
 
 (defn default-schemas []
-  (merge (predicate-schemas) (class-schemas) (comparator-schemas) (type-schemas) (sequence-schemas) (base-schemas)))
+  (merge (predicate-schemas) (class-schemas) (comparator-schemas) (type-schemas) (sequence-schemas) (conditional-schemas) (base-schemas)))
 
 (def default-registry
   (let [strict #?(:cljs (identical? mr/mode "strict")

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -367,6 +367,18 @@
 (defn -qualified-symbol-gen [schema]
   (-qualified-ident-gen schema symbol gen/symbol qualified-symbol? gen/symbol-ns))
 
+(defn -if-conditional-gen [schema options]
+  (let [[condition then else] (m/children schema)
+        condition-s (m/schema condition options)
+        then-s      (m/schema then options)
+        merged-then (mu/merge condition-s then-s options)
+        then-gen    (generator merged-then options)
+        else-gen    (when else
+                      (gen-such-that schema (m/validator schema) (generator (m/schema else options) options)))]
+    (if else-gen
+      (gen/one-of [then-gen else-gen])
+      then-gen)))
+
 (defn- gen-elements [es]
   (if (= 1 (count es))
     (gen/return (first es))
@@ -446,6 +458,8 @@
 (defmethod -schema-generator :* [schema options] (-*-gen schema options))
 (defmethod -schema-generator :+ [schema options] (-+-gen schema options))
 (defmethod -schema-generator :repeat [schema options] (-repeat-gen schema options))
+
+(defmethod -schema-generator :if [schema options] (-if-conditional-gen schema options))
 
 ;;
 ;; Creating a generator by different means, centralized under [[-create]]

--- a/src/malli/json_schema.cljc
+++ b/src/malli/json_schema.cljc
@@ -198,6 +198,13 @@
 (defmethod accept :union [_ schema _ {::keys [transform] :as options}] (transform (m/deref schema) options))
 (defmethod accept :select-keys [_ schema _ {::keys [transform] :as options}] (transform (m/deref schema) options))
 
+(defmethod accept :if [_ schema _ {::keys [transform] :as options}]
+  (let [omit-type?            (get (m/properties schema) :omit-condition-type true)
+        omitter               (fn [m] (if omit-type? (dissoc m :type) m))
+        [condition then else] (mapv #(transform % options) (m/children schema))]
+    (cond-> {:if (omitter condition) :then (omitter then)}
+      else (assoc :else (omitter else)))))
+
 (defn- -json-schema-walker [schema _ children options]
   (let [p (merge (m/type-properties schema) (m/properties schema))]
     (or (get p :json-schema)

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -3697,3 +3697,32 @@
     (is (= @count-into-schemas 3)) ;; was 6
     (is (m/coerce ConsCell [1 [2 [3 [4 [1 [2 [3 [4 nil]]]]]]]]))
     (is (= @count-into-schemas 3)))) ;; was 10
+
+(deftest if-conditional-schema-test
+  (testing "validation equivalence"
+    (let [condition [:map [:x [:= true]]]
+          then [:map [:y int?]]
+          else [:map [:y string?]]
+          jse-schema [:if condition
+                      then
+                      else]
+          equivalent-schema [:or [:and condition then]
+                                 [:and [:not condition] else]]
+          valid-when-true    {:x true  :y 42}
+          valid-when-false   {:x false :y "hello"}
+          invalid-when-true  {:x true  :y "oops"}
+          invalid-when-false {:x false :y 99}]
+      (testing ":if validates with matching JSON Schema If-Then-Else semantics"
+        (is (true?  (m/validate jse-schema valid-when-true)))
+        (is (true?  (m/validate jse-schema valid-when-false)))
+        (is (false? (m/validate jse-schema invalid-when-true)))
+        (is (false? (m/validate jse-schema invalid-when-false))))
+      (testing "matches the equivalent :or/:and malli schema"
+        (is (= (m/validate equivalent-schema valid-when-true)
+               (m/validate jse-schema valid-when-true)))
+        (is (= (m/validate equivalent-schema valid-when-false)
+               (m/validate jse-schema valid-when-false)))
+        (is (= (m/validate equivalent-schema invalid-when-true)
+               (m/validate jse-schema invalid-when-true)))
+        (is (= (m/validate equivalent-schema invalid-when-false)
+               (m/validate jse-schema invalid-when-false)))))))

--- a/test/malli/error_test.cljc
+++ b/test/malli/error_test.cljc
@@ -955,3 +955,29 @@
   (is (= ["invalid type"] (me/humanize (m/explain [:map] []))))
   (is (= [["invalid type"]] (me/humanize (m/explain [:vector [:map]] [[]]))))
   (is (= [["invalid type"]] (me/humanize (m/explain [:vector [:fn {:error/path [-1]} (comp int? :foo)]] [[]])))))
+
+(deftest if-conditional-test
+  (let [humanizer (fn [v]
+                    (-> [:map
+                         [:if-then-else {:optional true}
+                          [:if
+                           [:map [:condition [:= true]]]
+                           [:map [:result int?]]
+                           [:map [:result string?]]]]
+                         [:if-then {:optional true}
+                          [:if
+                           [:map [:condition [:= true]]]
+                           [:map [:result keyword?]]]]]
+                        (m/explain v)
+                        (me/humanize)))]
+    ; successes
+    (is (nil? (humanizer {:if-then-else {:condition true :result 123}})))
+    (is (nil? (humanizer {:if-then-else {:condition false :result "hello"}})))
+    (is (nil? (humanizer {:if-then {:condition true :result :hello}})))
+    (is (nil? (humanizer {:if-then {:condition false}})))
+    ; failures
+    (is (= {:if-then-else {:result ["should be an int"]}} (humanizer {:if-then-else {:condition true :result true}})))
+    (is (= {:if-then-else {:result ["should be a string"]}} (humanizer {:if-then-else {:condition false :result true}})))
+    (is (= {:if-then {:result ["should be a keyword"]}} (humanizer {:if-then {:condition true :result true}})))
+    ; Listed for brevity. This is not actually a failure, as missing else branch evaluates as valid/true.
+    (is (= nil (humanizer {:if-then {:condition false}})))))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1140,3 +1140,17 @@
 
 (deftest empty?-generator-test
   (is (every? empty? (mg/sample empty?))))
+
+(deftest if-conditional-generator-test
+  (let [if-then-else [:if
+                      [:map [:x [:= true]]]
+                      [:map [:y int?]]
+                      [:map [:y string?]]]
+        generated (mg/sample if-then-else {:size 20})]
+    (is (every? #(m/validate if-then-else %) generated) "Expected all generated values to validate against the schema")
+    (is (some #(true? (:x %)) generated) "Expected some generated values with x=true (then-branch)")
+    (is (some #(not (true? (:x %))) generated) "Expected some generated values without x (else-branch)"))
+  (let [if-then [:if
+                 [:map [:active [:= true]]]
+                 [:map [:name string?]]]]
+    (is (every? #(m/validate if-then %) (mg/sample if-then)))))

--- a/test/malli/json_schema_test.cljc
+++ b/test/malli/json_schema_test.cljc
@@ -394,3 +394,97 @@
   (is (= {:properties {:s {:$ref "#/definitions/malli.json-schema-test.foo"}} :required [:s] :type "object"
           :definitions {"malli.json-schema-test.foo" {:type "string"}} }
          (transform-and-check [:map [:s [:ref ::foo]]] {:registry (merge (m/default-schemas) {::foo :string})}))))
+
+(deftest if-conditional-test
+  (testing ":if schema with then and else branches produces if/then/else keys"
+    (let [if-then-else-schema [:if
+                               [:map ["type" [:= "credit"]]]
+                               [:map ["card-number" :string]]
+                               [:map ["iban" :string]]]]
+      (is (= {:if   {:properties {"type" {:const "credit"}}
+                     :required   ["type"]}
+              :then {:properties {"card-number" {:type "string"}}
+                     :required
+                     ["card-number"]}
+              :else {:properties {"iban" {:type "string"}}
+                     :required   ["iban"]}}
+             (json-schema/transform if-then-else-schema)))))
+  (testing ":if schema without else branch produces if/then without else key"
+    (let [if-then-schema [:if
+                          [:map ["region" [:= "EU"]]]
+                          [:map ["iban" :string]]]]
+      (is (= {:if   {:properties {"region" {:const "EU"}}
+                     :required   ["region"]}
+              :then {:properties {"iban" {:type "string"}}
+                     :required   ["iban"]}}
+             (json-schema/transform if-then-schema)))))
+  (testing "multiple conditions are wrapped in allOf"
+    (let [multiple-conditions-schema [:and
+                                      [:if
+                                       [:map ["type" [:= "credit"]]]
+                                       [:map ["card-number" :string]]
+                                       [:map ["cash" :boolean]]]
+                                      [:if
+                                       [:map ["region" [:= "EU"]]]
+                                       [:map ["iban" :string]]
+                                       [:map ["swift" :string]]]]]
+      (is (= {:allOf
+              [{:if   {:properties {"type" {:const "credit"}}
+                       :required   ["type"]}
+                :then {:properties {"card-number" {:type "string"}} :required
+                       ["card-number"]}
+                :else {:properties {"cash" {:type "boolean"}}
+                       :required   ["cash"]}}
+               {:if   {:properties {"region" {:const "EU"}}
+                       :required   ["region"]}
+                :then {:properties {"iban" {:type "string"}}
+                       :required   ["iban"]}
+                :else {:properties {"swift" {:type "string"}}
+                       :required   ["swift"]}}]}
+             (json-schema/transform multiple-conditions-schema)))))
+  (testing "nested :if in then branch is recursively transformed"
+    (let [nested-schema [:if
+                         [:map ["type" [:= "credit"]]]
+                         [:if
+                          [:map ["region" [:= "EU"]]]
+                          [:map ["iban" :string]]
+                          [:map ["swift" :string]]]
+                         [:map ["cash" :boolean]]]]
+      (is (= {:if   {:properties {"type" {:const "credit"}}
+                     :required   ["type"]}
+              :then {:if   {:properties {"region" {:const "EU"}}
+                            :required   ["region"]}
+                     :then {:properties {"iban" {:type "string"}}
+                            :required   ["iban"]}
+                     :else {:properties {"swift" {:type "string"}}
+                            :required   ["swift"]}}
+              :else {:properties {"cash" {:type "boolean"}}
+                     :required   ["cash"]}}
+             (json-schema/transform nested-schema)))))
+  (testing "allOf produced by :and recurses correctly into the if-then-else schema and does not overlap or conflict"
+    (let [other-allof-definitions-schema [:and
+                                          [:map ["shape" string?]]
+                                          [:if
+                                           [:map ["shape" [:= "ball"]]]
+                                           [:map ["radius" int?]]
+                                           [:map ["side" double?]]]]]
+      (is (= {:allOf [{:properties {"shape" {:type "string"}}
+                       :required   ["shape"]
+                       :type       "object"}
+                      {:if   {:properties {"shape" {:const "ball"}}
+                              :required   ["shape"]}
+                       :else {:properties {"side" {:type "number"}}
+                              :required   ["side"]}
+                       :then {:properties {"radius" {:type "integer"}}
+                              :required   ["radius"]}}]}
+             (json-schema/transform other-allof-definitions-schema)))))
+  (testing "can override type omission"
+    (let [type-emitting-schema [:if {:omit-condition-type false}
+                                [:map ["planet" [:= "Earth"]]]
+                                [:map ["habitable" [:= true]]
+                                 ["population" integer?]]
+                                [:map ["habitable" [:= false]]]]
+          result (json-schema/transform type-emitting-schema)]
+      (is (= "object" (get-in result [:if :type])))
+      (is (= "object" (get-in result [:then :type])))
+      (is (= "object" (get-in result [:else :type]))))))

--- a/test/malli/transform_test.cljc
+++ b/test/malli/transform_test.cljc
@@ -1229,3 +1229,15 @@
     (testing "encoding children using the string transformer works"
       (is (= encoded (m/encode child-inference-test-schema decoded (mt/string-transformer))))
       (is (= encoded (m/encode child-inference-test-schema encoded (mt/string-transformer)))))))
+
+(deftest if-conditional-transformations-test
+  (let [schema [:if
+                [:map [:animal [:= :cat]]]
+                [:map [:says [:= :meow]]]
+                [:map [:says [:= :bark]]]]
+        encoded {:animal "cat"
+                 :says   "meow"}
+        decoded {:animal :cat
+                 :says   :meow}]
+    (testing "roundtip works"
+      (is (= encoded (m/encode schema decoded (mt/string-transformer)))))))


### PR DESCRIPTION
Adds support for JSON Schema's conditional If-Then-Else structure by implementing a new schema type :if to enable detection and handling of the logic when transforming given data to JSON Schema.

This new :if schema type also has equivalence using Malli's existing core schemas (:and/:or/:not) which is internally used for transform and generator support.

Fixes #1287 