### PR TITLE
Close #1296: don't depend on sets throwing on 2 args

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         # Supported Java versions: LTS releases and latest
-        jdk: [8, 11, 17, 21, 25]
-        clojure: [11, 12]
+        jdk: [8, 11, 17, 21, 25, 26]
+        clojure: [11, 12, 13]
 
     name: Clojure ${{ matrix.clojure }} (Java ${{ matrix.jdk }})
 

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.12.4"}
+ :deps {org.clojure/clojure {:mvn/version "1.13.0-alpha3"}
         borkdude/dynaload {:mvn/version "0.3.5"}
         borkdude/edamame {:mvn/version "1.5.37"}
         org.clojure/test.check {:mvn/version "1.1.3"}
@@ -27,6 +27,7 @@
                                                         :sha "efbeb200b9594e265907c1d66ad4ffd9cd8c91cf"}}}
            :clojure-11 {:extra-deps {org.clojure/clojure {:mvn/version "1.11.3"}}}
            :clojure-12 {}
+           :clojure-13 {:extra-deps {org.clojure/clojure {:mvn/version "1.13.0-alpha3"}}}
            :sci {:extra-deps {org.babashka/sci {:mvn/version "0.12.51"}}}
            :cherry {:extra-deps {io.github.squint-cljs/cherry {:git/tag "v0.5.34" :git/sha "e455cf3"}}}
            :test-sci {:extra-paths ["test-sci"]

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.13.0-alpha3"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.4"}
         borkdude/dynaload {:mvn/version "0.3.5"}
         borkdude/edamame {:mvn/version "1.5.37"}
         org.clojure/test.check {:mvn/version "1.1.3"}

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2543,7 +2543,7 @@
 
       (testing "by default, all ifn? are valid"
         (is (true? (m/validate schema1 identity)))
-        (is (true? (m/validate schema1 single-arity))))
+        (is (true? (m/validate schema1 #{}))))
 
       (testing "using generative testing"
         (is (false? (m/validate schema2 identity)))
@@ -2597,7 +2597,7 @@
 
       (testing "using generative testing"
         (is (false? (m/validate schema2 single-arity)))
-        #?(:clj (is (false? (m/validate schema2 identity))))
+        (is (false? (m/validate schema2 identity)))
         (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
         (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2593,11 +2593,12 @@
           schema2 (m/schema ?schema {::m/function-checker mg/function-checker})]
 
       (testing "by default, all ifn? are valid"
-        (is (true? (m/validate schema1 identity))))
+        (is (true? (m/validate schema1 identity)))
+        (is (true? (m/validate schema1 #{}))))
 
       (testing "using generative testing"
         (is (false? (m/validate schema2 single-arity)))
-        (is (false? (m/validate schema2 identity)))
+        (is (false? (m/validate schema2 (fn [x] x))))
         (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
         (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2546,8 +2546,8 @@
         (is (true? (m/validate schema1 #{}))))
 
       (testing "using generative testing"
-        (is (false? (m/validate schema2 identity)))
         (is (false? (m/validate schema2 single-arity)))
+        (is (false? (m/validate schema2 (fn [x] x))))
         (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
         (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 
@@ -2688,11 +2688,13 @@
 
         (testing "by default, all ifn? are valid"
           (is (true? (m/validate schema1 identity)))
-          (is (true? (m/validate schema1 single-arity))))
+          (is (true? (m/validate schema1 #{}))))
 
         (testing "using generative testing"
           (is (false? (m/validate schema2 identity)))
+
           (is (false? (m/validate schema2 single-arity)))
+          (is (false? (m/validate schema2 (fn [x] x))))
           (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
           (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2547,7 +2547,7 @@
 
       (testing "using generative testing"
         (is (false? (m/validate schema2 single-arity)))
-        (is (false? (m/validate schema2 (fn [x] x))))
+        #?(:clj (is (false? (m/validate schema2 (fn [x] x)))))
         (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
         (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 
@@ -2598,7 +2598,7 @@
 
       (testing "using generative testing"
         (is (false? (m/validate schema2 single-arity)))
-        (is (false? (m/validate schema2 (fn [x] x))))
+        #?(:clj (is (false? (m/validate schema2 (fn [x] x)))))
         (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
         (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 
@@ -2691,10 +2691,10 @@
           (is (true? (m/validate schema1 #{}))))
 
         (testing "using generative testing"
-          (is (false? (m/validate schema2 identity)))
+          #?(:clj (is (false? (m/validate schema2 identity))))
 
           (is (false? (m/validate schema2 single-arity)))
-          (is (false? (m/validate schema2 (fn [x] x))))
+          #?(:clj (is (false? (m/validate schema2 (fn [x] x)))))
           (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
           (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 

--- a/test/malli/core_test.cljc
+++ b/test/malli/core_test.cljc
@@ -2543,12 +2543,11 @@
 
       (testing "by default, all ifn? are valid"
         (is (true? (m/validate schema1 identity)))
-        (is (true? (m/validate schema1 #{}))))
+        (is (true? (m/validate schema1 single-arity))))
 
       (testing "using generative testing"
+        (is (false? (m/validate schema2 identity)))
         (is (false? (m/validate schema2 single-arity)))
-        #?(:clj (is (false? (m/validate schema2 (fn [x] x)))))
-        #?(:clj (is (false? (m/validate schema2 #{}))))
         (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
         (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 
@@ -2594,13 +2593,11 @@
           schema2 (m/schema ?schema {::m/function-checker mg/function-checker})]
 
       (testing "by default, all ifn? are valid"
-        (is (true? (m/validate schema1 identity)))
-        (is (true? (m/validate schema1 #{}))))
+        (is (true? (m/validate schema1 identity))))
 
       (testing "using generative testing"
         (is (false? (m/validate schema2 single-arity)))
-        #?(:clj (is (false? (m/validate schema2 (fn [x] x)))))
-        #?(:clj (is (false? (m/validate schema2 #{}))))
+        #?(:clj (is (false? (m/validate schema2 identity))))
         (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
         (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 
@@ -2690,15 +2687,11 @@
 
         (testing "by default, all ifn? are valid"
           (is (true? (m/validate schema1 identity)))
-          (is (true? (m/validate schema1 #{}))))
+          (is (true? (m/validate schema1 single-arity))))
 
         (testing "using generative testing"
-          #?(:clj (is (false? (m/validate schema2 identity))))
-          (is (false? (m/validate schema2 #{})))
-
+          (is (false? (m/validate schema2 identity)))
           (is (false? (m/validate schema2 single-arity)))
-          #?(:clj (is (false? (m/validate schema2 (fn [x] x)))))
-          #?(:clj (is (false? (m/validate schema2 #{}))))
           (is (true? (validate-times function-schema-validation-times schema2 valid-f)))
           (is (false? (m/validate schema2 (fn [x y] (str x y)))))
 


### PR DESCRIPTION
Close #1296 

Now that sets accept two arguments in Clojure 1.13.0-alpha3 these tests will fail.