### PR TITLE
Consistent seq behaviour in :validate

### DIFF
--- a/src/malli/experimental/validate.cljc
+++ b/src/malli/experimental/validate.cljc
@@ -25,7 +25,7 @@
           m/AST
           (-to-ast [this _] (m/-to-value-ast this))
           m/Schema
-          (-validator [_] (m/-safe-pred (fn [val] (nil? (f val)))))
+          (-validator [_] (m/-safe-pred (fn [val] (empty? (f val)))))
           (-explainer [this path]
             (fn explain [x in0 acc]
               (try

--- a/test/malli/experimental/validate_test.cljc
+++ b/test/malli/experimental/validate_test.cljc
@@ -75,6 +75,22 @@
                  :value 3
                  :type :not-even}]
                (:errors (m/explain schema {:value {:a 3 :b 3}})))))))
+  (testing "seq treatment"
+    (let [returned-seq (m/schema [:validate (fn [x]
+                                              (for [[idx num] (map-indexed vector x)
+                                                    :when (even? num)]
+                                                {:in [idx]
+                                                 :value num}))]
+                                 {:registry (mev/schemas)})]
+      (is (true? (m/validate returned-seq [1 3 5])))
+      (is (nil? (m/explain returned-seq [1 3 5])))
+      (is (false? (m/validate returned-seq [1 3 4])))
+      (is (= [{:path [],
+               :in [2],
+               :schema returned-seq,
+               :value 4,
+               :type nil}]
+             (:errors (m/explain returned-seq [1 3 4]))))))
   (testing "humanize"
     (let [two-sub-errors (m/schema [:validate (fn [x]
                                                 [{:in [:a]


### PR DESCRIPTION
With the current behaviour, returning an empty list of errors gives `false` in `m/validate` but `nil` in `m/explain`. This PR brings consistency.

And separate (off) topic, but the test also shows that `:type` is returned as `nil` in the explain `:errors`, even if not provided. Not sure if this is consistent with other parts of the codebase where it's often not present, or if it was intentional to make it mandatory in this schema.