### PR TITLE
[perf] Optimize m.instrument/clj-collect!

### DIFF
--- a/src/malli/instrument.clj
+++ b/src/malli/instrument.clj
@@ -52,7 +52,18 @@
 (defn clj-collect!
   ([] (clj-collect! {:ns *ns*}))
   ([{:keys [ns]}]
-   (not-empty (reduce (fn [acc v] (let [v (-collect! v)] (cond-> acc v (conj v)))) #{} (vals (mapcat ns-publics (-sequential ns)))))))
+   (not-empty
+    (reduce (fn [acc nspace] ns-publics
+              (let [nspace (the-ns nspace)]
+                (reduce-kv (fn [acc _ ^clojure.lang.Var v]
+                             (if-let [v (and (instance? clojure.lang.Var v)
+                                             (= nspace (.ns v))
+                                             (not (:private (meta v)))
+                                             (-collect! v))]
+                               (conj acc v)
+                               acc))
+                           acc (ns-map nspace))))
+            #{} (-sequential ns)))))
 
 ;;
 ;; CLJS macro for collecting function schemas

--- a/src/malli/instrument.clj
+++ b/src/malli/instrument.clj
@@ -53,7 +53,7 @@
   ([] (clj-collect! {:ns *ns*}))
   ([{:keys [ns]}]
    (not-empty
-    (reduce (fn [acc nspace] ns-publics
+    (reduce (fn [acc nspace]
               (let [nspace (the-ns nspace)]
                 (reduce-kv (fn [acc _ ^clojure.lang.Var v]
                              (if-let [v (and (instance? clojure.lang.Var v)


### PR DESCRIPTION
This is minor, but `filter-key` is so inefficient that it got my attention. On a project like Metabase that has a few thousand namespaces, calling `(clj-collect! {:ns (all-ns)})` generates a lot of unnecessary garbage and slightly slows down the initialization.

```
Before:
Time per call: 534.50 ms   Alloc per call: 318,043,024b

After:
Time per call: 44.75 ms   Alloc per call: 13,792,652b
```