### PR TITLE
Fix double generator at -Double/MAX_VALUE bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ We use [Break Versioning][breakver]. The version numbers follow a `<major>.<mino
 
 Malli is in well matured [alpha](README.md#alpha).
 
+## UNRELEASED
+
+* FIX: generating a double/number schema bounded at `(- Double/MAX_VALUE)` (e.g. `[:<= (- Double/MAX_VALUE)]` or `[:double {:max (- Double/MAX_VALUE)}]`) no longer throws `Couldn't satisfy such-that predicate`, and now produces validator-accepted values [#1128](https://github.com/metosin/malli/issues/1128)
+
 ## 0.20.1 (2026-03-06)
 
 * FIX: don't throw in cljs-collect! on clojurescript 1.12 [#1263](https://github.com/metosin/malli/pull/1263)

--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -92,7 +92,21 @@
 (defn- gen-tuple [gens] (or (some -unreachable gens) (apply gen/tuple gens)))
 (defn- gen-maybe [g] (if (-unreachable-gen? g) nil-gen (gen/one-of [nil-gen g])))
 (def ^:private double-default {:infinite? false, :NaN? false})
-(defn- gen-double [opts] (gen/double* (-> (into double-default opts) (update :min #(some-> % double)) (update :max #(some-> % double)))))
+(def ^:private double-max-value #?(:clj Double/MAX_VALUE, :cljs (.-MAX_VALUE js/Number)))
+(defn- -double*
+  "Like `gen/double*`, but works around a test.check edge case: for the inclusive
+   range whose only in-range finite value is `(- Double/MAX_VALUE)` -- e.g.
+   `[:<= (- Double/MAX_VALUE)]` or `[:double {:max (- Double/MAX_VALUE)}]` --
+   test.check throws a such-that error even though the validator accepts that
+   value (see #1128). Since `gen/double*` treats `:max` as inclusive, returning
+   the boundary honors the same contract. Only short-circuit when that boundary
+   is actually attainable given `:min`; otherwise fall through so `gen/double*`
+   still signals the empty/unsatisfiable range."
+  [{:keys [min max] :as opts}]
+  (if (and (= max (- double-max-value)) (or (nil? min) (<= min max)))
+    (gen/return max)
+    (gen/double* opts)))
+(defn- gen-double [opts] (-double* (-> (into double-default opts) (update :min #(some-> % double)) (update :max #(some-> % double)))))
 
 (defn- gen-vector [{:keys [min max]} g]
   (cond
@@ -373,12 +387,12 @@
     (gen/elements es)))
 
 (defn- double-gen [schema options]
-  (gen/double* (merge (let [props (m/properties schema options)]
-                        {:infinite? (get props :gen/infinite? false)
-                         :NaN? (get props :gen/NaN? false)})
-                      (-> (-min-max schema options)
-                          (update :min #(some-> % double))
-                          (update :max #(some-> % double))))))
+  (-double* (merge (let [props (m/properties schema options)]
+                     {:infinite? (get props :gen/infinite? false)
+                      :NaN? (get props :gen/NaN? false)})
+                   (-> (-min-max schema options)
+                       (update :min #(some-> % double))
+                       (update :max #(some-> % double))))))
 
 (defmulti -schema-generator (fn [schema options] (m/type schema options)) :default ::default)
 
@@ -387,7 +401,14 @@
 (defmethod -schema-generator 'empty? [_ _] (ga/gen-for-pred empty?))
 (defmethod -schema-generator :> [schema options] (gen-double {:min (inc (-child schema options))}))
 (defmethod -schema-generator :>= [schema options] (gen-double {:min (-child schema options)}))
-(defmethod -schema-generator :< [schema options] (gen-double {:max (dec (-child schema options))}))
+(defmethod -schema-generator :< [schema options]
+  (let [max (dec (-child schema options))]
+    (if (= max (- double-max-value))
+      ;; the exclusive bound collapses onto `(- Double/MAX_VALUE)`: no finite
+      ;; double is strictly less, so the range is empty. Preserve the generation
+      ;; error rather than short-circuiting to a value the validator rejects.
+      (gen/double* (into double-default {:max max}))
+      (gen-double {:max max}))))
 (defmethod -schema-generator :<= [schema options] (gen-double {:max (-child schema options)}))
 (defmethod -schema-generator := [schema options] (gen/return (-child schema options)))
 (defmethod -schema-generator :not= [schema options] (gen-such-that schema #(not= % (-child schema options)) gen/any-printable))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -73,6 +73,27 @@
                                      :gen/NaN? true}))
         (is (not (test-presence special? nil))))))
 
+  (testing "double bounds at the representable extreme (#1128)"
+    (let [max-value #?(:clj Double/MAX_VALUE :cljs (.-MAX_VALUE js/Number))]
+      (testing "the boundary value is attainable, so every generated value passes the validator"
+        ;; the validator accepts (- Double/MAX_VALUE), so the generator must be
+        ;; able to produce a value it accepts at the same boundary
+        (doseq [schema [[:<= (- max-value)]
+                        [:double {:max (- max-value)}]
+                        [:float {:max (- max-value)}]
+                        [:>= max-value]
+                        [:double {:min max-value}]]]
+          (testing (m/form schema)
+            (is (m/validate schema (mg/generate schema {:seed 123})))
+            (is (every? (m/validator schema) (mg/sample schema {:seed 123, :size 100}))))))
+      (testing "an unsatisfiable range still errors instead of yielding a validator-rejected value"
+        ;; there is no finite double in these ranges, so generation must not
+        ;; short-circuit to the boundary (which the validator would reject)
+        (doseq [schema [[:double {:min 0 :max (- max-value)}] ;; empty: min > max
+                        [:< (- max-value)]]]                  ;; empty: nothing is strictly less
+          (testing (m/form schema)
+            (is (thrown? #?(:clj Throwable :cljs js/Error) (mg/generate schema {:seed 123}))))))))
+
   (testing "qualified-keyword properties"
     (testing "no namespace => random"
       (is (< 1 (->> (mg/sample [:qualified-keyword {:namespace nil}]


### PR DESCRIPTION
# Fix double generator at the `(- Double/MAX_VALUE)` bound (#1128)

## Problem

`m/validate` and `malli.generator/generate` disagree at the extreme double
boundary. The validator accepts `(- Double/MAX_VALUE)`, but the generator for
the same schema throws:

```clojure
(require '[malli.core :as m] '[malli.generator :as mg])

(m/validate [:<= (- Double/MAX_VALUE)] (- Double/MAX_VALUE))   ;=> true
(mg/generate [:<= (- Double/MAX_VALUE)])
;=> ExceptionInfo: Couldn't satisfy such-that predicate after 10 tries.

(m/validate [:double {:max (- Double/MAX_VALUE)}] (- Double/MAX_VALUE)) ;=> true
(mg/generate [:double {:max (- Double/MAX_VALUE)}])
;=> ExceptionInfo: Couldn't satisfy such-that predicate after 10 tries.
```

The generator cannot produce a value that the validator itself accepts.

## Root cause

`src/malli/generator.cljc` builds double generators via `gen/double*`
(test.check) — both `gen-double` (used by `:<=`, `:<`, `:>`, `:>=`, `pos?`,
`neg?`) and `double-gen` (used by `:double`, `:float`).

When the inclusive upper bound is `(- Double/MAX_VALUE)` (the most-negative
finite double), the only in-range finite value is `(- Double/MAX_VALUE)`
itself, and test.check's `double*` cannot reliably produce it: its candidate
lands just outside the single-value range and it exhausts the internal
`such-that` retries, throwing. The failure is specific to this negative-max
extreme — `:min Double/MAX_VALUE` / `[:double {:min Double/MAX_VALUE}]` already
work.

## Fix

`src/malli/generator.cljc` — wrap `gen/double*` in a helper `-double*` that both
`gen-double` and `double-gen` call. For the degenerate inclusive range whose
only in-range finite value is `(- Double/MAX_VALUE)`, return that value directly
(`gen/double*` documents `:max` as inclusive, so returning it honors the same
contract). The short-circuit only fires when the boundary is actually attainable
— i.e. when no `:min` excludes it — so genuinely empty ranges keep erroring:

```clojure
(def ^:private double-max-value #?(:clj Double/MAX_VALUE, :cljs (.-MAX_VALUE js/Number)))
(defn- -double*
  [{:keys [min max] :as opts}]
  (if (and (= max (- double-max-value)) (or (nil? min) (<= min max)))
    (gen/return max)
    (gen/double* opts)))
```

The `:<` schema needs one extra guard. malli lowers `[:< x]` to `{:max (dec x)}`,
converting the exclusive bound to an inclusive one — but `(dec (- Double/MAX_VALUE))`
is a no-op at that magnitude, so `:<` and `:<=` both reach `-double*` as
`{:max (- Double/MAX_VALUE)}` and cannot be told apart there. Since no finite
double is strictly less than `(- Double/MAX_VALUE)`, `[:< (- Double/MAX_VALUE)]`
is unsatisfiable and must keep erroring (as it does on `master`) rather than
short-circuiting to `(- Double/MAX_VALUE)`, which its own validator rejects. The
`:<` method special-cases this so the empty range still surfaces the generation
error:

```clojure
(defmethod -schema-generator :< [schema options]
  (let [max (dec (-child schema options))]
    (if (= max (- double-max-value))
      (gen/double* (into double-default {:max max}))  ; empty range -> error, as on master
      (gen-double {:max max}))))
```

## Behavior summary

| schema | `master` | this PR |
| --- | --- | --- |
| `[:<= (- Double/MAX_VALUE)]`, `[:double {:max (- Double/MAX_VALUE)}]` | throws such-that | generates `(- Double/MAX_VALUE)` (validator-accepted) |
| `[:double {:min 0 :max (- Double/MAX_VALUE)}]` (empty range) | throws | still throws |
| `[:< (- Double/MAX_VALUE)]` (empty range) | throws | still throws |
| `[:>= Double/MAX_VALUE]`, `[:double {:min Double/MAX_VALUE}]` | generates `Double/MAX_VALUE` | unchanged |

## Tests

`test/malli/generator_test.cljc` — extended the double-extreme regression case to
assert both directions:

- satisfiable bounds (`[:<= (- max)]`, `[:double {:max (- max)}]`,
  `[:float {:max (- max)}]`, `[:>= max]`, `[:double {:min max}]`) generate values
  that pass the schema's own validator;
- unsatisfiable bounds (`[:double {:min 0 :max (- max)}]` and `[:< (- max)]`)
  still throw rather than emitting a validator-rejected value.

## Verification

- `./bin/kaocha` (JVM): 250 tests, 18784 assertions, 0 failures.
- focused `malli.generator-test/generator-test`: 1 test, 1060 assertions, 0 failures.
- `./bin/node none` (ClojureScript, `:optimizations :none`): 236 tests, 18091
  assertions, 0 failures. (The `:advanced` and `cherry` CLJS variants were not run
  in this environment.)

## Scope

`[:> Double/MAX_VALUE]` / `[:double {:min ...}]` at the *positive* exclusive
extreme is a separate, genuinely pre-existing issue: `master` already returns a
non-validating value there, and this PR does not change min-side handling, so it
is unchanged. It is outside #1128, which concerns the `:max` /
`(- Double/MAX_VALUE)` boundary.

Fixes #1128
