### PR TITLE
Close #1035 Fix `:>` / `:<` generators producing values that violate the schema

### DIFF
--- a/src/malli/generator.cljc
+++ b/src/malli/generator.cljc
@@ -94,6 +94,23 @@
 (def ^:private double-default {:infinite? false, :NaN? false})
 (defn- gen-double [opts] (gen/double* (-> (into double-default opts) (update :min #(some-> % double)) (update :max #(some-> % double)))))
 
+(defn- -next-up
+  "Smallest double greater than the finite double x, or ##Inf if there is none."
+  [x]
+  #?(:clj  (Math/nextUp (double x))
+     ;; no Math/nextUp in js: step one ulp up (overshooting a value or two is harmless here)
+     :cljs (+ x (max js/Number.MIN_VALUE (* (js/Math.abs x) 2.220446049250313e-16)))))
+
+(defn- gen-double-above
+  "Generator of doubles strictly greater than x."
+  [x options]
+  (let [x (double x)]
+    (cond
+      (or (not= x x) (= x ##Inf)) (-never-gen options) ;; nothing is greater than ##NaN or ##Inf
+      (= x ##-Inf) (gen-double {})
+      :else (let [min (-next-up x)]
+              (if (= min ##Inf) (gen/return ##Inf) (gen-double {:min min}))))))
+
 (defn- gen-vector [{:keys [min max]} g]
   (cond
     (-unreachable-gen? g) (if (zero? (or min 0)) (gen/return []) g)
@@ -385,9 +402,9 @@
 (defmethod -schema-generator ::default [schema options] (ga/gen-for-pred (m/validator schema options)))
 
 (defmethod -schema-generator 'empty? [_ _] (ga/gen-for-pred empty?))
-(defmethod -schema-generator :> [schema options] (gen-double {:min (inc (-child schema options))}))
+(defmethod -schema-generator :> [schema options] (gen-double-above (-child schema options) options))
 (defmethod -schema-generator :>= [schema options] (gen-double {:min (-child schema options)}))
-(defmethod -schema-generator :< [schema options] (gen-double {:max (dec (-child schema options))}))
+(defmethod -schema-generator :< [schema options] (gen-fmap - (gen-double-above (- (double (-child schema options))) options)))
 (defmethod -schema-generator :<= [schema options] (gen-double {:max (-child schema options)}))
 (defmethod -schema-generator := [schema options] (gen/return (-child schema options)))
 (defmethod -schema-generator :not= [schema options] (gen-such-that schema #(not= % (-child schema options)) gen/any-printable))

--- a/test/malli/generator_test.cljc
+++ b/test/malli/generator_test.cljc
@@ -1138,5 +1138,15 @@
           v (mg/sample [:seqable {:min 1} :any])]
     (is (seq v))))
 
+(deftest comparator-generator-test
+  (doseq [x [0 5 1e16 1e300 #?(:clj Double/MAX_VALUE :cljs js/Number.MAX_VALUE) ##-Inf]
+          [op x] [[:> x] [:< (- x)]]
+          :let [schema [op x]]]
+    (testing schema
+      (is (every? (m/validator schema) (mg/sample schema {:seed 0 :size 100})))
+      (is (m/validate schema (shrink schema)))))
+  (testing "unsatisfiable"
+    (is (thrown? #?(:clj Exception, :cljs js/Error) (mg/generate [:> ##Inf])))))
+
 (deftest empty?-generator-test
   (is (every? empty? (mg/sample empty?))))


### PR DESCRIPTION
Fixes #1035.

## Problem

`[:> x]` turned the exclusive bound into an inclusive one with `(inc x)` and handed it to `gen/double*` as `:min`. `inc` does not move a double once `|x| >= 2^53`, so the generator was asked for values `>= x` and produced `x` itself:

```clojure
(= Double/MAX_VALUE
   (shrink [:> Double/MAX_VALUE])
   (shrink [:>= Double/MAX_VALUE]))
;=> true

(> Double/MAX_VALUE Double/MAX_VALUE)
;=> false
```

The reported `Double/MAX_VALUE` case is just the extreme end of it — the bug starts at `2^53`:

```clojure
(->> (mg/sample [:> 1e16] {:seed 1 :size 100}) (remove (m/validator [:> 1e16])) count)
;=> 2
(->> (mg/sample [:> 1e300] {:seed 1 :size 100}) (remove (m/validator [:> 1e300])) count)
;=> 2
```

`:<` had the mirror problem via `(dec x)`, and additionally threw on `[:< (- Double/MAX_VALUE)]` (`Couldn't satisfy such-that predicate after 10 tries`).

## Fix

`src/malli/generator.cljc`

* `-next-up` — the next representable double above `x`. `Math/nextUp` on the JVM; in   ClojureScript, where no such function exists, one arithmetic ulp step (overshooting a representable value or two is harmless for generation).
* `gen-double-above` — generator of doubles strictly greater than `x`, covering the three edges:
  * nothing is greater than `##NaN` or `##Inf` → unreachable generator (`-never-gen`);
  * everything finite is greater than `##-Inf` → the plain double generator;
  * above `Double/MAX_VALUE` only `##Inf` is left → `(gen/return ##Inf)`.
* `:>` now delegates to `gen-double-above`; `:<` is `:>` negated, which removes the duplicated mirror logic and fixes `[:< (- Double/MAX_VALUE)]` along the way.

```clojure
(mg/generate [:> Double/MAX_VALUE] {:seed 0})    ;=> ##Inf
(mg/generate [:> 1e16] {:seed 0})                ;=> 1.3510798882111488E16
(mg/generate [:< (- Double/MAX_VALUE)] {:seed 0}) ;=> ##-Inf
(mg/generate [:> 5] {:seed 0})                   ;=> 6.0   (unchanged)
```

